### PR TITLE
Add a property to canLeaveCharged, to indicate the need to previously open the door

### DIFF
--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -762,6 +762,7 @@
               "usedTiles": 33,
               "framesRemaining": 60,
               "initiateAt": 1,
+              "mustOpenDoorFirst": false,
               "openEnd": 2,
               "strats": [
                 {

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -550,6 +550,7 @@
           "canLeaveCharged": [
             {
               "initiateAt": 1,
+              "mustOpenDoorFirst": false,
               "usedTiles": 25,
               "framesRemaining": 0,
               "shinesparkFrames": 20,
@@ -592,6 +593,7 @@
           "canLeaveCharged": [
             {
               "initiateAt": 1,
+              "mustOpenDoorFirst": false,
               "usedTiles": 31,
               "framesRemaining": 0,
               "shinesparkFrames": 15,
@@ -619,7 +621,11 @@
                   ]
                 }
               ],
-              "openEnd": 1
+              "openEnd": 1,
+              "note": [
+                "MustOpenDoorFirst set to flase because the requirements already cover getting to the door and back.",
+                "Besides, it's also possible to shoot the door before sparking out, if trickier."
+              ]
             }
           ]
         },

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -31,14 +31,13 @@
           "canLeaveCharged": [
             {
               "initiateAt": 3,
+              "mustOpenDoorFirst": true,
               "usedTiles": 30,
               "framesRemaining": 0,
-              "shinesparkFrames": 200,
+              "shinesparkFrames": 125,
               "openEnd": 1,
               "note": [
-                "The shinespark really only lasts 125 frames, but this also requires prior access to node 1 (or a wraparound shot) to open the door.",
-                "The 75 additional frames are to get back up from node 5 to node 3.",
-                "The 125 frames of the spark are charged only once on the assumption Samus can refill at the ship."
+                "FIXME needs another canLeaveCharged with mustOpenDoorFirst at false, with the wraparound shot"
               ],
               "strats": [
                 {
@@ -50,13 +49,14 @@
             },
             {
               "initiateAt": 4,
+              "mustOpenDoorFirst": true,
               "usedTiles": 19,
               "framesRemaining": 0,
               "shinesparkFrames": 125,
               "openEnd": 2,
               "note": [
-                "In reality, prior access to node 1 (or a wraparound shot at node 3) is needed to open the door.",
-                "The shinespark is kept at 125 frames on the assumption Samus can refill at the ship then get back to node 4."
+                "It's actually possible to use this without going to 1 to open the door first, with a wraparound shot at 3.",
+                "However, it makes more sense to represent that by initiating at 3."
               ],
               "strats": [
                 {

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -250,6 +250,7 @@
               "shinesparkFrames": 30,
               "openEnd": 2,
               "initiateAt": 1,
+              "mustOpenDoorFirst": false,
               "strats": [
                 {
                   "name": "Bug Room Charge Out Right (Gravityless)",
@@ -269,7 +270,8 @@
                   ],
                   "requires": ["Gravity", "Morph"]
                 }
-              ]
+              ],
+              "note": "mustOpenDoorFirst is false because the door can be shot before initiating the spark."
             }
           ]
         }

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -1544,6 +1544,7 @@
               "framesRemaining": 30,
               "openEnd": 1,
               "initiateAt": 10,
+              "mustOpenDoorFirst": false,
               "strats": [
                 {
                   "name": "Mt. Everest Bottom Right Charged Drop",
@@ -1585,6 +1586,7 @@
           "canLeaveCharged": [
             {
               "initiateAt": 9,
+              "mustOpenDoorFirst": false,
               "usedTiles": 33,
               "framesRemaining": 0,
               "shinesparkFrames": 64,
@@ -1598,7 +1600,8 @@
               ],
               "note": [
                 "Involves dropping down to 2 to charge and then sparking out.",
-                "Initiates at 9 rather than 2 because dropping to 2 is expected to be free, and because you need to be at 9 to open the door first."
+                "Initiates at 9 rather than 2 because dropping to 2 is expected to be free, and because you need to be at 9 to open the door first.",
+                "MustOpenDoorFirst is still set to false because the door can be opened from 9, no need to actually go to 5."
               ]
             }
           ]

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -811,6 +811,7 @@
               "usedTiles": 33,
               "framesRemaining": 100,
               "initiateAt": 4,
+              "mustOpenDoorFirst": false,
               "openEnd": 2,
               "strats": [
                 {

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -107,7 +107,12 @@ Represents the possibility for Samus to charge a shinespark without using the do
 * _strats:_ An array of [strats](../strats.md), each of which may be executed in order to leave charged. Those all have implicit charging and shinesparking requirements.
 * _initiateAt:_ The node at which the charging operation must start. Samus must have access to this node to be able to leave the room charged. Additional considerations for this property:
   * If this property is missing, it is assumed to be the node by which Samus will leave the room
-  * If this property specifies a different node, the `canLeaveCharged` object's `requires` property must also account for all requirements for reaching the door from that node. Regular navigation is not intended to be used for that purpose.
+  * If this property specifies a different node, execution of the `canLeaveCharged` takes the player out of the room through the relevant door, without navigating any links. All requirements for leaving in this manner must be included in the `canLeaveCharged` object's `requires` property.
+  * See the definition of `mustOpenDoorFirst` as well. If it is `true`, it must be respected as well.
+* _mustOpenDoorFirst:_ Indicates whether Samus must have previously visited this node in order to open the door, in order to be able to execute this `canLeavedCharged`. This must have been done since the last time the room was entered. Additional considerations for this property:
+  * If this property is missing, it is assumed to be `false`.
+  * This is required if `initiateAt` is set.
+  * If `initiateAt` is not set, this property should be ommitted since Samus is already at the correct node and able to open the door.
 
 __Additional considerations__
 

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -467,6 +467,9 @@
                       "openEnd",
                       "strats"
                     ],
+                    "dependencies": {
+                      "initiateAt": { "required": ["mustOpenDoorFirst"] }
+                    },
                     "additionalProperties": false,
                     "properties": {
                       "usedTiles": {
@@ -494,6 +497,12 @@
                         "type": "integer",
                         "title": "Node to initiate at",
                         "description": "The ID of the node where Samus must be to begin the execution of this canLeaveCharged"
+                      },
+                      "mustOpenDoorFirst": {
+                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/canLeaveCharged/properties/mustOpenDoorFirst",
+                        "type": "boolean",
+                        "title": "Must OpenDoor First",
+                        "description": "Indicates whether this canLeaveCharged requires having previously visited the node's door to open it. Relevant (and required) only if initiateAt is set. If missing, assumed to be false."
                       },
                       "strats": {
                         "$id": "#/properties/rooms/items/properties/nodes/items/properties/canLeaveCharged/properties/strats",


### PR DESCRIPTION
This is sometimes needed when shinesparking out of a door.