### PR TITLE
Add to East Crateria: reqs, strats, 3 new tech

### DIFF
--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -1441,6 +1441,19 @@
                       "SpaceJump"
                     ]}
                   ]
+                },
+                {
+                  "name": "Shinespark",
+                  "notable": false,
+                  "requires": [
+                    {"canShineCharge": {
+                      "usedTiles": 22,
+                      "steepUpTiles": 3,
+                      "steepDownTiles": 3,
+                      "shinesparkFrames": 30,
+                      "openEnd": 0
+                    }}
+                  ]
                 }
               ]
             }

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -1417,7 +1417,7 @@
                     "canSuitlessMaridia",
                     "canSpringBallJumpMidAir"
                   ]
-                },
+                }
               ]
             },
             {

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -104,7 +104,8 @@
                   "name": "Gravity",
                   "notable": false,
                   "requires": [
-                    "Gravity"
+                    "Gravity",
+                    "canWalljump"
                   ]
                 },
                 {
@@ -196,6 +197,11 @@
                   "name": "Moat Horizontal Bomb Jump",
                   "notable": true,
                   "requires": ["canDoubleHBJ"]
+                },
+                {
+                  "name": "Double Spring Ball Jump",
+                  "notable": true,
+                  "requires": ["canDoubleSpringBallJumpMidAir"]
                 }
               ],
               "note": "Because Moving from 1 to 3 is free, all strats are represented here even if they start at 1."
@@ -788,9 +794,33 @@
               "id": 4,
               "strats": [
                 {
-                  "name": "Base",
+                  "name": "Wall Jump",
                   "notable": false,
-                  "requires": []
+                  "requires": ["canWalljump"]
+                },
+                {
+                  "name": "Space Jump",
+                  "notable": false,
+                  "requires": ["SpaceJump"]
+                },
+                {
+                  "name": "IBJ",
+                  "notable": false,
+                  "requires": [
+                    "Gravity",
+                    "canIBJ"
+                  ]
+                },
+                {
+                  "name": "Shinespark",
+                  "notable": false,
+                  "requires": [
+                    {"canShineCharge": {
+                      "usedTiles": 33,
+                      "shinesparkFrames": 50,
+                      "openEnd": 2
+                    }}
+                  ]
                 }
               ]
             },
@@ -977,8 +1007,19 @@
                   "requires": [
                     {"or":[
                       "SpaceJump",
-                      "Grapple",
-                      "Gravity"
+                      "Grapple"
+                    ]}
+                  ]
+                },
+                {
+                  "name": "Gravity Suit",
+                  "notable": false,
+                  "requires": [
+                    "Gravity",
+                    {"or":[
+                      "canWalljump",
+                      "HiJump",
+                      "canIBJ"
                     ]}
                   ]
                 },
@@ -998,6 +1039,18 @@
                         "shinesparkFrames": 105
                       }}
                     ]}
+                  ]
+                },
+                {
+                  "name": "Gravity Suit and Shinespark",
+                  "notable": false,
+                  "requires": [
+                    "Gravity",
+                    {"canShineCharge": {
+                      "usedTiles": 33,
+                      "shinesparkFrames": 25,
+                      "openEnd": 2
+                    }}
                   ]
                 },
                 {
@@ -1329,14 +1382,42 @@
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
+                    "HiJump",
+                    "canWalljump"
+                  ]
+                },
+                {
+                  "name": "Suitless with Space Jump",
+                  "notable": false,
+                  "requires": [
+                    "canSuitlessMaridia",
+                    "SpaceJump",
                     {"or": [
                       "HiJump",
-                      "canSpringBallJumpMidAir",
-                      "canUseFrozenEnemies",
-                      "SpaceJump"
+                      "canWalljump"
                     ]}
                   ]
-                }
+                },
+                {
+                  "name": "Suitless with Ice Beam",
+                  "notable": false,
+                  "requires": [
+                    "canSuitlessMaridia",
+                    "canUseFrozenEnemies",
+                    {"or": [
+                      "HiJump",
+                      "canDownGrab"
+                    ]}
+                  ]
+                },
+                {
+                  "name": "Suitless with SpringBall Jump Mid Air",
+                  "notable": false,
+                  "requires": [
+                    "canSuitlessMaridia",
+                    "canSpringBallJumpMidAir"
+                  ]
+                },
               ]
             },
             {
@@ -1345,7 +1426,15 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["Gravity"]
+                  "requires": [
+                    "Gravity",
+                    {"or":[
+                      "canWalljump",
+                      "HiJump",
+                      "SpaceJump",
+                      "canIBJ"
+                    ]}
+                  ]
                 },
                 {
                   "name": "Base Suitless",

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -815,6 +815,7 @@
                   "name": "Shinespark",
                   "notable": false,
                   "requires": [
+                    "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "shinesparkFrames": 50,
@@ -1019,7 +1020,8 @@
                     {"or":[
                       "canWalljump",
                       "HiJump",
-                      "canIBJ"
+                      "canIBJ",
+                      "SpeedBooster"
                     ]}
                   ]
                 },
@@ -1382,8 +1384,7 @@
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
-                    "HiJump",
-                    "canWalljump"
+                    "HiJump"
                   ]
                 },
                 {
@@ -1392,10 +1393,7 @@
                   "requires": [
                     "canSuitlessMaridia",
                     "SpaceJump",
-                    {"or": [
-                      "HiJump",
-                      "canWalljump"
-                    ]}
+                    "canWalljump"
                   ]
                 },
                 {
@@ -1403,11 +1401,7 @@
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
-                    "canUseFrozenEnemies",
-                    {"or": [
-                      "HiJump",
-                      "canDownGrab"
-                    ]}
+                    "canUseFrozenEnemies"
                   ]
                 },
                 {

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -1446,6 +1446,7 @@
                   "name": "Shinespark",
                   "notable": false,
                   "requires": [
+                    "Gravity",
                     {"canShineCharge": {
                       "usedTiles": 22,
                       "steepUpTiles": 3,

--- a/tech.json
+++ b/tech.json
@@ -609,6 +609,18 @@
       ]
     },
     {
+      "name": "canDoubleSpringBallJumpMidAir",
+      "requires": [
+        "Morph",
+        "SpringBall",
+        "HiJump"
+      ],
+      "note": [
+        "Using the SpringBallJumpMidAir twice during a single jump to gain even more height. This only works underwater with HiJump.",
+        "This consists of a tight variant of SpringBallJumpMidAir, then turning off spring ball, then a second SpringBallJumpMidAir all while still climbing upwards."
+      ]
+    },
+    {
       "name": "canGTCode",
       "requires": []
     },
@@ -701,6 +713,18 @@
       "name": "canBePatient",
       "requires": [],
       "note":"Executing a strat that requires waiting or doing the same thing over and over again for over 3 minutes, even with good execution"
+    },
+    {
+      "name": "canCrouchJump",
+      "requires": [],
+      "note":"The ability to crouch before jumping to reach higher ledges."
+    },
+    {
+      "name": "canDownGrab",
+      "requires": [
+        "canCrouchJump"
+      ],
+      "note":"The ability to aim down to reduce Samus' hitbox to reach higher ledges."
     }
   ]
 }


### PR DESCRIPTION
Added 3 new Tech that were needed while working on East Crateria:
- canDoubleSpringBallJumpMidAir
- canCrouchJump
- canDownGrab

Currently crouch jump and down grab are assumed to be free, but adding these as tech could make the game more accessible. I made canDownGrab require canCrouchJump, as canCrouchJump is easier and these two are typically performed together, since a down grab alone wouldn't give more height than a spin jump.

Added canDoubleSpringBallJumpMidAir strat to get out of the right side of The Moat (3 -> 2).

Expanded strats in several rooms to no longer assume canWallJump:
- The Moat (2 -> 3) - the gravity strat needs wall jump
- West Ocean (5 -> 4) - this expansion adds alternate strats (without requiring wall jump): space jump, gravity+ibj, or gravity+vertical shinespark
- West Ocean (13 -> 5) - the gravity strat needs wall jump, hi jump, ibj, or vertical shinespark
- East Ocean (3 -> 1) - the hi jump strat needs wall jump; space jump strat needs wall jump or hi jump; ice strat needs hi jump or crouch jump+down grab
- East Ocean (3 -> 2) - the gravity strat needs wall jump, hi jump, space jump, or ibj