### PR TITLE
Remove Heatproof Reqs from Ridley's Room

### DIFF
--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -3631,7 +3631,7 @@
                         [ "Ridley" ]
                       ]
                     }},
-                    "h_heatProof"
+                    "h_canNavigateHeatRooms"
                   ]
                 }
               ]
@@ -3660,7 +3660,10 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["h_heatProof"]
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    {"heatFrames": 50}
+                  ]
                 }
               ]
             }
@@ -3675,7 +3678,10 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["h_heatProof"]
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    {"heatFrames": 100}
+                  ]
                 }
               ]
             }
@@ -3690,7 +3696,10 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["h_heatProof"]
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    {"heatFrames": 50}
+                  ]
                 }
               ]
             },
@@ -3698,9 +3707,30 @@
               "id": 2,
               "strats": [
                 {
-                  "name": "Base",
+                  "name": "Wall Jump",
                   "notable": false,
-                  "requires": ["h_heatProof"]
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "canWalljump",
+                    {"heatFrames": 200}
+                  ]
+                },
+                {
+                  "name": "Space Jump",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "SpaceJump",
+                    {"heatFrames": 250}
+                  ]
+                },
+                {
+                  "name": "IBJ",
+                  "notable": false,
+                  "requires": [
+                    "h_heatProof",
+                    "canIBJ"
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
Removed h_heatProof requirements from Ridley's Room. The boss scenario for the actual fight still requires Varia. In the future, other strats could be added to the boss scenario, including suitless variants. This could also be useful in randomizers that have changes like the following:
- Those that remove grey doors from boss fights, allowing Samus to run through the room.
- Those that already have some bosses defeated, or that don't spawn until something happens.
- Those that use custom Ridley logic instead of the boss scenario, like Map Rando.