### PR TITLE
Fix a link in Spore Spawn Super

### DIFF
--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -1987,7 +1987,7 @@
           "from": 1,
           "to": [
             {
-              "id": 2,
+              "id": 3,
               "strats": [
                 {
                   "name": "Base",


### PR DESCRIPTION
The chute from the top goes to the Supers, not to the bottom door.