### PR TITLE
Move up definition of h_canUsePowerBombs to avoid forward reference

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -115,6 +115,17 @@
       ]
     },
     {
+      "name": "h_canUsePowerBombs",
+      "requires": [
+        "Morph",
+        "PowerBomb",
+        {"ammo": {
+          "type": "PowerBomb",
+          "count": 1
+        }}
+      ]
+    },
+    {
       "name": "h_canOpenYellowDoors",
       "requires": [ "h_canUsePowerBombs" ]
     },
@@ -216,17 +227,6 @@
       "requires": [
         "Morph",
         "Bombs"
-      ]
-    },
-    {
-      "name": "h_canUsePowerBombs",
-      "requires": [
-        "Morph",
-        "PowerBomb",
-        {"ammo": {
-          "type": "PowerBomb",
-          "count": 1
-        }}
       ]
     },
     {


### PR DESCRIPTION
The helper h_canOpenYellowDoors references h_canUsePowerBombs which is not defined until later in the list of helpers. It will be easier to process the helpers if we can avoid forward references like this. This is the only case of a forward reference in the helpers. This pull request resolves this by moving up the definition of h_canUsePowerBombs.