### PR TITLE
Fix broken reference to enemy "Botwoon"

### DIFF
--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -1311,10 +1311,18 @@
       "enemies": [
         {
           "id": "e1",
-          "groupName": "Botwoon",
-          "enemyName": "Botwoon",
+          "groupName": "Botwoon 1",
+          "enemyName": "Botwoon 1",
           "quantity": 1,
           "homeNodes": [ 3 ],
+          "stopSpawn": [ "f_DefeatedBotwoon" ]
+        },
+        {
+          "id": "e2",
+          "groupName": "Botwoon 2",
+          "enemyName": "Botwoon 2",
+          "quantity": 1,
+          "homeNodes": [ 4 ],
           "stopSpawn": [ "f_DefeatedBotwoon" ]
         }
       ],


### PR DESCRIPTION
It's no longer valid because the Botwoon enemy was split into two phases.