### PR TITLE
Add a `lavaPhysicsFrames` logical element for lava gravJumps

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -193,6 +193,14 @@ __Additional considerations__
 
 Much like the other logical elements that represent environmental frame damage, the lava frame counts listed in this project might not be stricly "perfect" play, but they are very much unforgiving. Their most significant value is to provide relative lengths to different lava runs. It's recommended to apply a leniency factor to those, possibly as an option that can vary by difficulty.
 
+#### lavaPhysicsFrames
+A `lavaPhysicsFrames` object works exactly like a `lavaFrames` object, except that Samus needs to be working with lava physics during that period of time. This means Gravity Suit will be manually turned off for this duration, even if it's available.
+
+__Example:__
+```json
+{"lavaPhysicsFrames": 70}
+```
+
 #### spikeHits object
 A `spikeHits` object represents the need for Samus to intentionally take a number of hits from spikes. This is meant to be converted to a flat health value based on item loadout. The vanilla damage per spike hit is 60 with Power Suit, 30 with Varia, and 15 with Gravity Suit.
 

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -4740,7 +4740,7 @@
                     "canLavaGravityJump",
                     "HiJump",
                     {"heatFrames": 600},
-                    {"lavaFrames": 100}
+                    {"lavaPhysicsFrames": 100}
                   ]
                 },
                 {
@@ -4753,7 +4753,7 @@
                     "canSuitlessLavaDive",
                     "canSuitlessLavaWalljump",
                     {"heatFrames": 750},
-                    {"lavaFrames": 250}
+                    {"lavaPhysicsFrames": 250}
                   ]
                 },
                 {

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -226,6 +226,13 @@
             "title": "Lava Frames",
             "description": "Fulfilled by spending an amount of energy that corresponds to spending a number of frames in lava."
           },
+          "lavaPhysicsFrames": {
+            "$id": "#/definitions/logicalRequirement/items/properties/lavaPhysicsFrames",
+            "type": "integer",
+            "minimum": 1,
+            "title": "Lava Physics Frames",
+            "description": "Fulfilled by spending an amount of energy that corresponds to spending a number of frames in lava, with Gravity Suit turned off if available."
+          },
           "energyAtMost": {
             "$id": "#/definitions/logicalRequirement/items/properties/energyAtMost",
             "type": "integer",


### PR DESCRIPTION
This will indicate that Gravity Suit's damage reduction shouldn't be applied when it's turned off.