### PR TITLE
Add morph requirement to Bowling Alley

### DIFF
--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -1587,7 +1587,8 @@
                   "notable": false,
                   "requires": [
                     "Wave",
-                    "ScrewAttack"
+                    "ScrewAttack",
+                    "Morph"
                   ],
                   "note": "The shot blocks can be broken with Wave by scrolling the screen right then coming back out of the tunnel and walking right."
                 }


### PR DESCRIPTION
Fix: The Screw/Wave strat needs Morph to be executed.