### PR TITLE
Add canWalljump checks throughout Brinstar

### DIFF
--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -1140,33 +1140,38 @@
                     "h_canUsePowerBombs",
                       {"or": [
                         "canWalljump",
-                        "h_canFly",
-                          {"canShineCharge": {
-                            "usedTiles": 33,
-                            "shinesparkFrames": 43,
-                            "openEnd": 2
-                          }}
+                        "h_canFly"
                       ]}
                   ],
                   "obstacles": [
                     {
                       "id": "A",
                       "requires": [
-                        {"or": [
-                          "h_canDestroyBombWalls",
-                          {"canShineCharge": {
-                            "usedTiles": 33,
-                            "shinesparkFrames": 43,
-                            "openEnd": 2
-                          }}
-                        ]}
+                        "h_canDestroyBombWalls"
                       ]
                     }
                   ],
-                  "note": [
-                    "Base strat when entering the room from below.",
-                    "The runway here is 31 tiles before breaking the PB blocks, but becomes longer after"
-                  ]
+                  "note": "Base strat when entering the room from below."
+                },
+                {
+                  "name": "Shinespark",
+                  "notable": false,
+                  "requires": [
+                    "h_canUsePowerBombs"
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": [
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "shinesparkFrames": 43,
+                          "openEnd": 2
+                        }}
+                      ]
+                    }
+                  ],
+                  "note": "The runway here is 31 tiles before breaking the PB blocks, but becomes longer after"
                 }
               ]
             }

--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -1157,18 +1157,17 @@
                   "name": "Shinespark",
                   "notable": false,
                   "requires": [
-                    "h_canUsePowerBombs"
+                    "h_canUsePowerBombs",
+                      {"canShineCharge": {
+                        "usedTiles": 33,
+                        "shinesparkFrames": 43,
+                        "openEnd": 2
+                      }}
                   ],
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires": [
-                        {"canShineCharge": {
-                          "usedTiles": 33,
-                          "shinesparkFrames": 43,
-                          "openEnd": 2
-                        }}
-                      ]
+                      "requires": []
                     }
                   ],
                   "note": "The runway here is 31 tiles before breaking the PB blocks, but becomes longer after"

--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -1114,7 +1114,13 @@
                 {
                   "name": "Go Back Up",
                   "notable": false,
-                  "requires": ["Morph"], 
+                  "requires": [
+                    "Morph",
+                      {"or": [
+                        "canWalljump",
+                        "h_canFly"
+                      ]}
+                  ], 
                   "obstacles": [
                     {
                       "id": "B",
@@ -1122,19 +1128,7 @@
                     },
                     {
                       "id": "A",
-                      "requires": [
-                        {"or":[
-                          "ScrewAttack",
-                          "Bombs",
-                          {"and":[
-                            "PowerBomb",
-                            {"ammo": {
-                              "type": "PowerBomb",
-                              "count": 1
-                            }}
-                          ]}
-                        ]}
-                      ]
+                      "requires": [ "h_canDestroyBombWalls" ]
                     }
                   ],
                   "note": "If the Crumble Block has been destroyed while going down, it's possible to go back up without breaking the PB blocks."
@@ -1142,22 +1136,28 @@
                 {
                   "name": "Break the PB Blocks",
                   "notable": false,
-                  "requires": ["h_canUsePowerBombs"],
+                  "requires": [
+                    "h_canUsePowerBombs",
+                      {"or": [
+                        "canWalljump",
+                        "h_canFly",
+                          {"canShineCharge": {
+                            "usedTiles": 33,
+                            "shinesparkFrames": 43,
+                            "openEnd": 2
+                          }}
+                      ]}
+                  ],
                   "obstacles": [
                     {
                       "id": "A",
                       "requires": [
                         {"or": [
-                          "ScrewAttack",
-                          "Bombs",
+                          "h_canDestroyBombWalls",
                           {"canShineCharge": {
                             "usedTiles": 33,
                             "shinesparkFrames": 43,
                             "openEnd": 2
-                          }},
-                          {"ammo": {
-                            "type": "PowerBomb",
-                            "count": 1
                           }}
                         ]}
                       ]

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -1077,7 +1077,22 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": []
+                  "requires": [
+                    {"or": [
+                      "HiJump",
+                      "h_canFly"
+                    ]}
+                  ]
+                },
+                {
+                  "name": "Wall Jump",
+                  "notable": false,
+                  "requires": [ "canWalljump" ]
+                },
+                {
+                  "name": "Crouch Jump Down Grab",
+                  "notable": false,
+                  "requires": [ "canDownGrab" ]
                 }
               ]
             }
@@ -2390,9 +2405,12 @@
                   "requires": [
                     {"or":[
                       "h_canFly",
-                      "SpeedBooster",
                       "HiJump",
-                      "canSpringBallJumpMidAir"
+                      "canSpringBallJumpMidAir",
+                        {"and": [
+                          "SpeedBooster",
+                          "canWalljump"
+                        ]}
                     ]}
                   ]
                 },
@@ -2424,19 +2442,33 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["Morph"]
+                  "requires": [
+                    "Morph",
+                      {"or": [
+                        "HiJump",
+                        "h_canFly",
+                        "canWalljump",
+                        "canUseFrozenEnemies"
+                      ]}
+                  ]
                 },
                 {
                   "name": "Turnaround Aim Cancel",
                   "notable": false,
                   "requires": ["canTurnaroundAimCancel"],
-                  "note": "Not notable because it's a one-way strat. It takes Morph or a Morphless Tunnel Crawl to get back out."
+                  "note": [
+                    "Not notable because it's a one-way strat. It takes Morph or a Morphless Tunnel Crawl to get back out.",
+                    "Getting into the tube with a wall jump or other method is assumed."
+                  ]
                 },
                 {
                   "name": "Green Hill Zone Tunnel Crawl (In)",
                   "notable": true,
                   "requires": ["canMorphlessTunnelCrawl"],
-                  "note": "It's a long Tunnel Crawl, so there's a heavy softlock risk."
+                  "note": [
+                    "It's a long Tunnel Crawl, so there's a heavy softlock risk.",
+                    "Getting into the tube with a wall jump or other method is assumed."
+                  ]
                 }
               ]
             }
@@ -2484,7 +2516,7 @@
                   "requires": ["Morph"]
                 },
                 {
-                  "name": "Green Hill Zone Tunnel Crawl (In)",
+                  "name": "Green Hill Zone Tunnel Crawl (Out)",
                   "notable": true,
                   "requires": ["canMorphlessTunnelCrawl"],
                   "note": "It's a long Tunnel Crawl, so there's a heavy softlock risk."

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -767,7 +767,13 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": []
+                  "requires": [
+                    {"or": [
+                      "HiJump",
+                      "h_canFly",
+                      "canWalljump"
+                    ]}
+                  ]
                 }
               ]
             }

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -774,6 +774,14 @@
                       "canWalljump"
                     ]}
                   ]
+                },
+                {
+                  "name": "Crouch Jump Down Grab",
+                  "notable": false,
+                  "requires": [
+                    "canDownGrab"
+                  ],
+                  "note": "This crouch jump down grab is a little tighter than most."
                 }
               ]
             }

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -1072,7 +1072,17 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": []
+                  "requires": [
+                    {"or": [
+                      "Grapple",
+                      "h_canFly",
+                      "canWalljump",
+                        {"and": [
+                          "SpeedBooster",
+                          "HiJump"
+                        ]}
+                    ]}
+                  ]
                 }
               ]
             },
@@ -2361,6 +2371,10 @@
                   "name": "Waterway Suitless Spark",
                   "notable": true,
                   "requires": [
+                    {"or": [
+                      "SpaceJump",
+                      "canWalljump"
+                    ]},
                     {"canShineCharge": {
                       "usedTiles": 32,
                       "shinesparkFrames": 72,

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -426,7 +426,10 @@
                 {
                   "name": "Red Tower Midair Spring Ball",
                   "notable": true,
-                  "requires": ["canSpringBallJumpMidAir"]
+                  "requires": [
+                    "canSpringBallJumpMidAir",
+                    "canWalljump"
+                  ]
                 }
               ]
             },

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -272,7 +272,13 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": []
+                  "requires": [
+                    {"or": [
+                      "HiJump",
+                      "h_canFly",
+                      "canWalljump"
+                    ]}
+                  ]
                 }
               ]
             }
@@ -385,15 +391,24 @@
                   "notable": false,
                   "requires": [
                     {"or":[
-                      "HiJump",
-                      "SpaceJump"
+                      "SpaceJump",
+                        {"and": [
+                          "HiJump",
+                          "canWalljump"
+                        ]}
                     ]}
                   ]
                 },
                 {
                   "name": "Use Frozen Enemies",
                   "notable": false,
-                  "requires": ["canUseFrozenEnemies"]
+                  "requires": [
+                    "canUseFrozenEnemies",
+                      {"or":[
+                        "HiJump",
+                        "canWalljump"
+                      ]}
+                  ]
                 },
                 {
                   "name": "IBJ",
@@ -515,10 +530,11 @@
                   "requires": ["canPreciseWalljump"]
                 },
                 {
-                  "name": "Space Jump",
+                  "name": "Wall Jump with Space Jump",
                   "notable": false,
                   "requires": [
                     "SpaceJump",
+                    "canWalljump",
                     {"enemyKill":{
                       "enemies": [
                         [ "Ripper" ]
@@ -529,6 +545,19 @@
                     "This strat exists on the belief that only the final wall jump is tricky",
                     "The top Ripper has to be killed otherwise there's no room to leverage Space Jump as an actual advantage."
                   ]
+                },
+                {
+                  "name": "Space Jump",
+                  "notable": false,
+                  "requires": [
+                    "SpaceJump",
+                    {"enemyKill":{
+                      "enemies": [
+                        [ "Ripper", "Ripper", "Ripper", "Ripper" ]
+                      ]
+                    }}
+                  ],
+                  "note": "This strat is for killing all of the Rippers and then using Space Jump to get up without wall jumps."
                 },
                 {
                   "name": "Red Tower IBJ",
@@ -1176,7 +1205,14 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["h_canPassBombPassages"]
+                  "requires": [
+                    "h_canPassBombPassages",
+                      {"or": [
+                        "HiJump",
+                        "h_canFly",
+                        "canWalljump"
+                      ]}
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
Most changes are simple wall jump additions throughout. Additionally there are a couple other changes:

- Switched to using the helper function "h_canDestroyBombWalls" in Blue Brinstar E-Tank Room to make the code simpler.
- Added a Space Jump strat to get to the top of Red Tower, as the previous Space Jump strat now requires a wall jump.