### PR TITLE
Update GT Logic - No longer assume safe spot

### DIFF
--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -660,7 +660,7 @@
                           "enemy": "Golden Torizo",
                           "type": "contact",
                           "hits": 9
-                        }},
+                        }}
                       ]}
                     ]}
                   ],

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -435,27 +435,31 @@
               "lockType": "bossFight",
               "unlockStrats": [
                 {
-                  "name": "Heatproof Supers",
+                  "name": "Safe Spot Heatproof Supers",
                   "notable": false,
                   "requires": [
                     "h_heatProof",
+                    "canSafeSpotGT",
                     "Super"
                   ],
                   "note": "Supers are farmable here, so no ammo requirement."
                 },
                 {
-                  "name": "Heatproof Charge",
+                  "name": "Safe Spot Heatproof Charge",
                   "notable": false,
                   "requires": [
                     "h_heatProof",
-                    "Charge"
+                    "canSafeSpotGT",
+                    "Charge",
+                    "canBePatient"
                   ]
                 },
                 {
-                  "name": "Supers",
+                  "name": "Safe Spot Supers",
                   "notable": false,
                   "requires": [
                     "canHeatRun",
+                    "canSafeSpotGT",
                     "Super",
                     {"heatFrames": 1200},
                     {"ammo": {
@@ -471,10 +475,11 @@
                   ]
                 },
                 {
-                  "name": "Full Combo",
+                  "name": "Safe Spot Full Combo",
                   "notable": false,
                   "requires": [
                     "canHeatRun",
+                    "canSafeSpotGT",
                     "Charge",
                     "Ice",
                     "Wave",
@@ -483,10 +488,11 @@
                   ]
                 },
                 {
-                  "name": "Almost Full Combo",
+                  "name": "Safe Spot Almost Full Combo",
                   "notable": false,
                   "requires": [
                     "canHeatRun",
+                    "canSafeSpotGT",
                     "Charge",
                     "Wave",
                     "Plasma",
@@ -494,26 +500,171 @@
                   ]
                 },
                 {
-                  "name": "Charge Plasma",
+                  "name": "Safe Spot Charge Plasma",
                   "notable": false,
                   "requires": [
                     "canHeatRun",
+                    "canSafeSpotGT",
                     "Charge",
                     "Plasma",
                     {"heatFrames": 2000}
                   ]
                 },
                 {
-                  "name": "Full Spazer",
+                  "name": "Safe Spot Full Spazer",
                   "notable": false,
                   "requires": [
                     "canHeatRun",
+                    "canSafeSpotGT",
                     "Charge",
                     "Ice",
                     "Wave",
                     "Spazer",
                     {"heatFrames": 4000}
                   ]
+                },
+                {
+                  "name": "Safe Spot Two Beam Charge",
+                  "notable": false,
+                  "requires": [
+                    "canHeatRun",
+                    "canSafeSpotGT",
+                    "Charge",
+                    {"heatFrames": 6500},
+                    {"or": [
+                      {"and": [
+                        "Ice",
+                        "Wave"
+                      ]},
+                      {"and": [
+                        "Ice",
+                        "Spazer"
+                      ]},
+                      {"and": [
+                        "Wave",
+                        "Spazer"
+                      ]}
+                    ]}
+                  ]
+                },
+                {
+                  "name": "Heatproof Supers",
+                  "notable": false,
+                  "requires": [
+                    "h_heatProof",
+                    "Super",
+                    {"enemyDamage": {
+                      "enemy": "Golden Torizo",
+                      "type": "contact",
+                      "hits": 10
+                    }}
+                  ],
+                  "note": [
+                    "This is an estimate of the net damage taken, including farmed energy.",
+                    "Supers are farmable here, so no ammo requirement."
+                  ]
+                },
+                {
+                  "name": "Supers",
+                  "notable": false,
+                  "requires": [
+                    "canHeatRun",
+                    "Super",
+                    {"heatFrames": 1200},
+                    {"ammo": {
+                      "type": "Super",
+                      "count": 30
+                    }},
+                    {"enemyDamage": {
+                      "enemy": "Golden Torizo",
+                      "type": "super",
+                      "hits": 4
+                    }}
+                  ],
+                  "devNote": [
+                    "No farming expected because that would change the heat frames.",
+                    "Supers count hard-coded because of GT's inherent 'dodging' ability.",
+                    "We could use an enemyKill if this were integrated into the enemy definition.",
+                    "It actually takes 29 supers but giving 1 extra in leniency since it's easy to miss"
+                  ]
+                },
+                {
+                  "name": "Full Combo",
+                  "notable": false,
+                  "requires": [
+                    "canHeatRun",
+                    {"heatFrames": 1800},
+                    "Charge",
+                    "Ice",
+                    "Wave",
+                    "Plasma",
+                    {"enemyDamage": {
+                      "enemy": "Golden Torizo",
+                      "type": "contact",
+                      "hits": 4
+                    }}
+                  ],
+                  "note": "This is an estimate of the net damage taken, including farmed energy."
+                },
+                {
+                  "name": "Almost Full Combo",
+                  "notable": false,
+                  "requires": [
+                    "canHeatRun",
+                    {"heatFrames": 2150},
+                    "Charge",
+                    "Wave",
+                    "Plasma",
+                    {"enemyDamage": {
+                      "enemy": "Golden Torizo",
+                      "type": "contact",
+                      "hits": 5
+                    }}
+                  ],
+                  "note": "This is an estimate of the net damage taken, including farmed energy."
+                },
+                {
+                  "name": "Charge Plasma",
+                  "notable": false,
+                  "requires": [
+                    "canHeatRun",
+                    {"heatFrames": 3600},
+                    "Charge",
+                    "Plasma",
+                    {"enemyDamage": {
+                      "enemy": "Golden Torizo",
+                      "type": "contact",
+                      "hits": 8
+                    }}
+                  ],
+                  "note": "This is an estimate of the net damage taken, including farmed energy."
+                },
+                {
+                  "name": "Full Spazer",
+                  "notable": false,
+                  "requires": [
+                    "h_heatProof",
+                    "Charge",
+                    "Ice",
+                    "Wave",
+                    "Spazer",
+                    {"or": [
+                      {"enemyDamage": {
+                        "enemy": "Golden Torizo",
+                        "type": "contact",
+                        "hits": 14
+                      }},
+                      {"and": [
+                        "Gravity",
+                        {"enemyDamage": {
+                          "enemy": "Golden Torizo",
+                          "type": "contact",
+                          "hits": 9
+                        }},
+                      ]}
+                    ]}
+                  ],
+                  "note": "This is an estimate of the net damage taken, including farmed energy."
                 }
               ]
             }

--- a/tech.json
+++ b/tech.json
@@ -444,6 +444,13 @@
               ]
             },
             {
+              "name": "canSafeSpotGT",
+              "requires": ["canUseEnemies"],
+              "note": [
+                "The ability to get into the safe spot in the Golden Torizo fight, where Samus is safe from GT's standard attacks, but she can still attack."
+              ]
+            },
+            {
               "name": "canUseFrozenEnemies",
               "requires": [ "Ice", "canUseEnemies" ],
               "note": "Can use Ice Beam to freeze enemies to use as platforms, or as walljump supports, to reach higher areas",

--- a/tech.json
+++ b/tech.json
@@ -444,13 +444,6 @@
               ]
             },
             {
-              "name": "canSafeSpotGT",
-              "requires": ["canUseEnemies"],
-              "note": [
-                "The ability to get into the safe spot in the Golden Torizo fight, where Samus is safe from GT's standard attacks, but she can still attack."
-              ]
-            },
-            {
               "name": "canUseFrozenEnemies",
               "requires": [ "Ice", "canUseEnemies" ],
               "note": "Can use Ice Beam to freeze enemies to use as platforms, or as walljump supports, to reach higher areas",
@@ -571,6 +564,13 @@
                 }
               ]
             }
+          ]
+        },
+        {
+          "name": "canSafeSpotGT",
+          "requires": [],
+          "note": [
+            "The ability to get into the safe spot in the Golden Torizo fight, where Samus can attack while being safe from GT's standard attacks."
           ]
         }
       ]


### PR DESCRIPTION
Add a new tech that is used in all existing GT strats: canSafeSpotGT.
Add strats that no longer assume the player knows how to use the safe spot.
Add canBePatient for weak charge beams, as the fight would take 2-5 minutes. (~5 min for charge, down to ~2 min for charge + wave)