### PR TITLE
Resource Capacity Object for #504

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -54,22 +54,6 @@ __Example:__
 }}
 ```
 
-#### ammoCapacity object
-An `ammo` object represents the need for Samus to be capable of holding at least a set amount of a specific ammo. It can have the following properties:
-* _type:_ The type of ammo held. Can have the following values:
-  * PowerBomb
-  * Missile
-  * Super
-* _count:_ The amount of ammo capacity that Samus must have.
-
-__Example:__
-```json
-{"ammoCapacity": {
-  "type": "PowerBomb",
-  "count": 11
-}}
-```
-
 #### ammoDrain object
 An `ammoDrain` object works very much like `ammo`, except that spending the ammo isn't mandatory. The ammo is just always spent if it's there. This has the same properties as an `ammo` object.
 
@@ -235,6 +219,26 @@ A `thornHits` object represents the need for Samus to intentionally take a numbe
 __Example:__
 ```json
 {"thornHits": 1}
+```
+
+#### resourceCapacity object
+A `resourceCapacity` object represents the need for Samus to be capable of holding at least a set amount of a specific resource. It can have the following properties:
+* _type:_ The type ofresource. Can have the following values:
+  * Missile
+  * Super
+  * PowerBomb
+  * RegularEnergy
+  * ReserveEnergy
+* _count:_ The amount of capacity that Samus must have.
+
+__Example:__
+```json
+{"resourceCapacity": [
+    { "type": "Missile", "count": 10},
+    { "type": "Super", "count":10},
+    { "type": "PowerBomb", "count": 11},
+    { "type": "RegularEnergy", "count":899}
+]}
 ```
 
 ### Momentum-Based Objects

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -54,6 +54,22 @@ __Example:__
 }}
 ```
 
+#### ammoCapacity object
+An `ammo` object represents the need for Samus to be capable of holding at least a set amount of a specific ammo. It can have the following properties:
+* _type:_ The type of ammo held. Can have the following values:
+  * PowerBomb
+  * Missile
+  * Super
+* _count:_ The amount of ammo capacity that Samus must have.
+
+__Example:__
+```json
+{"ammoCapacity": {
+  "type": "PowerBomb",
+  "count": 11
+}}
+```
+
 #### ammoDrain object
 An `ammoDrain` object works very much like `ammo`, except that spending the ammo isn't mandatory. The ammo is just always spent if it's there. This has the same properties as an `ammo` object.
 

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -111,10 +111,9 @@
                   "notable": false,
                   "requires": [
                     "Missile",
-                    {"ammoCapacity": {
-                      "type": "Missile",
-                      "count": 10
-                    }}
+                    {"resourceCapacity": [
+                        {"type": "Missile", "count": 10}
+                      ]}
                   ],
                   "note": [
                     "With a max of 5 missiles, Crocomire may not stop and shoot farmables often enough to kill it.",

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -111,7 +111,7 @@
                   "notable": false,
                   "requires": [
                     "Missile",
-                    {"ammo": {
+                    {"ammoCapacity": {
                       "type": "Missile",
                       "count": 10
                     }}

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -63,37 +63,6 @@
               }
             }
           },
-          "ammoCapacity": {
-            "$id": "#/definitions/logicalRequirement/items/properties/ammoCapacity",
-            "type": "object",
-            "title": "Ammo Capacity Requirement",
-            "description": "Fulfilled by having at least the maximum capacity of this ammo type",
-            "required": [
-              "type",
-              "count"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "type": {
-                "$id": "#/definitions/logicalRequirement/items/properties/ammoCapacity/properties/type",
-                "type": "string",
-                "enum": [
-                  "Missile",
-                  "Super",
-                  "PowerBomb"
-                ],
-                "title": "Ammo Type",
-                "description": "The type of ammo held."
-              },
-              "count": {
-                "$id": "#/definitions/logicalRequirement/items/properties/ammoCapacity/properties/count",
-                "type": "integer",
-                "minimum": 0,
-                "title": "Ammo Count",
-                "description": "The amount of ammo capacity that Samus must have."
-              }
-            }
-          },
           "ammoDrain": {
             "$id": "#/definitions/logicalRequirement/items/properties/ammoDrain",
             "type": "object",
@@ -284,6 +253,46 @@
             "minimum": 1,
             "title": "Thorn Hits",
             "description": "Fulfilled by spending an amount of energy that corresponds to taking a number of hits from thorns (the less damaging spikes found mainly in Brinstar)."
+          },
+          "resourceCapacity": {
+            "$id": "#/definitions/logicalRequirement/items/properties/resourceCapacity",
+            "type": "array",
+            "title": "Resource Capacity Requirement",
+            "description": "Fulfilled by having at least the maximum capacity for all given resource types",
+            "items": {
+              "$id": "#/definitions/logicalRequirement/items/properties/resourceCapacity/items",
+              "type": "object",
+              "required": [
+                "type",
+                "count"
+              ],
+              "minItems": 1,
+              "maxItems": 5,
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "$id": "#/definitions/logicalRequirement/items/properties/resourceCapacity/properties/items/type",
+                  "type": "string",
+                  "enum": [
+                    "Missile",
+                    "Super",
+                    "PowerBomb",
+                    "RegularEnergy",
+                    "ReserveEnergy"
+                  ],
+                  "title": "Resource Type",
+                  "description": "The type of resource held."
+                },
+                "count": {
+                  "$id": "#/definitions/logicalRequirement/items/properties/resourceCapacity/properties/items/count",
+                  "type": "integer",
+                  "minimum": 0,
+                  "title": "Resource Count",
+                  "description": "The amount of resource capacity that Samus must have."
+                }
+              }
+            }
+
           },
           "adjacentRunway": {
             "$id": "#/definitions/logicalRequirement/items/properties/adjacentRunway",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -63,6 +63,37 @@
               }
             }
           },
+          "ammoCapacity": {
+            "$id": "#/definitions/logicalRequirement/items/properties/ammoCapacity",
+            "type": "object",
+            "title": "Ammo Capacity Requirement",
+            "description": "Fulfilled by having at least the maximum capacity of this ammo type",
+            "required": [
+              "type",
+              "count"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "$id": "#/definitions/logicalRequirement/items/properties/ammoCapacity/properties/type",
+                "type": "string",
+                "enum": [
+                  "Missile",
+                  "Super",
+                  "PowerBomb"
+                ],
+                "title": "Ammo Type",
+                "description": "The type of ammo held."
+              },
+              "count": {
+                "$id": "#/definitions/logicalRequirement/items/properties/ammoCapacity/properties/count",
+                "type": "integer",
+                "minimum": 0,
+                "title": "Ammo Count",
+                "description": "The amount of ammo capacity that Samus must have."
+              }
+            }
+          },
           "ammoDrain": {
             "$id": "#/definitions/logicalRequirement/items/properties/ammoDrain",
             "type": "object",


### PR DESCRIPTION
An object that requires you have a maximum value of health or ammo.  For situations where you are currently equal to or under capacity but can regain resources to a threshold amount for some obstacle.
-croc allows farming in random cycles so you need enough ammo to survive the cycle, but could enter with no missiles.