### PR TITLE
Add Strats to Cathedral Entrance

### DIFF
--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -193,6 +193,29 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
+                    "h_canBombThings",
+                    {"heatFrames": 400}
+                  ],
+                "note": "Only one bomb is needed after using a spinjump to get into the two tile tunnel."
+                },
+                {
+                  "name": "Base with Spring Ball",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "h_canUseSpringBall",
+                    {"heatFrames": 350}
+                  ]
+                },
+                {
+                  "name": "Up from Below",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                      {"or": [
+                        "canWalljump",
+                        "SpaceJump"
+                      ]},
                     {"heatFrames": 300}
                   ]
                 }


### PR DESCRIPTION
Getting to the left door of the Cathedral Entrance:
- Added a wall jump requirement to the base strat, then renamed it to Up from Below.
- Added two other strats which go through the morph tunnel and are easier to execute but have more heat frames.