### PR TITLE
Schema improvements + prepare to define locks' `unlock` and `bypass` requirements as strats

### DIFF
--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -899,7 +899,7 @@
                       "requires": ["never"]
                     }
                   ],
-                  "Note": "This base strat represents only backtracking after entering from 7."
+                  "note": "This base strat represents only backtracking after entering from 7."
                 },
                 {
                   "name": "Spore Spawn Skip",
@@ -1183,7 +1183,7 @@
                       ]
                     }
                   ],
-                  "Note": "Morph reduces damage because the ceiling Sidehopper can't reach a morphed Samus."
+                  "note": "Morph reduces damage because the ceiling Sidehopper can't reach a morphed Samus."
                 },
                 {
                   "name": "Good Weapon Sidehopper Kill",
@@ -1264,11 +1264,13 @@
                   "notable": true,
                   "requires": [
                      "canQuickCrumbleEscape",
-                     "HiJump",
-                     {"obstacle":{
+                     "HiJump"
+                  ],
+                  "obstacles": [
+                    {
                       "id": "A",
                       "requires": ["never"]
-                    }}
+                    }
                   ],
                   "note": [
                     "This involves doing a quick-drop through the Crumble block, grabbing the item, and jumping back up before the crumble block reappears.",

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -3994,7 +3994,7 @@
                   "notable": false,
                   "requires": [
                     "canNavigateHeatRooms",
-                    {"roomReset":{
+                    {"resetRoom":{
                       "nodes": [2],
                       "obstaclesToAvoid": ["F"]
                     }},
@@ -4134,7 +4134,7 @@
                   "notable": false,
                   "requires": [
                     "heatProof",
-                    {"roomReset":{
+                    {"resetRoom":{
                       "nodes": [1],
                       "obstaclesToAvoid": ["E"]
                     }}
@@ -4200,10 +4200,6 @@
                   "notable": false,
                   "requires": [
                     "canNavigateHeatRooms",
-                    {"obstacle":{
-                      "id": "F",
-                      "requires": ["never"]
-                    }},
                     {"canShineCharge": {
                       "usedTiles": 22,
                       "shinesparkFrames": 0,
@@ -4219,9 +4215,16 @@
                     {
                       "id": "E",
                       "requires": null
+                    },
+                    {
+                      "id": "F",
+                      "requires": ["never"]
                     }
                   ],
-                  "note": "If the Dessgeegas to the far right are killed, a short charge can get through."
+                  "note": [
+                    "If the Dessgeegas to the far right are killed, a short charge can get through.",
+                    "To avoid redundancy, they must be killed by travelling between 7 and 6."
+                  ]
                 },
                 {
                   "name": "Tank the Damage",

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -336,7 +336,6 @@
           "nodeType": "door",
           "nodeSubType": "grey",
           "nodeAddress": "0x0019882",
-          "unlock": [ "DefeatGoldenTorizo" ],
           "sparking": {
             "runways": [
               {
@@ -1021,7 +1020,7 @@
                       ]
                     }
                   ],
-                  "Note": "Use a Springwall to get up to the bomb blocks, to break them with a morph bomb."
+                  "note": "Use a Springwall to get up to the bomb blocks, to break them with a morph bomb."
                 },
                 {
                   "name": "Screw Attack Room Transition Speedjump (Morph Bombs)",

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -448,7 +448,7 @@
                     "canSuitlessMaridia",
                     "canStationarySpinJump"  
                   ],
-                  "Note": "A stationary spinjump can put Samus into a situation where she can slowly infinite walljump to freedom."
+                  "note": "A stationary spinjump can put Samus into a situation where she can slowly infinite walljump to freedom."
                 }
               ]
             },

--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -1615,7 +1615,7 @@
               "unlock": [ "canOpenZebetites" ]
             }
           ],
-          "yield": "killedZebetites2"
+          "yields": ["killedZebetites2"]
         },
         {
           "id": 6,
@@ -1628,7 +1628,7 @@
               "unlock": [ "canOpenZebetites" ]
             }
           ],
-          "yield": "killedZebetites3"
+          "yields": ["killedZebetites3"]
         },
         {
           "id": 7,
@@ -1641,7 +1641,7 @@
               "unlock": [ "canOpenZebetites" ]
             }
           ],
-          "yield": "killedZebetites4"
+          "yields": ["killedZebetites4"]
         },
         {
           "id": 8,
@@ -1654,7 +1654,7 @@
               "unlock": [ "canOpenZebetites" ]
             }
           ],
-          "yield": "killedZebetites1"
+          "yields": ["killedZebetites1"]
         }
       ],
       "enemies": [

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -3,6 +3,13 @@
   "id": "https://raw.githubusercontent.com/miketrethewey/sm-json-data/master/schema/m3-region.schema.json",
 
   "definitions": {
+    "note": {
+      "type": ["string", "array"],
+      "title": "Note field",
+      "description": "Additional details or explanations, intended for human readers.",
+      "default": "",
+      "pattern": "^(.*)$"
+    },
     "logicalRequirements": {
       "type": [
         "array",
@@ -20,6 +27,7 @@
         "description": "Elements are assumed to be ANDed together, except when inside an OR object.",
         "minProperties": 1,
         "maxProperties": 1,
+        "additionalProperties": false,
         "properties": {
           "and": {
             "$ref" : "#definitions/logicalRequirements",
@@ -40,6 +48,7 @@
               "type",
               "count"
             ],
+            "additionalProperties": false,
             "properties": {
               "type": {
                 "$id": "#/definitions/logicalRequirement/items/properties/ammo/properties/type",
@@ -67,6 +76,7 @@
             "title": "Enemy Kill",
             "description": "Describes the need to be able to kill a set of enemies. By default, allows all non-situational weapons (provided they can damage the enemies)",
             "required": ["enemies"],
+            "additionalProperties": false,
             "properties": {
               "enemies": {
                 "$id": "#/definitions/logicalRequirement/items/properties/enemyKill/properties/enemies",
@@ -136,6 +146,7 @@
               "type",
               "hits"
             ],
+            "additionalProperties": false,
             "properties": {
               "enemy": {
                 "$id": "#/definitions/logicalRequirement/items/properties/enemyDamage/properties/enemy",
@@ -202,6 +213,7 @@
               "fromNode",
               "usedTiles"
             ],
+            "additionalProperties": false,
             "properties": {
               "fromNode": {
                 "$id": "#/definitions/logicalRequirement/items/properties/adjacentRunway/properties/fromNode",
@@ -227,6 +239,7 @@
               "framesRemaining",
               "shinesparkFrames"
             ],
+            "additionalProperties": false,
             "properties": {
               "fromNode": {
                 "$id": "#/definitions/logicalRequirement/items/properties/canComeInCharged/properties/fromNode",
@@ -261,6 +274,7 @@
               "openEnd",
               "shinesparkFrames"
             ],
+            "additionalProperties": false,
             "properties": {
               "usedTiles": {
                 "$id": "#/definitions/logicalRequirement/items/properties/canShineCharge/properties/usedTiles",
@@ -345,6 +359,7 @@
                 "required": ["obstaclesToAvoid"]
               }
             ],
+            "additionalProperties": false,
             "properties": {
               "nodes": {
                 "$id": "#/definitions/logicalRequirement/items/properties/resetRoom/properties/nodes",
@@ -401,6 +416,7 @@
         "notable",
         "requires"
       ],
+      "additionalProperties": false,
       "properties": {
         "name": {
           "$id": "#/definitions/strat/items/properties/name",
@@ -435,6 +451,7 @@
               "id",
               "requires"
             ],
+            "additionalProperties": false,
             "properties": {
               "id": {
                 "$id": "#/definitions/strat/properties/obstacles/items/properties/id",
@@ -446,14 +463,14 @@
                 "pattern": "^(.*)$"
               },
               "requires": {
-                "$id": "#/definitions/strat/properties/obstacles/items/properties/requires",
                 "$ref" : "#/definitions/logicalRequirements",
+                "$id": "#/definitions/strat/properties/obstacles/items/properties/requires",
                 "title": "Obstacle Requirements",
                 "description": "Equipment, tech, and flag requirements to destroy this obstacle, on top of requirements defined on the obstacle itself (does not apply if obstacle already destroyed since entering the room)."
               },
               "bypass": {
-                "$id": "#/definitions/strat/properties/obstacles/items/properties/bypass",
                 "$ref" : "#/definitions/logicalRequirements",
+                "$id": "#/definitions/strat/properties/obstacles/items/properties/bypass",
                 "title": "Obstacle Bypass Requirements",
                 "description": "Equipment, tech, and flag requirements to bypass this obstacle instead of destroying it."
               },
@@ -466,16 +483,15 @@
                   "type": "string",
                   "pattern": "^(.*)$"
                 }
+              },
+              "note": {
+                "$ref" : "#definitions/note"
               }
             }
           }
         },
         "note": {
-          "$id": "#/definitions/strat/properties/note",
-          "type": ["string", "array"],
-          "title": "Note field",
-          "default": "",
-          "pattern": "^(.*)$"
+          "$ref" : "#definitions/note"
         }
       }
     }
@@ -484,7 +500,13 @@
 
   "type": "object",
   "title": "Super Metroid Room Schema",
+  "additionalProperties": false,
   "properties": {
+    "$schema": {
+      "type": "string",
+      "title": "JSON Schema Path",
+      "description": "A path to the definition of this file's JSON schema."
+    },
     "rooms": {
       "type": "array",
       "items": {
@@ -500,6 +522,7 @@
           "nodes",
           "links"
         ],
+        "additionalProperties": false,
         "properties": {
           "id": {
             "$id": "#/items/properties/id",
@@ -543,10 +566,14 @@
             "pattern": "^(.*)$"
           },
           "note": {
-            "$id": "#/items/properties/note",
-            "type": ["string", "array"],
-            "title": "Note field",
-            "default": "",
+            "$ref" : "#definitions/note"
+          },
+          "roomAddress": {
+            "$id": "#/items/properties/roomAddress",
+            "type": "string",
+            "title": "Room Address",
+            "description": "Memory address of this room.",
+            "examples": ["0x79E9F", "0x79F11"],
             "pattern": "^(.*)$"
           },
           "nodes": {
@@ -564,6 +591,7 @@
                 "nodeSubType",
                 "locks"
               ],
+              "additionalProperties": false,
               "properties": {
                 "id": {
                   "$id": "#/items/properties/nodes/items/properties/id",
@@ -659,29 +687,19 @@
                   "$id": "#/items/properties/nodes/items/properties/nodeAddress",
                   "type": "string",
                   "title": "Memory Address",
-                  "description": "Memory address of this location"
+                  "description": "Memory address of this location",
+                  "examples": ["0x0019852", "0x001985e"]
                 },
-                "requires": {
-                  "$id": "#/items/properties/nodes/items/properties/requires",
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "title": "Node Requirements",
-                  "description": "Equipment, tech, and flag requirements to reach this node within Room",
-                  "items": {
-                    "$id": "#/items/properties/nodes/items/properties/requires/items",
-                    "type": [
-                      "object",
-                      "string"
-                    ],
-                    "title": "Elements are assumed to be ANDed together, unless this array has a key of 'or'"
-                  }
+                "interactionRequires": {
+                  "$ref" : "#definitions/logicalRequirements",
+                  "title": "Interaction Requirements",
+                  "description": "Equipment, tech, and flag requirements to interact with this node once it has been reached. This is separate from one-time unlock requirements."
                 },
                 "sparking": {
                   "$id": "#/items/properties/nodes/items/properties/sparking",
                   "type": "object",
                   "title": "Shinespark capabilities of this Room",
+                  "additionalProperties": false,
                   "properties": {
                     "runways": {
                       "$id": "#/items/properties/nodes/items/properties/sparking/properties/runways",
@@ -691,6 +709,7 @@
                         "$id": "#/items/properties/nodes/items/properties/sparking/properties/runways/items",
                         "type": "object",
                         "title": "Runway Object",
+                        "additionalProperties": false,
                         "properties": {
                           "length": {
                             "$id": "#/items/properties/nodes/items/properties/sparking/properties/runways/items/properties/length",
@@ -747,12 +766,7 @@
                             "default": 1
                           },
                           "note": {
-                            "$id": "#/items/properties/nodes/items/properties/sparking/properties/runways/items/properties/note",
-                            "type": ["string", "array"],
-                            "title": "Runway Note field",
-                            "default": "",
-                            "examples": [ "This is a comment about a runway" ],
-                            "pattern": "^(.*)$"
+                            "$ref" : "#definitions/note"
                           }
                         }
                       }
@@ -770,6 +784,7 @@
                           "usedTiles",
                           "openEnd"
                         ],
+                        "additionalProperties": false,
                         "properties": {
                           "usedTiles": {
                             "$id": "#/items/properties/nodes/items/properties/sparking/properties/canLeaveCharged/properties/usedTiles",
@@ -793,7 +808,7 @@
                             "$id": "#/items/properties/nodes/items/properties/sparking/properties/canLeaveCharged/properties/initiateAt",
                             "type": "integer",
                             "title": "Node to initiate at",
-                            "description": "The ID of the node where Samus must be to execute this canLeaveCharged"
+                            "description": "The ID of the node where Samus must be to begin the execution of this canLeaveCharged"
                           },
                           "requires": {
                             "$id": "#/items/properties/nodes/items/properties/sparking/properties/canLeaveCharged/properties/requires",
@@ -809,9 +824,50 @@
                             "type": "integer",
                             "title": "Number of Open Ends",
                             "description": "The number of open ends (between 0 and 2) that are present at the edges of the used tiles. Those add a little additional room."
+                          },
+                          "gentleUpTiles": {
+                            "$id": "#/items/properties/nodes/items/properties/sparking/properties/canLeaveCharged/properties/gentleUpTiles",
+                            "type": "integer",
+                            "minimum": 0,
+                            "title": "Gentle Up Tiles",
+                            "description": "The number of tiles (among the used tiles) that slope gently upward (going up by half a tile)."
+                          },
+                          "gentleDownTiles": {
+                            "$id": "#/items/properties/nodes/items/properties/sparking/properties/canLeaveCharged/properties/gentleDownTiles",
+                            "type": "integer",
+                            "minimum": 0,
+                            "title": "Gentle Down Tiles",
+                            "description": "The number of tiles (among the used tiles) that slope gently downward (going down by half a tile)."
+                          },
+                          "steepUpTiles": {
+                            "$id": "#/items/properties/nodes/items/properties/sparking/properties/canLeaveCharged/properties/steepUpTiles",
+                            "type": "integer",
+                            "minimum": 0,
+                            "title": "Steep Up Tiles",
+                            "description": "The number of tiles (among the used tiles) that slope steeply upward (going up by a tile)."
+                          },
+                          "steepDownTiles": {
+                            "$id": "#/items/properties/nodes/items/properties/sparking/properties/canLeaveCharged/properties/steepDownTiles",
+                            "type": "integer",
+                            "minimum": 0,
+                            "title": "Steep Down Tiles",
+                            "description": "The number of tiles (among the used tiles) that slope steeply downward (going down by a tile)."
+                          },
+                          "startingDownTiles": {
+                            "$id": "#/items/properties/nodes/items/properties/sparking/properties/canLeaveCharged/properties/startingDownTiles",
+                            "type": "integer",
+                            "minimum": 0,
+                            "title": "Starting Down Tiles",
+                            "description": "The number of tiles (among the used tiles) that slope downwards at the start of a run, preventing the execution of a stutter."
+                          },
+                          "note": {
+                            "$ref" : "#definitions/note"
                           }
                         }
                       }
+                    },
+                    "note": {
+                      "$ref" : "#definitions/note"
                     }
                   }
                 },
@@ -836,7 +892,16 @@
                     "type": "object",
                     "title": "Lock Object",
                     "description": "Contains corresponding lock and unlock conditions for a node. If lock condition is missing, the lock is initially active.",
-                    "required": [ "lockType", "unlock" ],
+                    "required": [ "lockType" ],
+                    "oneOf": [
+                      {
+                        "required": ["unlock"]
+                      },
+                      {
+                        "required": ["unlockStrats"]
+                      }
+                    ],
+                    "additionalProperties": false,
                     "properties": {
                       "lockType": {
                         "$id": "#/items/properties/nodes/items/properties/locks/items/properties/lockType",
@@ -856,38 +921,43 @@
                         "pattern": "^(.*)$"
                       },
                       "lock": {
+                        "$ref" : "#definitions/logicalRequirements",
                         "$id": "#/items/properties/nodes/items/properties/locks/items/properties/lock",
-                        "type": [
-                          "array",
-                          "null"
-                        ],
                         "title": "Lock Requirements",
                         "description": "Equipment, tech, and flag requirements for this node to be locked"
                       },
+                      "unlockStrats": {
+                        "$id": "#/items/properties/nodes/items/properties/locks/items/properties/unlockStrats",
+                        "type": "array",
+                        "title": "Unlock Strats",
+                        "description": "An array of strats that can be used to unlock the lock.",
+                        "items": {
+                          "$ref" : "#/definitions/strat",
+                          "$id": "#/items/properties/nodes/items/properties/locks/items/properties/unlockStrats/items"
+                        }
+                      },
                       "unlock": {
                         "$id": "#/items/properties/nodes/items/properties/locks/items/properties/unlock",
-                        "type": [
-                          "array",
-                          "null"
-                        ],
                         "title": "Unlock Requirements",
                         "description": "Equipment, tech, and flag requirements to deactivate the associated lock"
                       },
+                      "bypassStrats": {
+                        "$id": "#/items/properties/nodes/items/properties/locks/items/properties/bypassStrats",
+                        "type": "array",
+                        "title": "Bypass Strats",
+                        "description": "An array of strats that can be used to bypass the lock, going through it without unlocking it.",
+                        "items": {
+                          "$ref" : "#/definitions/strat",
+                          "$id": "#/items/properties/nodes/items/properties/locks/items/properties/bypassStrats/items"
+                        }
+                      },
                       "bypass": {
                         "$id": "#/items/properties/nodes/items/properties/locks/items/properties/bypass",
-                        "type": [
-                          "array",
-                          "null"
-                        ],
                         "title": "Bypass Requirements",
                         "description": "Equipment, tech, and flag requirements to bypass the associated lock without deactivating it. Must be done each time the node is interacted with while the lock is enabled."
                       },
                       "note": {
-                        "$id": "#/items/properties/nodes/items/properties/locks/items/properties/note",
-                        "type": ["string", "array"],
-                        "title": "Lock Note field",
-                        "default": "",
-                        "pattern": "^(.*)$"
+                        "$ref" : "#definitions/note"
                       }
                     }
                   }
@@ -931,14 +1001,7 @@
                   "title": "This Node grants an ability/flag"
                 },
                 "note": {
-                  "$id": "#/items/properties/nodes/items/properties/note",
-                  "type": ["string", "array"],
-                  "title": "Node Note field",
-                  "default": "",
-                  "examples": [
-                    "Door Object"
-                  ],
-                  "pattern": "^(.*)$"
+                  "$ref" : "#definitions/note"
                 }
               }
             }
@@ -955,6 +1018,7 @@
                 "from",
                 "to"
               ],
+              "additionalProperties": false,
               "properties": {
                 "from": {
                   "$id": "#/items/properties/links/items/properties/from",
@@ -980,6 +1044,7 @@
                       "id",
                       "strats"
                     ],
+                    "additionalProperties": false,
                     "properties": {
                       "id": {
                         "$id": "#/items/properties/links/items/properties/to/items/properties/id",
@@ -996,8 +1061,8 @@
                         "title": "Link Strats",
                         "description": "An array of strats that can be used to cross the link.",
                         "items": {
-                          "$id": "#/items/properties/links/items/properties/to/items/properties/strats/items",
-                          "$ref" : "#/definitions/strat"
+                          "$ref" : "#/definitions/strat",
+                          "$id": "#/items/properties/links/items/properties/to/items/properties/strats/items"
                         }
                       },
                       "yields": {
@@ -1006,11 +1071,7 @@
                         "title": "This Link grants an ability/flag"
                       },
                       "note": {
-                        "$id": "#/items/properties/links/items/properties/to/items/properties/note",
-                        "type": ["string", "array"],
-                        "title": "Note field",
-                        "default": "",
-                        "pattern": "^(.*)$"
+                        "$ref" : "#definitions/note"
                       }
                     }
                   }
@@ -1031,6 +1092,7 @@
                 "name",
                 "obstacleType"
               ],
+              "additionalProperties": false,
               "properties": {
                 "id": {
                   "$id": "#/items/properties/obstacles/items/properties/id",
@@ -1066,28 +1128,12 @@
                   "pattern": "^(.*)$"
                 },
                 "note": {
-                  "$id": "#/items/properties/obstacles/items/properties/note",
-                  "type": ["string", "array"],
-                  "title": "Note field",
-                  "default": "",
-                  "pattern": "^(.*)$"
+                  "$ref" : "#definitions/note"
                 },
                 "requires": {
-                  "$id": "#/items/properties/obstacles/items/properties/requires",
-                  "type": [
-                    "array",
-                    "null"
-                  ],
-                  "title": "Absolute Obstacle Requireemts",
-                  "description": "Equipment, tech, and flag requirements that are always needed to break this obstacle. Those are applied on top of any requirements specified on an `obstacle` logical element that references this obstacle.",
-                  "items": {
-                    "$id": "#/items/properties/obstacles/items/properties/requires/items",
-                    "type": [
-                      "object",
-                      "string"
-                    ],
-                    "title": "Elements are assumed to be ANDed together, unless this array has a key of 'or'"
-                  }
+                  "$ref" : "#definitions/logicalRequirements",
+                  "title": "Absolute Obstacle Requirements",
+                  "description": "Equipment, tech, and flag requirements that are always needed to break this obstacle. Those are applied on top of any requirements specified on an `obstacle` logical element that references this obstacle."
                 }
               }
             }
@@ -1112,6 +1158,7 @@
                   [ "betweenNodes" ]
                 }
               ],
+              "additionalProperties": false,
               "properties": {
                 "name": {
                   "$id": "#/items/properties/enemies/items/properties/name",
@@ -1160,36 +1207,22 @@
                   ]
                 },
                 "spawn": {
-                  "$id": "#/items/properties/enemies/items/properties/spawn",
-                  "type": [
-                    "array",
-                    "null"
-                  ],
+                  "$ref" : "#definitions/logicalRequirements",
                   "title": "Spawn Requirements",
                   "description": "Equipment, tech, and flag requirements for this enemy to spawn. If null, enemy can spawn from game start."
                 },
                 "stopSpawn": {
-                  "$id": "#/items/properties/enemies/items/properties/stopSpawn",
-                  "type": [
-                    "array",
-                    "null"
-                  ],
+                  "$ref" : "#definitions/logicalRequirements",
                   "title": "Stop Spawning Requirements",
                   "description": "Equipment, tech, and flag requirements for this enemy to stop spawning. If null, enemy can always spawn once its spawn requirements have been met."
                 },
                 "dropRequires": {
-                  "$id": "#/items/properties/enemies/items/properties/dropRequires",
-                  "type": "array",
+                  "$ref" : "#definitions/logicalRequirements",
                   "title": "Drop Requires",
-                  "description": "Equipment, tech, and flag requirements that are needed to obtain the drop from this enemy without taking any damage. These go on top of what's needed to reach and kill the enemy.",
-                  "default": []
+                  "description": "Equipment, tech, and flag requirements that are needed to obtain the drop from this enemy without taking any damage. These go on top of what's needed to reach and kill the enemy."
                 },
                 "note": {
-                  "$id": "#/items/properties/enemies/items/properties/note",
-                  "type": ["string", "array"],
-                  "title": "Note field",
-                  "default": "",
-                  "pattern": "^(.*)$"
+                  "$ref" : "#definitions/note"
                 }
               }
             }


### PR DESCRIPTION
Also:
- `note` definition has been centralized
- the schema now rejects properties it doesn't know
- more logical requirement properties use the `logicalRequirements` definition
