### PR TITLE
Add a `previousNode` logical element

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -293,6 +293,14 @@ __Additional considerations__
 ### Room Pathing Objects
 This section contains logical elements that are affected by Samus' pathing within a room.
 
+#### previousNode object
+A `previousNode` object represents the need for Samus to have arrived to the node directly from a given node. This usually has to do with quick-respawn blocks not being back yet.
+
+__Example:__
+```json
+{"previousNode": 1}
+```
+
 #### previousStratProperty object
 A `previousStratProperty` object represents the need for Samus to have arrived to the node via a strat that has a given stratProperty. This usually has to do with quick-respawn blocks not being back yet, or spinjump conservation. In those cases, arriving via other strats doesn't allow reproducing those conditions.
 

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -970,44 +970,40 @@
                 {
                   "name": "Early Supers Quick Crumble Escape (Dual Quick Crumble)",
                   "notable": true,
-                  "requires": ["canQuickCrumbleEscape"],
-                  "note": [
-                    "This requires coming to this node from node 1, but it's not explicitly stated since that's the only meaningful way in.",
-                    "This one involves doing a second quick crumble escape on the way out as a means to avoid doing a crumble jump."
-                  ]
+                  "requires": [
+                    "canQuickCrumbleEscape",
+                    {"previousNode": 1}
+                  ],
+                  "note": "This one involves doing a second quick crumble escape on the way out as a means to avoid doing a crumble jump."
                 },
                 {
                   "name": "Early Supers Quick Crumble Escape (Space)",
                   "notable": true,
                   "requires": [
                     "canQuickCrumbleEscape",
-                    "SpaceJump"
+                    "SpaceJump",
+                    {"previousNode": 1}
                   ],
-                  "note": [
-                    "This requires coming to this node from node 1, but it's not explicitly stated since that's the only meaningful way in.",
-                    "Space Jump is here as an alternative to performing a crumble jump on the way out."
-                  ]
+                  "note": "Space Jump is here as an alternative to performing a crumble jump on the way out."
                 },
                 {
                   "name": "Early Supers Quick Crumble Escape (SpringBall)",
                   "notable": true,
                   "requires": [
                     "canQuickCrumbleEscape",
-                    "canUseSpringBall"
+                    "canUseSpringBall",
+                    {"previousNode": 1}
                   ],
-                  "note": [
-                    "This requires coming to this node from node 1, but it's not explicitly stated since that's the only meaningful way in.",
-                    "Spring Ball is here as an alternative to performing a crumble jump on the way out."
-                  ]
+                  "note": "Spring Ball is here as an alternative to performing a crumble jump on the way out."
                 },
                 {
                   "name": "Early Supers Quick Crumble Escape (Crumble Jump)",
                   "notable": true,
                   "requires": [
                     "canQuickCrumbleEscape",
-                    "canCrumbleJump"
-                  ],
-                  "note": "This requires coming to this node from node 1, but it's not explicitly stated since that's the only meaningful way in."
+                    "canCrumbleJump",
+                    {"previousNode": 1}
+                  ]
                 }
               ]
             },

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -1386,7 +1386,8 @@
                   "notable": true,
                   "requires": [
                      "canQuickCrumbleEscape",
-                     "HiJump"
+                     "HiJump",
+                     {"previousNode": 4}
                   ],
                   "obstacles": [
                     {

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -386,6 +386,12 @@
               }
             }
           },
+          "previousNode": {
+            "$id": "#/definitions/logicalRequirement/items/properties/previousNode",
+            "type": "integer",
+            "title": "Previous Node",
+            "description": "Fulfilled if the player arrived to the current node directly from the node with the provided in-room ID."
+          },
           "previousStratProperty": {
             "$id": "#/definitions/logicalRequirement/items/properties/previousStratProperty",
             "type": "string",


### PR DESCRIPTION
This element indicates that a strat can only be executed if coming directly from a specific node. Fixes #321.