### PR TITLE
Metroid Rooms logic

### DIFF
--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -140,13 +140,37 @@
               {
                 "usedTiles": 31,
                 "framesRemaining": 120,
-                "openEnd": 2
+                "openEnd": 1
               }
             ]
           },
+          "yields": [ "killedMetroidRoom1" ],
           "locks": [
             {
-              "unlock": [ "Kill All Enemies" ]
+              "unlock": [
+                {"or": [
+                  {"and":[
+                    "Ice",
+                    {"or":[
+                      "Missile",
+                      "Super"
+                    ]}
+                  ]},
+                  {"and":[
+                    "Morph",
+                    "PowerBomb",
+                    "canMetroidAvoid",
+                    {"cost": [
+                      {"ammo": [
+                        {
+                          "type": "PowerBomb",
+                          "count": 3
+                        }
+                      ]}
+                    ]}
+                  ]}
+                ]}
+              ]
             }
           ]
         },
@@ -179,12 +203,18 @@
         {
           "name": "Metroid",
           "quantity": 4,
-          "homeNodes": [ 1, 2 ]
+          "homeNodes": [ 1,2 ],
+          "stopSpawn": [ "killedMetroidRoom1" ]
         },
         {
           "name": "Rinka",
-          "quantity": 4,
-          "homeNodes": [ 1, 2 ]
+          "quantity": 1,
+          "homeNodes": [ 1 ]
+        },
+        {
+          "name": "Rinka",
+          "quantity": 2,
+          "homeNodes": [ 2 ]
         }
       ],
       "links": [
@@ -193,7 +223,14 @@
           "to": [
             {
               "id": 2,
-              "requires": null,
+              "requires": [
+                {"or": [
+                  "SpaceJump",
+                  {"cost": [
+                    {"acidFrames": 30}
+                  ]}
+                ]}                
+              ],
               "unlock": null
             }
           ]
@@ -203,8 +240,19 @@
           "to": [
             {
               "id": 1,
-              "requires": null,
-              "unlock": [ "canKillMetroids" ]
+              "requires": [
+                {"or": [
+                  "SpaceJump",
+                  {"cost": [
+                    {"acidFrames": 60}
+                  ]}
+                ]},
+                {"or": [
+                  "Ice",
+                  "canMetroidAvoid"
+                ]}
+              ],
+              "unlock": null
             }
           ]
         }
@@ -248,9 +296,33 @@
               }
             ]
           },
+          "yields": [ "killedMetroidRoom2" ],
           "locks": [
             {
-              "unlock": [ "Kill All Enemies" ]
+              "unlock": [
+                {"or": [
+                  {"and":[
+                    "Ice",
+                    {"or":[
+                      "Missile",
+                      "Super"
+                    ]}
+                  ]},
+                  {"and":[
+                    "Morph",
+                    "PowerBomb",
+                    "canMetroidAvoid",
+                    {"cost": [
+                      {"ammo": [
+                        {
+                          "type": "PowerBomb",
+                          "count": 3
+                        }
+                      ]}
+                    ]}
+                  ]}
+                ]}                  
+              ]
             }
           ]
         }
@@ -259,7 +331,8 @@
         {
           "name": "Metroid",
           "quantity": 2,
-          "homeNodes": [ 1, 2 ]
+          "homeNodes": [ 1, 2 ],
+          "stopSpawn": [ "killedMetroidRoom2" ]
         },
         {
           "name": "Rinka",
@@ -274,7 +347,7 @@
             {
               "id": 2,
               "requires": null,
-              "unlock": [ "canKillMetroids" ]
+              "unlock": null
             }
           ]
         },
@@ -283,7 +356,12 @@
           "to": [
             {
               "id": 1,
-              "requires": null,
+              "requires": [ 
+                {"or": [
+                  "Ice",
+                  "canMetroidAvoid"
+                ]}
+              ],
               "unlock": null
             }
           ]
@@ -342,9 +420,33 @@
               }
             ]
           },
+          "yields": [ "killedMetroidRoom3" ],
           "locks": [
             {
-              "unlock": [ "Kill All Enemies" ]
+              "unlock": [
+                {"or": [
+                  {"and":[
+                    "Ice",
+                    {"or":[
+                      "Missile",
+                      "Super"
+                    ]}
+                  ]},
+                  {"and":[
+                    "Morph",
+                    "PowerBomb",
+                    "canMetroidAvoid",
+                    {"cost": [
+                      {"ammo": [
+                        {
+                          "type": "PowerBomb",
+                          "count": 3
+                        }
+                      ]}
+                    ]}
+                  ]}
+                ]}                  
+              ]
             }
           ]
         }
@@ -353,7 +455,8 @@
         {
           "name": "Metroid",
           "quantity": 3,
-          "homeNodes": [ 1, 2 ]
+          "homeNodes": [ 1, 2 ],
+          "stopSpawn": [ "killedMetroidRoom3" ]
         },
         {
           "name": "Rinka",
@@ -368,7 +471,7 @@
             {
               "id": 2,
               "requires": null,
-              "unlock": [ "canKillMetroids" ]
+              "unlock": null
             }
           ]
         },
@@ -377,7 +480,12 @@
           "to": [
             {
               "id": 1,
-              "requires": null,
+              "requires": [ 
+                {"or": [
+                  "Ice",
+                  "canMetroidAvoid"
+                ]}
+              ],
               "unlock": null
             }
           ]
@@ -411,9 +519,33 @@
           "name": "Bottom Door",
           "nodeType": "door",
           "nodeSubType": "grey",
+          "yields": [ "killedMetroidRoom4" ],
           "locks": [
             {
-              "unlock": [ "Kill All Enemies" ]
+              "unlock": [
+                {"or": [
+                  {"and":[
+                    "Ice",
+                    {"or":[
+                      "Missile",
+                      "Super"
+                    ]}
+                  ]},
+                  {"and":[
+                    "Morph",
+                    "PowerBomb",
+                    "canMetroidAvoid",
+                    {"cost": [
+                      {"ammo": [
+                        {
+                          "type": "PowerBomb",
+                          "count": 3
+                        }
+                      ]}
+                    ]}
+                  ]}
+                ]}                  
+              ]
             }
           ]
         }
@@ -422,7 +554,8 @@
         {
           "name": "Metroid",
           "quantity": 3,
-          "homeNodes": [ 1, 2 ]
+          "homeNodes": [ 1, 2 ],
+          "stopSpawn": [ "killedMetroidRoom4" ]
         },
         {
           "name": "Rinka",
@@ -437,7 +570,7 @@
             {
               "id": 2,
               "requires": null,
-              "unlock": [ "canKillMetroids" ]
+              "unlock": null
             }
           ]
         },
@@ -446,7 +579,12 @@
           "to": [
             {
               "id": 1,
-              "requires": null,
+              "requires": [ 
+                {"or": [
+                  "Ice",
+                  "canMetroidAvoid"
+                ]}
+              ],
               "unlock": null
             }
           ]

--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -159,7 +159,12 @@
                   {"and":[
                     "Morph",
                     "PowerBomb",
-                    "canMetroidAvoid",
+                    {"or": [
+                      {"cost": [
+                        {"metroidFrames": 300}
+                      ]},
+                      "canMetroidAvoid"
+                    ]},
                     {"cost": [
                       {"ammo": [
                         {
@@ -225,6 +230,7 @@
               "id": 2,
               "requires": [
                 {"or": [
+                  "SpeedBooster",
                   "SpaceJump",
                   {"cost": [
                     {"acidFrames": 30}
@@ -242,14 +248,11 @@
               "id": 1,
               "requires": [
                 {"or": [
+                  "SpeedBooster",
                   "SpaceJump",
                   {"cost": [
                     {"acidFrames": 60}
                   ]}
-                ]},
-                {"or": [
-                  "Ice",
-                  "canMetroidAvoid"
                 ]}
               ],
               "unlock": null
@@ -311,7 +314,12 @@
                   {"and":[
                     "Morph",
                     "PowerBomb",
-                    "canMetroidAvoid",
+                    {"or": [
+                      {"cost": [
+                        {"metroidFrames": 100}
+                      ]},
+                      "canMetroidAvoid"
+                    ]},
                     {"cost": [
                       {"ammo": [
                         {
@@ -356,12 +364,7 @@
           "to": [
             {
               "id": 1,
-              "requires": [ 
-                {"or": [
-                  "Ice",
-                  "canMetroidAvoid"
-                ]}
-              ],
+              "requires": null,
               "unlock": null
             }
           ]
@@ -435,7 +438,12 @@
                   {"and":[
                     "Morph",
                     "PowerBomb",
-                    "canMetroidAvoid",
+                    {"or": [
+                      {"cost": [
+                        {"metroidFrames": 425}
+                      ]},
+                      "canMetroidAvoid"
+                    ]},
                     {"cost": [
                       {"ammo": [
                         {
@@ -482,8 +490,13 @@
               "id": 1,
               "requires": [ 
                 {"or": [
+                  "killedMetroidRoom3",
+                  "ScrewAttack",
                   "Ice",
-                  "canMetroidAvoid"
+                  "canMetroidAvoid",
+                  {"cost": [
+                    {"metroidFrames": 175}
+                  ]}
                 ]}
               ],
               "unlock": null
@@ -534,7 +547,12 @@
                   {"and":[
                     "Morph",
                     "PowerBomb",
-                    "canMetroidAvoid",
+                    {"or": [
+                      {"cost": [
+                        {"metroidFrames": 275}
+                      ]},
+                      "canMetroidAvoid"
+                    ]},
                     {"cost": [
                       {"ammo": [
                         {
@@ -581,11 +599,22 @@
               "id": 1,
               "requires": [ 
                 {"or": [
+                  "killedMetroidRoom4",
+                  "ScrewAttack",
                   "Ice",
-                  "canMetroidAvoid"
+                  "canMetroidAvoid",
+                  {"cost": [
+                    {"enemyDamage": {
+                      "enemy": "Rinka",
+                      "type": "contact",
+                      "hits": 1
+                    }},
+                    {"metroidFrames": 250}
+                  ]}
                 ]}
               ],
-              "unlock": null
+              "unlock": null,
+              "note": "Taking a rinka hit stops the Metroid damage for a while and is less damage."
             }
           ]
         }

--- a/tech.json
+++ b/tech.json
@@ -271,6 +271,11 @@
     "note": "Using a frozen wall crawling enemy (such as a Zeela or Geemer) to perform a ceiling clip"
   },
   {
+    "name": "canMetroidAvoid",
+    "requires": [],
+    "note": "Being proficient at avoiding Metroids"
+  },
+  {
     "name": "canMochtroidClip",
     "requires": [
       "canUseFrozenEnemies"


### PR DESCRIPTION
Each room of Metroids is killable with only 3 Power Bombs but they need a great deal of tricky avoidance so I created canMetroidAvoid either for going in reverse or for killing Metroids with Power Bombs.

Fitting the Missile & Super ammo into this goes together with the rest of the issues surrounding enemies so leaving it alone for now.