### PR TITLE
Remove farming utility 

### DIFF
--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -686,7 +686,6 @@
           "nodeType": "door",
           "nodeSubType": "blue",
           "nodeAddress": "0x0018d4e",
-          "utility": [ "farming" ],
           "sparking": {
             "runways": [
               {

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -3005,7 +3005,6 @@
           "nodeType": "door",
           "nodeSubType": "eye",
           "nodeAddress": "0x00198ca",
-          "utility": [ "farming" ],
           "sparking": {
             "runways": [
               {
@@ -3034,7 +3033,6 @@
           "nodeType": "door",
           "nodeSubType": "blue",
           "nodeAddress": "0x00198d6",
-          "utility": [ "farming" ],
           "sparking": {
             "runways": [
               {

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -421,8 +421,7 @@
           "name": "Main Junction",
           "nodeType": "junction",
           "nodeSubType": "junction",
-          "locks": null,
-          "utility": [ "farming" ]
+          "locks": null
         }
       ],
       "enemies": [

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -868,8 +868,7 @@
           "name": "Central Bottom Junction",
           "nodeType": "junction",
           "nodeSubType": "junction",
-          "locks": null,
-          "utility": [ "farming" ]
+          "locks": null
         }
       ],
       "obstacles": [
@@ -1197,7 +1196,6 @@
           "nodeType": "door",
           "nodeSubType": "blue",
           "nodeAddress": "0x001979e",
-          "utility": [ "farming" ],
           "sparking": {
             "runways": [
               {
@@ -2296,7 +2294,6 @@
           "nodeType": "door",
           "nodeSubType": "blue",
           "nodeAddress": "0x00197b6",
-          "utility": [ "farming" ],
           "sparking": {
             "runways": [
               {

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -34,7 +34,6 @@ The `utility` property is an array of utility functions available to Samus at a 
 * _energy:_ Note that this excludes reserve tanks
 * _reserve:_ Note that this excludes regular energy. If a node can refill reserves as well as energy, it will have both `energy` and `reserve`
 * _map_
-* _farming:_ Represents the presence monster spawners. This may be removed later and replaced by actual monster spawners.
 
 #### interactionRequires
 [Logical requirements](../logicalRequirements.md) that must be fulfilled each time Samus interacts with the node.

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -1017,14 +1017,20 @@
                     "array",
                     "null"
                   ],
-                  "title": "Helping stations at this Node",
+                  "title": "Utilities",
+                  "description": "Helping stations at this Node (such as save, refills, or map station)",
                   "items": {
                     "$id": "#/items/properties/nodes/items/properties/utility/items",
-                    "type": [
-                      "object",
-                      "string"
-                    ],
-                    "title": "Elements are assumed to be ANDed together, unless this array has a key of 'or'"
+                    "type": "string",
+                    "enum": [
+                      "save",
+                      "missile",
+                      "super",
+                      "powerbomb",
+                      "energy",
+                      "reserve",
+                      "map"
+                    ]
                   }
                 },
                 "view": {


### PR DESCRIPTION
Farming should be inferred from the presence of respawning enemies