### PR TITLE
Fix Ice Beam Tutorial Room

### DIFF
--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -1947,6 +1947,27 @@
                       "hits": 1
                     }}
                   ]
+                },
+                {
+                  "name": "Ice",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "Morph",
+                    "canUseFrozenEnemies",
+                    {"heatFrames": 300}
+                  ],
+                  "note": "An ice shot through the morph tunnel can freeze the Boyon even without Wave."
+                },
+                {
+                  "name": "Heat and Lava Proof",
+                  "notable": false,
+                  "requires": [
+                    "Varia",
+                    "Gravity",
+                    "Morph"
+                  ],
+                  "note": "With heat and lava proof, Samus can move slower through the room and avoid Boyon hits."
                 }
               ]
             }


### PR DESCRIPTION
Moving from right to left from node 2 to 1:
- Samus can shoot Ice Beam through the morph tunnel to freeze the Boyon, avoiding a hit. 
- With the addition of Heat and Lava Proof to the base strat, Samus can move slower to avoid the Boyon hit, taking no damage in the room.