### PR TITLE
Enemy weeds

### DIFF
--- a/enemies/brinstar/main.json
+++ b/enemies/brinstar/main.json
@@ -1,38 +1,5 @@
 [
   {
-      "id": 25,
-      "name": "Beetom",
-      "dmgToSamus": [
-          10,
-          5,
-          2
-      ],
-      "hp": 50,
-      "note": "Damages every 64 frames",
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0.4,
-          "big-energy": 0,
-          "missile": 0,
-          "super": 0,
-          "powerbomb": 101.6
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [
-          "canShoot",
-          "hasBeamUpgrade",
-          "canPseudoScrew"
-      ],
-      "mult": {
-          "canUseMorphBombs": 2,
-          "canUsePowerBombs": 2
-      }
-  },
-  {
       "id": 26,
       "name": "Boulder",
       "dmgToSamus": [
@@ -60,38 +27,6 @@
           "Missile",
           "canUseMorphBombs",
           "canUsePowerBombs",
-          "canUseSpeedEchoes",
-          "canShinespark",
-          "Screw"
-      ],
-      "mult": {}
-  },
-  {
-      "id": 27,
-      "name": "Boyon",
-      "dmgToSamus": [
-          10,
-          5,
-          2
-      ],
-      "hp": 1000,
-      "drops": {
-          "no-drop": 52,
-          "small-energy": 8,
-          "big-energy": 4,
-          "missile": 34,
-          "super": 2,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [
-          "canShoot",
-          "hasBeamUpgrade",
-          "Missile",
           "canUseSpeedEchoes",
           "canShinespark",
           "Screw"
@@ -172,38 +107,6 @@
       "freezable": true,
       "invul": [],
       "mult": {}
-  },
-  {
-      "id": 31,
-      "name": "Kihunter (green)",
-      "dmgToSamus": [
-          20,
-          10,
-          5
-      ],
-      "hp": 60,
-      "drops": {
-          "no-drop": 30,
-          "small-energy": 20,
-          "big-energy": 12,
-          "missile": 32,
-          "super": 4,
-          "powerbomb": 4
-      },
-      "dims": {
-          "w": 8,
-          "h": 18
-      },
-      "freezable": true,
-      "invul": [
-          "canShoot",
-          "hasBeamUpgrade",
-          "canUseMorphBombs"
-      ],
-      "mult": {
-          "Missile": 2,
-          "Super": 2
-      }
   },
   {
       "id": 32,
@@ -292,31 +195,6 @@
       "mult": {}
   },
   {
-      "id": 35,
-      "name": "Reo",
-      "dmgToSamus": [
-          15,
-          7,
-          3
-      ],
-      "hp": 45,
-      "drops": {
-          "no-drop": 16,
-          "small-energy": 12,
-          "big-energy": 32,
-          "missile": 34,
-          "super": 4,
-          "powerbomb": 4
-      },
-      "dims": {
-          "w": 16,
-          "h": 7
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
       "id": 36,
       "name": "Ripper",
       "dmgToSamus": [
@@ -383,81 +261,6 @@
       "mult": {}
   },
   {
-      "id": 38,
-      "name": "Skree",
-      "dmgToSamus": [
-          10,
-          5,
-          2
-      ],
-      "hp": 15,
-      "drops": {
-          "no-drop": 54.8,
-          "small-energy": 8,
-          "big-energy": 1.2,
-          "missile": 34,
-          "super": 2,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 8,
-          "h": 12
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
-      "id": 39,
-      "name": "Skultera",
-      "dmgToSamus": [
-          80,
-          40,
-          20
-      ],
-      "hp": 300,
-      "drops": {
-          "no-drop": 28,
-          "small-energy": 32,
-          "big-energy": 12,
-          "missile": 28,
-          "super": 2,
-          "powerbomb": 0
-      },
-      "dims": {
-          "w": 13,
-          "h": 11
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
-      "id": 40,
-      "name": "Sidehopper",
-      "dmgToSamus": [
-          80,
-          40,
-          20
-      ],
-      "hp": 320,
-      "drops": {
-          "no-drop": 40,
-          "small-energy": 8,
-          "big-energy": 8,
-          "missile": 22,
-          "super": 22,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 24,
-          "h": 20
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
       "id": 41,
       "name": "Sm. Sidehopper",
       "dmgToSamus": [
@@ -477,145 +280,6 @@
       "dims": {
           "w": 16,
           "h": 13
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
-      "id": 42,
-      "name": "Green Space Pirate (standing)",
-      "dmgToSamus": [
-          20,
-          10,
-          5
-      ],
-      "hp": 90,
-      "drops": {
-          "no-drop": 18,
-          "small-energy": 20,
-          "big-energy": 12,
-          "missile": 40,
-          "super": 8,
-          "powerbomb": 4
-      },
-      "dims": {
-          "w": 16,
-          "h": 32
-      },
-      "freezable": true,
-      "invul": [
-          "canShoot"
-      ],
-      "mult": {
-          "Missile": 2,
-          "Super": 2,
-          "canUseMorphBombs": 2
-      }
-  },
-  {
-      "id": 43,
-      "name": "Waver",
-      "dmgToSamus": [
-          10,
-          5,
-          2
-      ],
-      "hp": 30,
-      "drops": {
-          "no-drop": 2,
-          "small-energy": 24,
-          "big-energy": 24,
-          "missile": 24,
-          "super": 24,
-          "powerbomb": 4
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
-      "id": 44,
-      "name": "Yapping Maw",
-      "dmgToSamus": [
-          0,
-          0,
-          0
-      ],
-      "hp": 20,
-      "drops": {
-          "no-drop": 2,
-          "small-energy": 32,
-          "big-energy": 32,
-          "missile": 32,
-          "super": 2,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [
-          "canShoot",
-          "hasBeamUpgrade",
-          "Missile",
-          "canUseMorphBombs",
-          "canUsePowerBombs",
-          "Screw",
-          "canPseudoScrew"
-      ],
-      "mult": {}
-  },
-  {
-      "id": 45,
-      "name": "Zeb",
-      "dmgToSamus": [
-          6,
-          3,
-          1
-      ],
-      "hp": 9,
-      "drops": {
-          "no-drop": 2,
-          "small-energy": 24,
-          "big-energy": 24,
-          "missile": 24,
-          "super": 24,
-          "powerbomb": 4
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
-      "id": 46,
-      "name": "Zebbo",
-      "dmgToSamus": [
-          20,
-          10,
-          5
-      ],
-      "hp": 30,
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0,
-          "big-energy": 56,
-          "missile": 4,
-          "super": 40,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
       },
       "freezable": true,
       "invul": [],

--- a/enemies/maridia/main.json
+++ b/enemies/maridia/main.json
@@ -1,85 +1,5 @@
 [
   {
-      "id": 56,
-      "name": "Bull",
-      "dmgToSamus": [
-          10,
-          5,
-          2
-      ],
-      "hp": 100,
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0,
-          "big-energy": 2,
-          "missile": 0,
-          "super": 0,
-          "powerbomb": 100
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": false,
-      "invul": [
-          "canShoot",
-          "Ice",
-          "Wave",
-          "Spazer"
-      ],
-      "mult": {}
-  },
-  {
-      "id": 57,
-      "name": "Cacatac",
-      "dmgToSamus": [
-          20,
-          10,
-          5
-      ],
-      "hp": 60,
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0,
-          "big-energy": 0.4,
-          "missile": 0,
-          "super": 101.6,
-          "powerbomb": 0
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
-      "id": 58,
-      "name": "Choot",
-      "dmgToSamus": [
-          80,
-          40,
-          20
-      ],
-      "hp": 100,
-      "drops": {
-          "no-drop": 2,
-          "small-energy": 24,
-          "big-energy": 24,
-          "missile": 24,
-          "super": 24,
-          "powerbomb": 4
-      },
-      "dims": {
-          "w": 16,
-          "h": 5
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
       "id": 59,
       "name": "Evir",
       "dmgToSamus": [
@@ -290,59 +210,6 @@
       "mult": {}
   },
   {
-      "id": 67,
-      "name": "Puyo",
-      "dmgToSamus": [
-          60,
-          30,
-          15
-      ],
-      "hp": 100,
-      "drops": {
-          "no-drop": 2,
-          "small-energy": 24,
-          "big-energy": 24,
-          "missile": 24,
-          "super": 4,
-          "powerbomb": 24
-      },
-      "dims": {
-          "w": 8,
-          "h": 4
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
-      "id": 68,
-      "name": "Sciser",
-      "dmgToSamus": [
-          120,
-          60,
-          30
-      ],
-      "hp": 200,
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0.4,
-          "big-energy": 40,
-          "missile": 0,
-          "super": 0,
-          "powerbomb": 61.6
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "mult": {
-          "canUseMorphBombs": 2,
-          "canUsePowerBombs": 2
-      },
-      "invul": []
-  },
-  {
       "id": 69,
       "name": "Shaktool",
       "dmgToSamus": [
@@ -371,31 +238,6 @@
           "Screw",
           "canPseudoScrew"
       ],
-      "mult": {}
-  },
-  {
-      "id": 70,
-      "name": "Skultera",
-      "dmgToSamus": [
-          80,
-          40,
-          20
-      ],
-      "hp": 300,
-      "drops": {
-          "no-drop": 28,
-          "small-energy": 32,
-          "big-energy": 12,
-          "missile": 28,
-          "super": 2,
-          "powerbomb": 0
-      },
-      "dims": {
-          "w": 13,
-          "h": 11
-      },
-      "freezable": true,
-      "invul": [],
       "mult": {}
   },
   {
@@ -489,31 +331,6 @@
           "canUsePowerBombs": 2
       },
       "invul": []
-  },
-  {
-      "id": 74,
-      "name": "Zebbo",
-      "dmgToSamus": [
-          20,
-          10,
-          5
-      ],
-      "hp": 30,
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0,
-          "big-energy": 56,
-          "missile": 4,
-          "super": 40,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
   },
   {
       "id": 75,

--- a/enemies/norfair/main.json
+++ b/enemies/norfair/main.json
@@ -1,92 +1,5 @@
 [
   {
-      "id": 76,
-      "name": "Alcoon",
-      "dmgToSamus": [
-          50,
-          25,
-          12
-      ],
-      "hp": 200,
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0.4,
-          "big-energy": 0,
-          "missile": 0,
-          "super": 0,
-          "powerbomb": 101.6
-      },
-      "dims": {
-          "w": 8,
-          "h": 24
-      },
-      "freezable": true,
-      "mult": {
-          "Missile": 2,
-          "Super": 2
-      },
-      "invul": []
-  },
-  {
-      "id": 77,
-      "name": "Boulder",
-      "dmgToSamus": [
-          40,
-          20,
-          10
-      ],
-      "hp": 20,
-      "drops": {
-          "no-drop": 102,
-          "small-energy": 0,
-          "big-energy": 0,
-          "missile": 0,
-          "super": 0,
-          "powerbomb": 0
-      },
-      "dims": {
-          "w": 16,
-          "h": 16
-      },
-      "freezable": false,
-      "invul": [
-          "canShoot",
-          "hasBeamUpgrade",
-          "Missile",
-          "canUseMorphBombs",
-          "canUsePowerBombs",
-          "canUseSpeedEchoes",
-          "canShinespark",
-          "Screw"
-      ],
-      "mult": {}
-  },
-  {
-      "id": 78,
-      "name": "Cacatac",
-      "dmgToSamus": [
-          20,
-          10,
-          5
-      ],
-      "hp": 60,
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0,
-          "big-energy": 0.4,
-          "missile": 0,
-          "super": 101.6,
-          "powerbomb": 0
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
       "id": 79,
       "name": "Dessgeega",
       "dmgToSamus": [
@@ -144,31 +57,6 @@
           "Wave",
           "Spazer"
       ],
-      "mult": {}
-  },
-  {
-      "id": 81,
-      "name": "Fireflea",
-      "dmgToSamus": [
-          4,
-          2,
-          1
-      ],
-      "hp": 20,
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0,
-          "big-energy": 0.4,
-          "missile": 0,
-          "super": 0,
-          "powerbomb": 101.6
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [],
       "mult": {}
   },
   {
@@ -230,41 +118,6 @@
       "mult": {}
   },
   {
-      "id": 84,
-      "name": "Geemer (grey)",
-      "dmgToSamus": [
-          5,
-          2,
-          1
-      ],
-      "hp": 15,
-      "drops": {
-          "no-drop": 40,
-          "small-energy": 52,
-          "big-energy": 8,
-          "missile": 0,
-          "super": 0,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": false,
-      "invul": [
-          "canShoot",
-          "Ice",
-          "Wave",
-          "Spazer",
-          "Missile",
-          "Super",
-          "canUseSpeedEchoes",
-          "canShinespark",
-          "canPseudoScrew"
-      ],
-      "mult": {}
-  },
-  {
       "id": 85,
       "name": "Geruta",
       "dmgToSamus": [
@@ -322,76 +175,6 @@
       "mult": {
           "IceBeam": 2
       }
-  },
-  {
-      "id": 87,
-      "name": "Kago",
-      "dmgToSamus": [
-          0,
-          0,
-          0
-      ],
-      "hp": 1600,
-      "drops": {
-          "no-drop": 2,
-          "small-energy": 20,
-          "big-energy": 36,
-          "missile": 28,
-          "super": 8,
-          "powerbomb": 8
-      },
-      "dims": {
-          "w": 16,
-          "h": 16
-      },
-      "freezable": false,
-      "invul": [
-          "canShoot",
-          "hasBeamUpgrade",
-          "Missile",
-          "Super",
-          "canUseMorphBombs",
-          "canUseSpeedEchoes",
-          "canShinespark",
-          "Screw",
-          "PsuedoScrew"
-      ],
-      "mult": {}
-  },
-  {
-      "id": 88,
-      "name": "Kamer",
-      "dmgToSamus": [
-          0,
-          0,
-          0
-      ],
-      "hp": 20,
-      "drops": {
-          "no-drop": 2,
-          "small-energy": 32,
-          "big-energy": 32,
-          "missile": 32,
-          "super": 2,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 10,
-          "h": 8
-      },
-      "freezable": false,
-      "invul": [
-          "canShoot",
-          "hasBeamUpgrade",
-          "Missile",
-          "SuperMissiles",
-          "canUseMorphBombs",
-          "canUsePowerBombs",
-          "canUseSpeedEchoes",
-          "canShinespark",
-          "canPseudoScrew"
-      ],
-      "mult": {}
   },
   {
       "id": 89,
@@ -572,95 +355,6 @@
       },
       "freezable": false,
       "invul": true,
-      "mult": {}
-  },
-  {
-      "id": 95,
-      "name": "Ripper 2 (green)",
-      "dmgToSamus": [
-          10,
-          5,
-          2
-      ],
-      "hp": 200,
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0,
-          "big-energy": 0.4,
-          "missile": 0,
-          "super": 101.6,
-          "powerbomb": 0
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": false,
-      "invul": [
-          "canShoot",
-          "hasBeamUpgrade",
-          "canUseMorphBombs",
-          "canUseSpeedEchoes",
-          "canPseudoScrew"
-      ],
-      "mult": {}
-  },
-  {
-      "id": 96,
-      "name": "Ripper 2 (red)",
-      "dmgToSamus": [
-          10,
-          5,
-          2
-      ],
-      "hp": 200,
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0,
-          "big-energy": 0.4,
-          "missile": 0,
-          "super": 101.6,
-          "powerbomb": 0
-      },
-      "dims": {
-          "w": 8,
-          "h": 4
-      },
-      "freezable": true,
-      "invul": [
-          "canShoot",
-          "hasBeamUpgrade",
-          "Missile",
-          "canUseMorphBombs",
-          "canUseSpeedEchoes",
-          "canShinespark",
-          "canPseudoScrew"
-      ],
-      "mult": {}
-  },
-  {
-      "id": 97,
-      "name": "Skree",
-      "dmgToSamus": [
-          10,
-          5,
-          2
-      ],
-      "hp": 15,
-      "drops": {
-          "no-drop": 54.8,
-          "small-energy": 8,
-          "big-energy": 1.2,
-          "missile": 34,
-          "super": 2,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 8,
-          "h": 12
-      },
-      "freezable": true,
-      "invul": [],
       "mult": {}
   },
   {
@@ -874,39 +568,6 @@
       "mult": {}
   },
   {
-      "id": 105,
-      "name": "Tripper",
-      "dmgToSamus": [
-          0,
-          0,
-          0
-      ],
-      "hp": 20,
-      "drops": {
-          "no-drop": 2,
-          "small-energy": 32,
-          "big-energy": 32,
-          "missile": 32,
-          "super": 2,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 10,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [
-          "canShoot",
-          "hasBeamUpgrade",
-          "Missile",
-          "canUseMorphBombs",
-          "canUseSpeedEchoes",
-          "canShinespark",
-          "canPseudoScrew"
-      ],
-      "mult": {}
-  },
-  {
       "id": 106,
       "name": "Viola",
       "dmgToSamus": [
@@ -933,55 +594,5 @@
           "canUsePowerBombs": 2
       },
       "invul": []
-  },
-  {
-      "id": 107,
-      "name": "Waver",
-      "dmgToSamus": [
-          10,
-          5,
-          2
-      ],
-      "hp": 30,
-      "drops": {
-          "no-drop": 2,
-          "small-energy": 24,
-          "big-energy": 24,
-          "missile": 24,
-          "super": 24,
-          "powerbomb": 4
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
-  },
-  {
-      "id": 108,
-      "name": "Zebbo",
-      "dmgToSamus": [
-          20,
-          10,
-          5
-      ],
-      "hp": 30,
-      "drops": {
-          "no-drop": 0,
-          "small-energy": 0,
-          "big-energy": 56,
-          "missile": 4,
-          "super": 40,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 8,
-          "h": 8
-      },
-      "freezable": true,
-      "invul": [],
-      "mult": {}
   }
 ]

--- a/enemies/wreckedship/main.json
+++ b/enemies/wreckedship/main.json
@@ -81,41 +81,6 @@
       "mult": {}
   },
   {
-      "id": 52,
-      "name": "Kamer",
-      "dmgToSamus": [
-          0,
-          0,
-          0
-      ],
-      "hp": 20,
-      "drops": {
-          "no-drop": 2,
-          "small-energy": 32,
-          "big-energy": 32,
-          "missile": 32,
-          "super": 2,
-          "powerbomb": 2
-      },
-      "dims": {
-          "w": 10,
-          "h": 8
-      },
-      "freezable": false,
-      "invul": [
-          "canShoot",
-          "hasBeamUpgrade",
-          "Missile",
-          "SuperMissiles",
-          "canUseMorphBombs",
-          "canUsePowerBombs",
-          "canUseSpeedEchoes",
-          "canShinespark",
-          "canPseudoScrew"
-      ],
-      "mult": {}
-  },
-  {
       "id": 53,
       "name": "Kihunter (yellow)",
       "dmgToSamus": [
@@ -140,31 +105,6 @@
       "invul": [
           "canUseMorphBombs"
       ],
-      "mult": {}
-  },
-  {
-      "id": 54,
-      "name": "Skultera",
-      "dmgToSamus": [
-          80,
-          40,
-          20
-      ],
-      "hp": 300,
-      "drops": {
-          "no-drop": 28,
-          "small-energy": 32,
-          "big-energy": 12,
-          "missile": 28,
-          "super": 2,
-          "powerbomb": 0
-      },
-      "dims": {
-          "w": 13,
-          "h": 11
-      },
-      "freezable": true,
-      "invul": [],
       "mult": {}
   },
   {


### PR DESCRIPTION
Lots of duplicated enemy definitions, remove the dupes. Leave notes in commit messages for knowing where the dupes were so that we can document them later.
