### PR TITLE
Fix Fast Pillars Setup Room runway resets, since the ice clip from below is not possible. Resolves # 211.

### DIFF
--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -202,7 +202,7 @@
                     "canHeatRun"
                   ]},
                   {"resetRoom":{
-                    "nodes": [1, 2, 3, 4],
+                    "nodes": [1, 4],
                     "obstaclesToAvoid": ["A"]
                   }},
                   {"cost": [
@@ -215,7 +215,7 @@
                 "length": 12,
                 "requires": [
                   {"resetRoom":{
-                    "nodes": [1, 2, 3, 4],
+                    "nodes": [1, 4],
                     "obstaclesToAvoid": ["A"]
                   }},
                   {"or": [


### PR DESCRIPTION
So sad.