### PR TITLE
Add the easy X-Ray climbs to logic 

### DIFF
--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -247,7 +247,15 @@
           "to": [
             {
               "id": 4,
-              "requires": [ "Morph" ],
+              "requires": [
+                { "or": [
+                    "Morph",
+                    { "and": [
+                        "canXrayClimb",
+                        { "resetRoomAtNode": [ 3 ] }
+                    ]}
+                ]}
+              ],
               "unlock": null
             }
           ]

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -343,7 +343,11 @@
               "requires": [
                 {"or": [
                   "canUsePowerBombs",
-                  "canWallCrawlerClip"
+                  "canWallCrawlerClip",
+                  { "and": [
+                      "canXRayClimb",
+                      { "resetRoomAtNode": [ 8 ] }
+                  ]}
                 ]}
               ],
               "unlock": null
@@ -922,7 +926,14 @@
             },
             {
               "id": 6,
-              "requires": [ "canBeetomClip" ],
+              "requires": 
+              { "or": [
+                  "canBeetomClip",
+                  { "and": [
+                      "canXrayClimb",
+                    { "resetRoomAtNode": [ 3 ] }
+                  ]}
+              ]},
               "unlock": null
             }
           ]

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -143,9 +143,7 @@
                     ]}
                 ]}
               ],
-              "unlock"
-              :
-              null
+              "unlock": null
             }
           ]
         },

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -134,8 +134,18 @@
           "to": [
             {
               "id": 1,
-              "requires": [ "canUsePowerBombs" ],
-              "unlock": null
+              "requires": [
+                { "or": [
+                    "canUsePowerBombs",
+                    { "and": [
+                        "canXRayClimb",
+                        { "resetRoomAtNode": [ 2 ] }
+                    ]}
+                ]}
+              ],
+              "unlock"
+              :
+              null
             }
           ]
         },

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -431,7 +431,15 @@
           "to": [
             {
               "id": 8,
-              "requires": [ "Morph" ],
+              "requires": [
+                { "or": [
+                    "Morph",
+                    { "and": [
+                        "canXRayClimb",
+                        { "resetRoomAtNode": [ 2 ] }
+                    ]}
+                ]}
+              ],
               "unlock": null
             }
           ]

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -675,20 +675,18 @@
                       {"heatFrames": 400}
                     ]}
                   ]},
-                  {
-                    "and": [
+                  {"and": [
                       "canUseFrozenEnemies",
                       "Charge",
                       "canDestroyBombWalls",
                       "heatProof"
-                    ]
-                  },
+                  ]},
                   { "and": [
                       {"or": [
                         "heatProof",
                         "canHeatRun"
                       ]},
-                      "canXrayClimb",
+                      "canXRayClimb",
                       { "resetRoomAtNode": [ 2 ] },
                       { "cost": [
                           {"enemyDamage": {
@@ -701,7 +699,7 @@
                             "type": "contact",
                             "hits": 1
                           }},
-                          {"heatFrames": 1299}
+                          {"heatFrames": 600}
                       ]}
                   ]},
                   {"and": [
@@ -1450,9 +1448,9 @@
                             ]}
                         ]},
                         { "and": [
-                            { "canXrayClimb": [ 1 ] },
+                            { "canXRayClimb": [ 1 ] },
                             { "cost": [
-                                { "heatFrames": 1100 }
+                                { "heatFrames": 700 }
                             ]}
                         ]}
                     ]},

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -675,11 +675,34 @@
                       {"heatFrames": 400}
                     ]}
                   ]},
-                  {"and": [
-                    "canUseFrozenEnemies",
-                    "Charge",
-                    "canDestroyBombWalls",
-                    "heatProof"
+                  {
+                    "and": [
+                      "canUseFrozenEnemies",
+                      "Charge",
+                      "canDestroyBombWalls",
+                      "heatProof"
+                    ]
+                  },
+                  { "and": [
+                      {"or": [
+                        "heatProof",
+                        "canHeatRun"
+                      ]},
+                      "canXrayClimb",
+                      { "resetRoomAtNode": [ 2 ] },
+                      { "cost": [
+                          {"enemyDamage": {
+                              "enemy": 93,
+                              "type": "projectile",
+                              "hits": 2
+                          }},
+                          {"enemyDamage": {
+                            "enemy": 102,
+                            "type": "contact",
+                            "hits": 1
+                          }},
+                          {"heatFrames": 1299}
+                      ]}
                   ]},
                   {"and": [
                     {"or": [
@@ -1407,38 +1430,52 @@
               "id": 4,
               "requires": [
                 {"or": [
-                  "heatProof",
-                  "canHeatRun"
+                   "heatProof",
+                   "canHeatRun"
                 ]},
-                "canUsePowerBombs",
-                {"or": [
-                  "canWalljump",
-                  {"cost": [
-                    {"heatFrames": 200}
-                  ]}
-                ]},
-                {"and" :[
-                  {"cost": [
-                    {"heatFrames": 800}
-                  ]},
-                  {"or": [
-                    {"cost": [
-                      {"enemyDamage": [{
-                        "enemy": 79,
-                        "type": "contact",
-                        "hits": 1
-                      }]}
+                {"and": [
+                    {"or": [
+                        {"and": [
+                            "canUsePowerBombs",
+                            { "or": [
+                                { "and": [
+                                    "canWalljump",
+                                    {"cost": [
+                                        { "heatFrames": 200 }
+                                    ]}
+                                ]},
+                                { "cost": [
+                                    { "heatFrames": 800 }
+                                ]}
+                            ]}
+                        ]},
+                        { "and": [
+                            { "canXrayClimb": [ 1 ] },
+                            { "cost": [
+                                { "heatFrames": 1100 }
+                            ]}
+                        ]}
                     ]},
-                    "ScrewAttack",
-                    "Super",
-                    {"and": [
-                      "Plasma",
-                      {"or": [
-                        "Ice",
-                        "Wave"
-                      ]}
+                    { "or": [
+                        { "cost": [
+                          {"enemyDamage": [
+                              {
+                                "enemy": 79,
+                                "type": "contact",
+                                "hits": 1
+                              }
+                          ]}
+                        ]},
+                        "ScrewAttack",
+                        "Super",
+                        { "and": [
+                            "Plasma",
+                            { "or": [
+                                "Ice",
+                                "Wave"
+                            ]}
+                        ]}
                     ]}
-                  ]}
                 ]}
               ],
               "unlock": null

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -1430,48 +1430,46 @@
                 {"or": [
                    "heatProof",
                    "canHeatRun"
-                ]},
-                {"and": [
-                    {"or": [
-                        {"and": [
-                            "canUsePowerBombs",
-                            { "or": [
-                                { "and": [
-                                    "canWalljump",
-                                    {"cost": [
-                                        { "heatFrames": 200 }
-                                    ]}
-                                ]},
-                                { "cost": [
-                                    { "heatFrames": 800 }
+                ]}, 
+                {"or": [
+                    {"and": [
+                        "canUsePowerBombs",
+                        { "or": [
+                            { "and": [
+                                "canWalljump",
+                                {"cost": [
+                                    { "heatFrames": 200 }
                                 ]}
-                            ]}
-                        ]},
-                        { "and": [
-                            { "canXRayClimb": [ 1 ] },
+                            ]},
                             { "cost": [
-                                { "heatFrames": 700 }
+                                { "heatFrames": 800 }
                             ]}
                         ]}
                     ]},
-                    { "or": [
+                    { "and": [
+                        { "canXRayClimb": [ 1 ] },
                         { "cost": [
-                          {"enemyDamage": [
-                              {
-                                "enemy": 79,
-                                "type": "contact",
-                                "hits": 1
-                              }
-                          ]}
-                        ]},
-                        "ScrewAttack",
-                        "Super",
-                        { "and": [
-                            "Plasma",
-                            { "or": [
-                                "Ice",
-                                "Wave"
-                            ]}
+                            { "heatFrames": 700 }
+                        ]}
+                    ]}
+                ]},
+                { "or": [
+                    { "cost": [
+                      {"enemyDamage": [
+                          {
+                            "enemy": 79,
+                            "type": "contact",
+                            "hits": 1
+                          }
+                      ]}
+                    ]},
+                    "ScrewAttack",
+                    "Super",
+                    { "and": [
+                        "Plasma",
+                        { "or": [
+                            "Ice",
+                            "Wave"
                         ]}
                     ]}
                 ]}

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -683,7 +683,7 @@
                         ]}
                     ]},
                     { "and": [
-                        "canXrayClimb",
+                        "canXRayClimb",
                         { "resetRoomAtNode": [ 1 ] },
                         { "cost": [
                             {"heatFrames": 300}
@@ -692,7 +692,7 @@
                 ]}
               ],
               "unlock": null,
-              "note": "Shinespark and XrayClimb have a direct link. Other strats should go 1 -> 4 -> 2."
+              "note": "Shinespark and XRayClimb have a direct link. Other strats should go 1 -> 4 -> 2."
             },
             {
               "id": 3,
@@ -713,7 +713,7 @@
                         ]}
                     ]},
                     { "and": [
-                        "canXrayClimb",
+                        "canXRayClimb",
                         { "resetRoomAtNode": [ 1 ] },
                         {"cost": [
                             { "heatFrames": 800 }
@@ -722,7 +722,7 @@
                 ]}
               ],
               "unlock": null,
-              "note": "Shinespark and XrayClimb have a direct link. Other strats should go 1 -> 4 -> 2 -> 3."
+              "note": "Shinespark and XRayClimb have a direct link. Other strats should go 1 -> 4 -> 2 -> 3."
             },
             {
               "id": 4,

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -665,47 +665,64 @@
         {
           "from": 1,
           "to": [
-            {
-              "id": 2,
+            { "id": 2,
               "requires": [
                 {"or": [
-                  "heatProof",
-                  "canHeatRun"
+                    "heatProof",
+                    "canHeatRun"
                 ]},
-                {"and": [
-                  {"canComeInCharged": {
-                    "fromNode": 1,
-                    "framesRemaining": 30,
-                    "shinesparkFrames": 35
-                  }},
-                  {"cost": [
-                    {"heatFrames": 200}
-                  ]}
+                { "or": [
+                    { "and": [
+                        {"canComeInCharged": {
+                            "fromNode": 1,
+                            "framesRemaining": 30,
+                            "shinesparkFrames": 35
+                        }},
+                        { "cost": [
+                            { "heatFrames": 200 }
+                        ]}
+                    ]},
+                    { "and": [
+                        "canXrayClimb",
+                        { "resetRoomAtNode": [ 1 ] },
+                        { "cost": [
+                            {"heatFrames": 300}
+                        ]}
+                    ]}
                 ]}
               ],
               "unlock": null,
-              "note": "Only the shinespark is a direct link. Other strats should go 1 -> 4 -> 2."
+              "note": "Shinespark and XrayClimb have a direct link. Other strats should go 1 -> 4 -> 2."
             },
             {
               "id": 3,
               "requires": [
-                {"or": [
-                  "heatProof",
-                  "canHeatRun"
+                { "or": [
+                    "heatProof",
+                    "canHeatRun"
                 ]},
-                {"and": [
-                  {"canComeInCharged": {
-                    "fromNode": 1,
-                    "framesRemaining": 60,
-                    "shinesparkFrames": 50
-                  }},
-                  {"cost": [
-                    {"heatFrames": 250}
-                  ]}
+                { "or": [
+                    { "and": [
+                        { "canComeInCharged": {
+                            "fromNode": 1,
+                            "framesRemaining": 60,
+                            "shinesparkFrames": 50
+                        }},
+                        { "cost": [
+                            { "heatFrames": 250 }
+                        ]}
+                    ]},
+                    { "and": [
+                        "canXrayClimb",
+                        { "resetRoomAtNode": [ 1 ] },
+                        {"cost": [
+                            { "heatFrames": 800 }
+                        ]}
+                    ]}
                 ]}
               ],
               "unlock": null,
-              "note": "Only the shinespark is a direct link. Other strats should go 1 -> 4 -> 2 -> 3."
+              "note": "Shinespark and XrayClimb have a direct link. Other strats should go 1 -> 4 -> 2 -> 3."
             },
             {
               "id": 4,

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -144,6 +144,10 @@
                       "HiJump",
                       "canSpringBallJumpMidAir"
                     ]}
+                  ]},
+                  {"and": [
+                     "canXrayClimb",
+                     {"resetRoomAtNode": [1]}
                   ]}
                 ]}
               ],
@@ -606,29 +610,37 @@
             {
               "id": 2,
               "requires": [
-                "Grapple",
-                {"or": [
-                  {"and": [
-                    "canSwim",
-                    {"or": [
-                      "HiJump",
-                      "SpaceJump",
-                      {"and": [
-                        "canIBJ",
-                        "canUseSpringBall"
-                      ]},
-                      "canGravityWalljump"
-                    ]}
-                  ]},
-                  {"and": [
-                    "canSuitlessMaridia",
-                    "SpaceJump",
-                    "HiJump",
-                    {"or": [
-                      "canSpringBallJumpMidAir",
-                      "canFlatleyTurnaroundJump"
-                    ]}
-                  ]}
+                {"or":[
+                   {"and": [
+                     "Grapple",
+                     {"or": [
+                       {"and": [
+                         "canSwim",
+                         {"or": [
+                           "HiJump",
+                           "SpaceJump",
+                           {"and": [
+                             "canIBJ",
+                             "canUseSpringBall"
+                           ]},
+                           "canGravityWalljump"
+                         ]}
+                       ]},
+                       {"and": [
+                         "canSuitlessMaridia",
+                         "SpaceJump",
+                         "HiJump",
+                         {"or": [
+                           "canSpringBallJumpMidAir",
+                           "canFlatleyTurnaroundJump"
+                         ]}
+                       ]}
+                     ]}
+                   ]},
+                   {"and": [
+                     "canXrayClimb",
+                     { "resetRoomAtNode": [1] }
+                   ]}
                 ]}
               ],
               "unlock": null

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -146,7 +146,7 @@
                     ]}
                   ]},
                   {"and": [
-                     "canXrayClimb",
+                     "canXRayClimb",
                      {"resetRoomAtNode": [1]}
                   ]}
                 ]}
@@ -638,7 +638,7 @@
                      ]}
                    ]},
                    {"and": [
-                     "canXrayClimb",
+                     "canXRayClimb",
                      { "resetRoomAtNode": [1] }
                    ]}
                 ]}

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -134,20 +134,28 @@
               "requires": [
                 {"or": [
                   {"and": [
-                    "canDestroyBombWalls",
-                    "canSwim"
-                  ]},
-                  {"and": [
-                    "canSuitlessMaridia",
-                    "canPassBombPassages",
+                    "canSwim",
                     {"or": [
-                      "HiJump",
-                      "canSpringBallJumpMidAir"
+                      "canDestroyBombWalls",
+                      {"and": [
+                         "canXRayClimb",
+                         {"resetRoomAtNode": [1]}
+                      ]}
                     ]}
                   ]},
                   {"and": [
-                     "canXRayClimb",
-                     {"resetRoomAtNode": [1]}
+                    "canSuitlessMaridia",
+                    {"or": [
+                      "HiJump",
+                      "canSpringBallJumpMidAir"
+                    ]},
+                    {"or": [
+                       "canPassBombPassages",
+                       {"and": [
+                          "canXRayClimb",
+                          {"resetRoomAtNode": [1]}
+                       ]}
+                    ]}
                   ]}
                 ]}
               ],
@@ -639,7 +647,11 @@
                    ]},
                    {"and": [
                      "canXRayClimb",
-                     { "resetRoomAtNode": [1] }
+                     { "resetRoomAtNode": [1] },
+                     {"or": [
+                        "canSwim",
+                        "canSuitlessMaridia"
+                     ]}
                    ]}
                 ]}
               ],

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -250,6 +250,20 @@
               "id": 2,
               "requires": [ "canUsePowerBombs" ],
               "unlock": null
+            },
+            {
+              "id":  9,
+              "requires": [
+                {"and": [
+                    "canXrayClimb",
+                    {"resetRoomAtNode": [1]},
+                    {"or": [
+                       "canSwim",
+                       "canSuitlessMaridia"
+                    ]}
+                ]}
+              ],
+              "unlock": null
             }
           ]
         },
@@ -277,6 +291,14 @@
                         "canSpringBallJumpMidAir"
                       ]}
                     ]}
+                  ]},
+                  {"and": [
+                      "canXrayClimb",
+                      {"resetRoomAtNode": [2]},
+                      {"or": [
+                        "canSwim",
+                        "canSuitlessMaridia"
+                      ]}
                   ]}
                 ]}
               ],
@@ -1047,7 +1069,11 @@
                     "canSuitlessMaridia",
                     {"or": [
                       "canMochtroidClimb",
-                      "Grapple"
+                      "Grapple",
+                      {"and": [
+                        "canXrayClimb",
+                        {"resetRoomAtNode": [2]}
+                      ]}
                     ]}
                   ]}
                 ]}
@@ -1448,13 +1474,19 @@
                       "canFly",
                       "canSpringBallJumpMidAir",
                       "HiJump",
-                      "canXRayClimb"
+                      {"and": [
+                         "canXRayClimb",
+                         {"resetRoomAtNode": [2]}
+                      ]}
                     ]}
                   ]},
                   {"and": [
                     "canSuitlessMaridia",
                     {"or": [
-                      "canXRayClimb",
+                      {"and": [
+                         "canXRayClimb",
+                         {"resetRoomAtNode": [2]}
+                      ]},
                       {"and": [
                         "HiJump",
                         "canSpringBallJumpMidAir"
@@ -1733,6 +1765,10 @@
                       {"and": [
                         "canUseFrozenEnemies",
                         "HiJump"
+                      ]},
+                      {"and": [
+                         "XrayClimb",
+                         {"resetRoomAtNode": [1]}
                       ]}
                     ]}
                   ]}

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -255,7 +255,7 @@
               "id":  9,
               "requires": [
                 {"and": [
-                    "canXrayClimb",
+                    "canXRayClimb",
                     {"resetRoomAtNode": [1]},
                     {"or": [
                        "canSwim",
@@ -293,7 +293,7 @@
                     ]}
                   ]},
                   {"and": [
-                      "canXrayClimb",
+                      "canXRayClimb",
                       {"resetRoomAtNode": [2]},
                       {"or": [
                         "canSwim",
@@ -1071,7 +1071,7 @@
                       "canMochtroidClimb",
                       "Grapple",
                       {"and": [
-                        "canXrayClimb",
+                        "canXRayClimb",
                         {"resetRoomAtNode": [2]}
                       ]}
                     ]}

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -1986,7 +1986,7 @@
                       ]}
                    ]},
                    {"and": [
-                      "canXrayClimb",
+                      "canXRayClimb",
                       {"resetRoomAtNode": [2]},
                       {"or": [
                          "canSuitlessMaridia",

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -1960,27 +1960,39 @@
             {
               "id": 1,
               "requires": [
-                "Morph",
                 {"or": [
-                  {"and": [
-                    "canSuitlessMaridia",
-                    "Super",
-                    "canUseFrozenEnemies",
-                    {"or": [
-                      "canCrabClimb",
-                      "canSpringBallJumpMidAir",
-                      "HiJump"
-                    ]}
-                  ]},
-                  {"and": [
-                    "canSwim",
-                    {"or": [
-                      "canUseFrozenEnemies",
-                      "canFly",
-                      "HiJump",
-                      "canGravityJump"
-                    ]}
-                  ]}
+                   {"and":[ 
+                      "Morph",
+                      { "or": [ 
+                          {"and":[
+                              "canSuitlessMaridia",
+                              "Super",
+                              "canUseFrozenEnemies",
+                              {"or":[
+                                  "canCrabClimb",
+                                  "canSpringBallJumpMidAir",
+                                  "HiJump"
+                              ]}
+                          ]},
+                          { "and":[ 
+                              "canSwim",
+                              { "or":[ 
+                                  "canUseFrozenEnemies",
+                                  "canFly",
+                                  "HiJump",
+                                  "canGravityJump"
+                              ]}
+                          ]}
+                      ]}
+                   ]},
+                   {"and": [
+                      "canXrayClimb",
+                      {"resetRoomAtNode": [2]},
+                      {"or": [
+                         "canSuitlessMaridia",
+                         "canSwim"
+                      ]}
+                   ]}
                 ]}
               ],
               "unlock": null

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1199,7 +1199,7 @@
               "id": 3,
               "requires": [
                 {"and": [
-                   "canXrayClimb",
+                   "canXRayClimb",
                    {"resetRoomAtNode": [4]}
                 ]}
               ],
@@ -1301,7 +1301,7 @@
                   "canFly",
                   "canUseFrozenEnemies",
                   {"and": [
-                     "canXrayClimb",
+                     "canXRayClimb",
                      {"resetRoomAtNode": [2, 3]}
                    ]}
                 ]}

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1196,6 +1196,16 @@
           "from": 5,
           "to": [
             {
+              "id": 3,
+              "requires": [
+                {"and": [
+                   "canXrayClimb",
+                   {"resetRoomAtNode": [4]}
+                ]}
+              ],
+              "unlock": null
+            },
+            {
               "id": 4,
               "requires": null,
               "unlock": null
@@ -1289,7 +1299,11 @@
                     ]}
                   ]},
                   "canFly",
-                  "canUseFrozenEnemies"
+                  "canUseFrozenEnemies",
+                  {"and": [
+                     "canXrayClimb",
+                     {"resetRoomAtNode": [2, 3]}
+                   ]}
                 ]}
               ],
               "unlock": null

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -520,7 +520,7 @@
               "id": 1,
               "requires": [
                 {"and": [
-                   "canXrayClimb",
+                   "canXRayClimb",
                    {"resetRoomAtNode": [2]}
                 ]}
               ],

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -517,6 +517,16 @@
           "from": 2,
           "to": [
             {
+              "id": 1,
+              "requires": [
+                {"and": [
+                   "canXrayClimb",
+                   {"resetRoomAtNode": [2]}
+                ]}
+              ],
+              "unlock": null
+            },
+            {
               "id": 3,
               "requires": [ "canUsePowerBombs" ],
               "unlock": null

--- a/tech.json
+++ b/tech.json
@@ -70,6 +70,11 @@
     "note": "Positioning Samus at the very edge of a platofrm, facing away, then turning around and jumping to initiate the jump off the platform (and slightly below it)"
   },
   {
+    "name": "canStationarySpinJump",
+    "requires": null,
+    "note": "Quickly press and release forward and then immediately press jump (after stopping) to spin jump with no horizontal movement."
+  },
+  {
     "name": "canCrystalFlash",
     "requires": [
       {"Missile": 2},
@@ -370,14 +375,16 @@
   },
   {
     "name": "canXRayClimb",
-    "requires": [
-      "XRay"
+    "requires": [ 
+      "XRayScope",
+      "canStationarySpinJump"
     ],
-    "note": "Using the X-Ray's forced standup trick to climb up through in-bound walls"
+    "note": "Enter the partner door with a stationary spinjump moving away to touch the transition with momentum that will get you stuck in the destination door.  Then use the X-Ray's forced standup trick to climb up through in-bound walls"
   },
   {
     "name": "canXRayClimbOOB",
-    "requires": [ "XRayScope" ]
+    "requires": [ "XRayScope" ],
+    "note":  "Using the X-Ray climb tech to enter a tile not recognized by the game map."
   },
   {
     "name": "canQuickCrumbleEscape",


### PR DESCRIPTION
This should be all the left wall X-Ray climbs that can be set up with a simple stationary spin jump.  Exceptions: 1)The door on the crumble blocks in Big Pink. 2)Wrecked Ship Bowling Alley climb that goes up through the spike floor.  Part of #164 