### PR TITLE
Fix the requirement for Zebes Awake in the Pit Room.

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -1870,8 +1870,15 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [ "Missile" ],
-                  "note": "Entering this room from either door with any missiles collected spawns the enemies in this and nearby rooms."
+                  "requires": [ 
+                    "Missile",
+                    "Morph"
+                  ],
+                  "note": [
+                    "Entering this room with Morph and any missiles collected spawns the enemies in this room and makes both doors gray and unlockable by killing the enemies.",
+                    "Opening either of the flashing gray doors is then what causes the flag to be set.",
+                    "FIXME: Remove this node and instead unlock the flag using door locks. This should be added in all rooms to any gray door locked by enemy kills (but not boss kills)."
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
The Pit Room requires both Morph and Missiles in order for the enemies to spawn.

Also added a note to clarify what seems to be a common misconception that entering the Pit Room with the required items is what sets the Zebes Awake flag. In fact the flag is set by opening any gray door locked by an enemy kill count. In the vanilla game this naturally happens in the Pit Room, but more generally it can happen in other places. So we should probably follow this up with a more systematic fix to address that. This change is enough for now to make the Map Randomizer work properly since it eliminates all gray doors in the game except for the ones in the Pit Room (with the result that the Pit Room is the only possible room where the Zebes Awake flag can become set).