### PR TITLE
Replace boss enemyKill strats with explicit strats

### DIFF
--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -2863,11 +2863,10 @@
                   "name": "Supers",
                   "notable": false,
                   "requires": [
-                    {"enemyKill":{
-                      "enemies": [
-                        [ "Spore Spawn" ]
-                      ],
-                      "explicitWeapons": [ "Super" ]
+                    "Super",
+                    {"ammo": {
+                      "type": "Super",
+                      "count": 4
                     }}
                   ],
                   "note": [

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -956,33 +956,24 @@
               "lockType": "bossFight",
               "unlockStrats": [
                 {
-                  "name": "Regular Phantoon",
+                  "name": "Charge",
                   "notable": false,
-                  "requires": [
-                    {
-                      "enemyKill": {
-                        "enemies": [
-                          ["Phantoon"]
-                        ],
-                        "excludedWeapons": ["Super"],
-                        "farmableAmmo": ["Missile"]
-                      }
-                    }
-                  ],
-                  "note": "The strat for Charge-based weapons."
+                  "requires": ["Charge"]
+                },
+                {
+                  "name": "Missiles",
+                  "notable": false,
+                  "requires": ["Missile"],
+                  "note": "No ammo count because Missiles are farmable here."
                 },
                 {
                   "name": "Nintendo Power Phantoon",
                   "notable": false,
-                  "requires": [
-                    {"enemyKill": {
-                      "enemies": [
-                        ["Phantoon"]
-                      ],
-                      "explicitWeapons": ["Super"],
-                      "farmableAmmo": ["Super"]
-                    }}
-                  ]
+                  "requires": ["Super"],
+                  "note": [
+                    "No ammo count because Supers are farmable here.",
+                    "FIXME add tech/energy/item requirements to survive flames."
+                    ]
                 }
               ]
             }


### PR DESCRIPTION
Replace enemyKill strats for Phantoon and Spore Spawn. 

Reasons:
- enemyKill is more complicated to follow, requiring processing a lot of information in order to determine the possible strats (e.g., enemy JSON, weapons JSON, and the modifiers in the strat such as farmableAmmo, explicitWeapons, excludedWeapons).
- Because of this, it will be easier for us to use in the randomizer we are designing as we haven't fully implemented enemyKill. It may also make it easier for a player to see all of the possible strats in logic which can be used to kill the bosses.
- This more explicit structure is already used for most of the other bosses/minibosses (BT, Kraid, Crocomire, GT, Back-Side Botwoon, and the other Spore Spawn strats).