### PR TITLE
Add canWallJump requirements to Wrecked Ship

### DIFF
--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -2006,7 +2006,10 @@
                 {
                   "name": "HiJump",
                   "notable": false,
-                  "requires": ["HiJump"]
+                  "requires": [
+                    "HiJump",
+                    "canWalljump"
+                  ]
                 },
                 {
                   "name": "Bomb Jump",
@@ -2038,14 +2041,21 @@
                       "fromNode": 1,
                       "usedTiles": 3
                     }},
-                    "SpeedBooster"
+                    "SpeedBooster",
+                      {"or": [
+                        "canWalljump",
+                        "HiJump"
+                      ]}
                   ],
                   "note": "A bit finicky for shorter runways, but exactly 3 tiles works."
                 },
                 {
                   "name": "Sponge Bath In-Room Speedjump",
                   "notable": true,
-                  "requires": ["SpeedBooster"],
+                  "requires": [
+                    "SpeedBooster",
+                    "canWalljump"
+                  ],
                   "note": "It doesn't work from flush against the door. Start moving about half a tile away from it."
                 }
               ]
@@ -2410,7 +2420,7 @@
                     "h_canUseSpringBall"
                   ],
                   "note": [
-                    "From a standstill at the door, jump just before the first stept.",
+                    "From a standstill at the door, jump just before the first step.",
                     "Mid-air mockball and bounce on the first platform.",
                     "This should bounce on the third platform and get to the item."
                   ]
@@ -2423,7 +2433,10 @@
                 {
                   "name": "Walljumps",
                   "notable": false,
-                  "requires": ["Gravity"]
+                  "requires": [
+                    "Gravity",
+                    "canWalljump"
+                  ]
                 },
                 {
                   "name": "Space Jump",


### PR DESCRIPTION
Added canWalljump requirements to sponge bath and the Wrecked Ship Energy Tank Room.

Fixed a minor typo in a note.