### PR TITLE
Fix Crocomire Escape Room

### DIFF
--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -2843,6 +2843,69 @@
               "id": 3,
               "strats": [
                 {
+                  "name": "Grapple",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "Grapple",
+                    {"heatFrames": 600}
+                  ]
+                },
+                {
+                  "name": "Space Jump",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "SpaceJump",
+                    {"heatFrames": 600}
+                  ]
+                },
+                {
+                  "name": "Speedjump",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "HiJump",
+                    "SpeedBooster",
+                    "canWalljump",
+                    {"heatFrames": 600}
+                  ]
+                },
+                {
+                  "name": "Croc Escape IBJ",
+                  "notable": true,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "canIBJ",
+                    {"heatFrames": 1650}
+                  ]
+                },
+                {
+                  "name": "MidAir SpringBall",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "HiJump",
+                    "canSpringBallJumpMidAir",
+                    {"heatFrames": 600}
+                  ]
+                },
+                {
+                  "name": "Croc Escape SpringBall Bomb Boost",
+                  "notable": true,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "canSpringBallJumpMidAir",
+                    "canUnmorphBombBoost",
+                    "canDownGrab",
+                    {"heatFrames": 800}
+                  ],
+                  "note": [
+                    "Uses a bomb boost at the end of a mid-air SpringBall jump.",
+                    "Also requires a downgrab to complete the maneuver."
+                  ]
+                },
+                {
                   "name": "Croc Escape SpringBall Freeze",
                   "notable": true,
                   "requires": [
@@ -2866,67 +2929,6 @@
                     "canUseFrozenEnemies",
                     "HiJump",
                     {"heatFrames": 1150}
-                  ]
-                },
-                {
-                  "name": "Grapple",
-                  "notable": false,
-                  "requires": [
-                    "h_canNavigateHeatRooms",
-                    "Grapple",
-                    {"heatFrames": 600}
-                  ]
-                },
-                {
-                  "name": "Space Jump",
-                  "notable": false,
-                  "requires": [
-                    "h_canNavigateHeatRooms",
-                    "SpaceJump",
-                    {"heatFrames": 600}
-                  ]
-                },
-                {
-                  "name": "MidAir SpringBall",
-                  "notable": false,
-                  "requires": [
-                    "h_canNavigateHeatRooms",
-                    "HiJump",
-                    "canSpringBallJumpMidAir",
-                    {"heatFrames": 600}
-                  ]
-                },
-                {
-                  "name": "Croc Escape SpringBall Bomb Boost",
-                  "notable": true,
-                  "requires": [
-                    "h_canNavigateHeatRooms",
-                    "canSpringBallJumpMidAir",
-                    "canUnmorphBombBoost",
-                    {"heatFrames": 800}
-                  ],
-                  "note": [
-                    "Uses a bomb boost at the end of a mid-air SpringBall jump.",
-                    "Also requires a downgrab to complete the maneuver."
-                  ]
-                },
-                {
-                  "name": "Speedjump",
-                  "notable": false,
-                  "requires": [
-                    "h_canNavigateHeatRooms",
-                    "HiJump",
-                    "SpeedBooster",
-                    {"heatFrames": 600}
-                  ]
-                },
-                {
-                  "name": "Croc Escape IBJ",
-                  "notable": true,
-                  "requires": [
-                    "h_canNavigateHeatRooms",
-                    "canIBJ",
-                    {"heatFrames": 1650}
                   ]
                 },
                 {
@@ -2992,7 +2994,8 @@
                     "HiJump",
                     "SpeedBooster",
                     {"heatFrames": 500}
-                  ]
+                  ],
+                  "note": "This can be done from the top right, single tile block."
                 },
                 {
                   "name": "HiJump",
@@ -3000,8 +3003,10 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "HiJump",
+                    "canWalljump",
                     {"heatFrames": 600}
-                  ]
+                  ],
+                  "note": "This can be done from the top right, single tile block."
                 },
                 {
                   "name": "Morph",


### PR DESCRIPTION
Getting up to the item (to escape):
- Reordered the strats so the easiest ones are first to match most other places in the data. I hadn't realized how messy this was going to look. I can separate these and split this into two pull requests if necessary.
- Added canWallJump tech to the Speedjump strat.
- Added canDownGrab tech to the Springball bomb boost, as indicated by its note. This was only recently added as a tech.

Getting back out to the right after getting the item:
- Added a note to identify where to execute two strats: Speedjump and HiJump.
- Also added canWallJump to the HiJump strat.