### PR TITLE
Fix door pointers in Green Shaft and Maridia Missile Refill

### DIFF
--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -123,7 +123,7 @@
           "name": "Green Shaft Mid-Low Left Door (to Firefleas)",
           "nodeType": "door",
           "nodeSubType": "red",
-          "nodeAddress": "0x0018d12",
+          "nodeAddress": "0x0018cca",
           "runways": [
             {
               "name": "Base Runway - Green Shaft Mid-Low Left Door (to Firefleas)",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -2112,7 +2112,7 @@
           "name": "Maridia Missile Refill Room Door (to Halfie Climb)",
           "nodeType": "door",
           "nodeSubType": "blue",
-          "nodeAddress": "0x001a8f4",
+          "nodeAddress": "0x001a894",
           "runways": [
             {
               "name": "Base Runway - Maridia Missile Refill Room Door (to Halfie Climb)",


### PR DESCRIPTION
In Green Shaft two doors in this room were described with the same nodeAddress (a copy-paste error?). And in the Maridia Missile Refill room the nodeAddress for the (exiting) door was (incorrectly) given as the same as the door entering this room. I checked SMILE to get the correct nodeAddress for both of these.