### PR TITLE
Changes to green Brinstar Reserve 

### DIFF
--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -881,9 +881,13 @@
           {
             "id": 4,
             "requires": [
+              "canMorph",
               { "or": [
                 "canPassBombPassages",
-                "canBrinstarReserveHoleInOne"
+                {"and": [
+                  "canTunnelCrawl",
+                  "ScrewAttack"
+                ]}
               ]}
             ],
             "unlock": null
@@ -906,9 +910,13 @@
           {
             "id": 4,
             "requires": [
+              "canMorph",
               { "or": [
                 "canPassBombPassages",
-                "canBrinstarReserveHoleInOne"
+                {"and": [
+                  "canTunnelCrawl",
+                  "ScrewAttack"
+                ]}
               ]}
             ],
             "unlock": null
@@ -933,7 +941,10 @@
             "requires": [
               { "or": [
                 "canPassBombPassages",
-                "canBrinstarReserveHoleInOne"
+                {"and": [
+                  "canTunnelCrawl",
+                  "ScrewAttack"
+                ]}
               ]}
             ],
             "unlock": null

--- a/tech.json
+++ b/tech.json
@@ -199,8 +199,9 @@
     "note": "This maneuver involves manipulating baby turtle movement to group them together in a corner, to clear the rest of the surface to charge a shinespark. Much easier with morph."
   },
   {
-    "name": "canBrinstarReserveHoleInOne",
-    "requires": []
+    "name": "canTunnelCrawl",
+    "requires": [],
+    "note": "Moving along a 2-tile-high passage while standing up by repeatedly spin-jumping and then pressing down. Comes with softlock risks without Morph Ball."
   },
   {
     "name": "canCWJ",


### PR DESCRIPTION
Fix Morph req for far missile from the left side of the room, and replace canBrinstarReserveHoleInOne with less specific tech.