### PR TITLE
Samus Eater Logic for #488

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -193,12 +193,20 @@ __Additional considerations__
 
 Much like the other logical elements that represent environmental frame damage, the lava frame counts listed in this project might not be stricly "perfect" play, but they are very much unforgiving. Their most significant value is to provide relative lengths to different lava runs. It's recommended to apply a leniency factor to those, possibly as an option that can vary by difficulty.
 
-#### lavaPhysicsFrames
+#### lavaPhysicsFrames object
 A `lavaPhysicsFrames` object works exactly like a `lavaFrames` object, except that Samus needs to be working with lava physics during that period of time. This means Gravity Suit will be manually turned off for this duration, even if it's available.
 
 __Example:__
 ```json
 {"lavaPhysicsFrames": 70}
+```
+
+#### samusEaterFrames object
+A `samusEaterFrames` object represents the need for Samus to take damage from the environmental enemy known as a Samus Eater.  When captured, fixed damage is dealt over a set number of frames. The frame amount is 320 for ceiling and 160 for floor variations.  The vanilla damage is 2 per 20 frames in Power Suit, 1 per 20 frames in Varia Suit, 1 per 40 frames in Gravity Suit.
+
+__Example:__
+```json
+{"samusEaterFrames": 160}
 ```
 
 #### spikeHits object

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -1409,6 +1409,23 @@
               "usableComingIn": false,
               "openEnd": 1
             }
+          ],
+          "canLeaveCharged": [
+            {
+              "framesRemaining": 70,
+              "usedTiles": 33,
+              "openEnd": 0,
+              "strats": [
+                {
+                  "name": "Samus Eater Left",
+                  "requires": [
+                    "canSamusEaterStandUp",
+                    { "samusEaterFrames": 160 }
+                  ],
+                  "notable": false
+                }
+              ]
+            }
           ]
         },
         {
@@ -1430,6 +1447,23 @@
                 }
               ],
               "openEnd": 1
+            }
+          ],
+          "canLeaveCharged": [
+            {
+              "framesRemaining": 40,
+              "usedTiles": 33,
+              "openEnd": 0,
+              "strats": [
+                {
+                  "name": "Samus Eater Right",
+                  "requires": [
+                    "canSamusEaterStandUp",
+                    { "samusEaterFrames": 160 }
+                  ],
+                  "notable": false
+                }
+              ]
             }
           ]
         }
@@ -1963,6 +1997,23 @@
                 }
               ],
               "openEnd": 1
+            }
+          ],
+          "canLeaveCharged": [
+            {
+              "framesRemaining": 100,
+              "usedTiles": 33,
+              "openEnd": 0,
+              "strats": [
+                {
+                  "name": "Samus Eater",
+                  "requires": [
+                    "canSamusEaterStandUp",
+                    { "samusEaterFrames": 160 }
+                  ],
+                  "notable": false
+                }
+              ]
             }
           ]
         },

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -234,11 +234,11 @@
             "description": "Fulfilled by spending an amount of energy that corresponds to spending a number of frames in lava, with Gravity Suit turned off if available."
           },
           "samusEaterFrames": {
-            "$id": "#/definitions/logicalRequirement/items/properties/samusEaterHits",
+            "$id": "#/definitions/logicalRequirement/items/properties/samusEaterFrames",
             "type": "integer",
             "minimum": 1,
             "title": "Samus Eater Frames",
-            "description": "Fulfilled by spending an amount of energy that corresponds to spending a number of frames captured by a Samus Eater."
+            "description": "Fulfilled by spending an amount of energy that correlates to the number of frames captured by a Samus Eater."
           },
           "energyAtMost": {
             "$id": "#/definitions/logicalRequirement/items/properties/energyAtMost",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -233,6 +233,13 @@
             "title": "Lava Physics Frames",
             "description": "Fulfilled by spending an amount of energy that corresponds to spending a number of frames in lava, with Gravity Suit turned off if available."
           },
+          "samusEaterFrames": {
+            "$id": "#/definitions/logicalRequirement/items/properties/samusEaterHits",
+            "type": "integer",
+            "minimum": 1,
+            "title": "Samus Eater Frames",
+            "description": "Fulfilled by spending an amount of energy that corresponds to spending a number of frames captured by a Samus Eater."
+          },
           "energyAtMost": {
             "$id": "#/definitions/logicalRequirement/items/properties/energyAtMost",
             "type": "integer",

--- a/tech.json
+++ b/tech.json
@@ -444,6 +444,11 @@
               ]
             },
             {
+              "name": "canSamusEaterStandUp",
+              "requires": [ "canUseEnemies" ],
+              "note": "Keep control of most of Samus' abilities while captured by the Samus Eater.  Useful for building a shinespark without moving."
+            },
+            {
               "name": "canUseFrozenEnemies",
               "requires": [ "Ice", "canUseEnemies" ],
               "note": "Can use Ice Beam to freeze enemies to use as platforms, or as walljump supports, to reach higher areas",


### PR DESCRIPTION
-Samus eaters as a damage source
-Using them to build shinesparks in hellway and alpha pbs.  Beta pbs has a runway already.