### PR TITLE
Clean GateGlitch, DownGrab, Mockball tech

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -248,6 +248,60 @@
         ]},
         "h_canShoot"
       ]
+    },
+    {
+      "name": "h_canGreenGateGlitch",
+      "requires": [ 
+        "Super",
+        {"ammo": {
+          "type": "Super",
+          "count": 1
+        }}
+      ]
+    },
+    {
+      "name": "h_canBlueGateGlitch",
+      "requires": [
+        {"or": [
+          {"and": [
+            "Missile",
+            {"ammo": {
+              "type": "Missile",
+              "count": 1
+            }}
+          ]},
+          {"and": [
+            "Super",
+            {"ammo": {
+              "type": "Super",
+              "count": 1
+            }}
+          ]}
+        ]}
+      ]
+    },
+    {
+      "name": "h_canHeatedBlueGateGlitch",
+      "requires": [ 
+        "h_canNavigateHeatRooms",
+        {"heatFrames": 60},
+        "h_canBlueGateGlitch"
+      ]
+    },
+    {
+      "name": "h_canHeatedGreenGateGlitch",
+      "requires": [ 
+        "h_canNavigateHeatRooms",
+        {"heatFrames": 60},
+        "h_canGreenGateGlitch"
+      ]
+    },
+    {
+      "name": "h_canCrouchJumpDownGrab",
+      "requires": [ 
+        "canCrouchJump",
+        "canDownGrab"
+      ]
     }
   ]
 }

--- a/helpers.json
+++ b/helpers.json
@@ -251,7 +251,8 @@
     },
     {
       "name": "h_canGreenGateGlitch",
-      "requires": [ 
+      "requires": [
+        "canGateGlitch",
         "Super",
         {"ammo": {
           "type": "Super",
@@ -262,6 +263,7 @@
     {
       "name": "h_canBlueGateGlitch",
       "requires": [
+        "canGateGlitch",
         {"or": [
           {"and": [
             "Missile",

--- a/helpers.json
+++ b/helpers.json
@@ -214,15 +214,6 @@
       ]
     },
     {
-      "name": "h_canOpenWrongFacingBlueGateFromRight",
-      "requires": [
-        {"or": [
-          "canGateGlitch",
-          "Wave"
-        ]}
-      ]
-    },
-    {
       "name": "h_canUseMorphBombs",
       "requires": [
         "Morph",

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -2299,9 +2299,14 @@
               "openEnd": 0,
               "strats": [
                 {
-                  "name": "Open Blue Gate",
+                  "name": "Wave",
                   "notable": false,
-                  "requires": [ "h_canOpenWrongFacingBlueGateFromRight" ]
+                  "requires": [ "Wave" ]
+                },
+                {
+                  "name": "Gate Glitch",
+                  "notable": false,
+                  "requires": [ "h_canBlueGateGlitch" ]
                 },
                 {
                   "name": "Arrive From Left",
@@ -2517,9 +2522,14 @@
               "id": 1,
               "strats": [
                 {
-                  "name": "Base",
+                  "name": "Wave",
                   "notable": false,
-                  "requires": ["h_canOpenWrongFacingBlueGateFromRight"]
+                  "requires": ["Wave"]
+                },
+                {
+                  "name": "Gate Glitch",
+                  "notable": false,
+                  "requires": ["h_canBlueGateGlitch"]
                 }
               ]
             }

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -1113,7 +1113,7 @@
                 {
                   "name": "Crouch Jump Down Grab",
                   "notable": false,
-                  "requires": [ "canDownGrab" ]
+                  "requires": [ "h_canCrouchJumpDownGrab" ]
                 }
               ]
             }

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -779,7 +779,7 @@
                   "name": "Crouch Jump Down Grab",
                   "notable": false,
                   "requires": [
-                    "canDownGrab"
+                    "h_canCrouchJumpDownGrab"
                   ],
                   "note": "This crouch jump down grab is a little tighter than most."
                 },

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -1603,7 +1603,7 @@
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires": ["canHeatedGGG"]
+                      "requires": ["h_canHeatedGreenGateGlitch"]
                     }
                   ],
                   "note": "This longer runway requires the green gate to be open, and usually involves tanking some ripper hits."
@@ -1709,7 +1709,7 @@
                     {
                       "id": "A",
                       "requires": [
-                        "canHeatedGGG"
+                        "h_canHeatedGreenGateGlitch"
                       ]
                     }
                   ]

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -2737,7 +2737,7 @@
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires": ["canGGG"]
+                      "requires": ["h_canGreenGateGlitch"]
                     }
                   ]
                 }

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -2015,7 +2015,7 @@
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires": [ "canGGG" ]
+                      "requires": [ "h_canGreenGateGlitch" ]
                     }
                   ]
                 }
@@ -2151,7 +2151,7 @@
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires": [ "canGGG" ]
+                      "requires": [ "h_canGreenGateGlitch" ]
                     }
                   ]
                 }

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1161,7 +1161,7 @@
                     {
                       "id": "A",
                       "requires": [
-                        "canHeatedGateGlitch"
+                        "h_canHeatedBlueGateGlitch"
                       ]
                     }
                   ]
@@ -3807,7 +3807,7 @@
                     {
                       "id": "A",
                       "requires": [
-                        "canHeatedGateGlitch"
+                        "h_canHeatedBlueGateGlitch"
                       ]
                     }
                   ]
@@ -4493,7 +4493,7 @@
                     {
                       "id": "A",
                       "requires": [
-                        "canHeatedGateGlitch"
+                        "h_canHeatedBlueGateGlitch"
                       ]
                     }
                   ]

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1189,7 +1189,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canDownGrab",
+                    "h_canCrouchJumpDownGrab",
                     {"heatFrames": 125}
                   ]
                 }
@@ -3255,7 +3255,7 @@
                         "canWalljump",
                         "HiJump",
                         "SpaceJump",
-                        "canDownGrab"
+                        "h_canCrouchJumpDownGrab"
                       ]},
                     {"heatFrames": 280}
                   ]
@@ -3292,7 +3292,7 @@
                         "canWalljump",
                         "HiJump",
                         "SpaceJump",
-                        "canDownGrab"
+                        "h_canCrouchJumpDownGrab"
                       ]},
                     {"heatFrames": 310}
                   ]
@@ -3329,7 +3329,7 @@
                         "canWalljump",
                         "HiJump",
                         "SpaceJump",
-                        "canDownGrab"
+                        "h_canCrouchJumpDownGrab"
                       ]},
                     {"heatFrames": 200}
                   ]
@@ -3391,7 +3391,7 @@
                         "canWalljump",
                         "HiJump",
                         "SpaceJump",
-                        "canDownGrab"
+                        "h_canCrouchJumpDownGrab"
                       ]},
                     {"heatFrames": 100}
                   ]

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -2988,12 +2988,12 @@
                     "h_canNavigateHeatRooms",
                     "canSpringBallJumpMidAir",
                     "canUnmorphBombBoost",
-                    "canDownGrab",
+                    "h_canCrouchJumpDownGrab",
                     {"heatFrames": 800}
                   ],
                   "note": [
                     "Uses a bomb boost at the end of a mid-air SpringBall jump.",
-                    "Also requires a downgrab to complete the maneuver."
+                    "Also requires a crouchjump and downgrab to complete the maneuver."
                   ]
                 },
                 {

--- a/tech.json
+++ b/tech.json
@@ -169,43 +169,10 @@
     },
     {
       "name": "canGateGlitch",
-      "requires": [
-        {"or": [
-          {"and": [
-            "Missile",
-            {"ammo": {
-              "type": "Missile",
-              "count": 1
-            }}
-          ]},
-          "h_canOpenGreenDoors"
-        ]}
-      ],
+      "requires": [],
       "note": [
-        "The ability to open a left-facing blue gate using missiles or supers. It's recommended to apply a number of tries as leniency here.",
-        "If this tech is turned off, it's strongly recommended to turn off canHeatedGateGlitch at the same time."
-      ]
-    },
-    {
-      "name": "canHeatedGateGlitch",
-      "requires": [
-        "h_canNavigateHeatRooms",
-        {"heatFrames": 60},
-        {"or": [
-          {"and": [
-            "Missile",
-            {"ammo": {
-              "type": "Missile",
-              "count": 1
-            }}
-          ]},
-          "h_canOpenGreenDoors"
-        ]}
-      ],
-      "note": [
-        "Separate from canGateGlitch to simplify the cost per attempt.",
-        "If this tech is turned off, it's strongly recommended to turn off canGateGlitch at the same time.",
-        "This will be naturally impossible without Varia if canHeatRun is turned off."
+        "The ability to open a left-facing blue or green gate using missiles or supers.",
+        "It's recommended to apply a number of tries as leniency."
       ]
     },
     {
@@ -214,29 +181,6 @@
       "note": [
         "A general tech for opening right-facing gates from the left.",
         "Individual strats may differ, so requirements are left for individual strats to define."
-      ]
-    },
-    {
-      "name": "canGGG",
-      "requires": [
-        "h_canOpenGreenDoors"
-      ],
-      "note": [
-        "The ability to open a left facing green gate using supers. It's recommended to apply a number of tries as leniency here.",
-        "If this tech is turned off, it's strongly recommended to turn off canHeatedGGG at the same time."
-      ]
-    },
-    {
-      "name": "canHeatedGGG",
-      "requires": [
-        "h_canNavigateHeatRooms",
-        "h_canOpenGreenDoors",
-        {"heatFrames": 60}
-      ],
-      "note": [
-        "Separate from canGGG to simplify the cost per attempt.",
-        "If this tech is turned off, it's strongly recommended to turn off canGGG at the same time.",
-        "This will be naturally impossible without Varia if canHeatRun is turned off."
       ]
     },
     {
@@ -263,11 +207,6 @@
       "note": "Using i-frames to setup a jump from a spike floor. The i-frames are typically obtained by getting damaged by said spike floor"
     },
     {
-      "name": "canMachball",
-      "requires": [ "Morph" ],
-      "note": "Alias for canMockball"
-    },
-    {
       "name": "can2HighWallMidAirMorph",
       "requires": [
         "canWalljump",
@@ -290,7 +229,7 @@
     {
       "name": "canMockball",
       "requires": [ "Morph" ],
-      "note": "Alias for canMachball"
+      "note": "Sometimes referred to as a Machball"
     },
     {
       "name": "canMidAirMockball",
@@ -728,12 +667,12 @@
     {
       "name": "canCrouchJump",
       "requires": [],
-      "note":"The ability to crouch before jumping to reach higher ledges."
+      "note":"The ability to crouch before jumping to reach higher ledges. Commonly paired with a Down Grab."
     },
     {
       "name": "canDownGrab",
-      "requires": [ "canCrouchJump" ],
-      "note":"The ability to aim down to reduce Samus' hitbox to reach higher ledges."
+      "requires": [],
+      "note":"The ability to aim down to reduce Samus' hitbox to reach higher ledges. Commonly paired with a Crouch Jump."
     },
     {
       "name": "canJumpIntoIBJ",


### PR DESCRIPTION
- Removed duplicate gate glitch tech and converted them into one tech: canGateGlitch, and 4 helpers, which include ammo used. Propagated these helpers throughout the codebase.
- Removed canDownGrab dependency of canCrouchJump and made a helper which combines both. Propagated this helpers throughout the codebase.
- Removed canMachball and put a note about the alternate spelling into canMockball.
- Removed the helper h_canOpenWrongFacingBlueGateFromRight and replaced its uses with two separate strats: Wave and the new helper h_canBlueGateGlitch