### PR TITLE
Fix Crocomire Room and Post Croc Farm Room

### DIFF
--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -219,7 +219,7 @@
                   "requires": [
                     "f_DefeatedCrocomire",
                     "Gravity",
-                    {"acidFrames": 50}
+                    {"acidFrames": 30}
                   ]
                 },
                 {
@@ -323,13 +323,14 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    {"acidFrames": 35}
+                    {"acidFrames": 20}
                   ]
                 },
                 {
                   "name": "Acid Bath",
                   "notable": false,
                   "requires": [
+                    "canWalljump",
                     {"acidFrames": 60}
                   ]
                 },
@@ -349,7 +350,8 @@
                   "notable": true,
                   "requires": [
                     "SpeedBooster",
-                    "canTrickyJump"
+                    "canTrickyJump",
+                    "canWalljump"
                   ],
                   "note": "With a precise enough jump, it's possible to avoid acid damage without a shinespark."
                 }
@@ -599,10 +601,7 @@
                   "name": "Base",
                   "notable": false,
                   "requires": [
-                    {"or":[
-                      "h_canFly",
-                      "HiJump"
-                    ]}
+                    "h_canFly"
                   ]
                 },
                 {
@@ -617,12 +616,22 @@
                 {
                   "name": "Use Frozen Enemies",
                   "notable": false,
-                  "requires": ["canUseFrozenEnemies"]
+                  "requires": ["canUseFrozenEnemies"],
+                  "note": "Use the moving platform (Kamer) to elevate the Gamets and then freeze them."
+                },
+                {
+                  "name": "Hi Jump from Moving Platform",
+                  "notable": false,
+                  "requires": ["HiJump"],
+                  "note": "Run on the moving platform (Kamer)."
                 },
                 {
                   "name": "Post Crocomire Farming Room Speed Jump",
                   "notable": true,
-                  "requires": ["SpeedBooster"],
+                  "requires": [
+                    "SpeedBooster",
+                    "canWalljump"
+                  ],
                   "note": [
                     "Doesn't require opening the bottom right door, even. Just using the available space and jumping late enough.",
                     "It does require killing the Gamets and leaving the drops there so they don't kill your momentum."
@@ -658,9 +667,15 @@
                   "name": "Post Crocomire Farming Room Dboost",
                   "notable": true,
                   "requires": [
+                    "canTrickyJump",
                     "canDamageBoost",
-                    "canTrickyJump"
-                  ]
+                    {"enemyDamage": {
+                      "enemy": "Gamet",
+                      "type": "contact",
+                      "hits": 1
+                    }}
+                  ],
+                  "note": "Use the moving platform (Kamer) to elevate the Gamets."
                 }
               ]
             },
@@ -690,7 +705,28 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": []
+                  "requires": [
+                    {"or":[
+                      "HiJump",
+                      "h_canFly",
+                      "canWalljump"
+                    ]}
+                  ]
+                },
+                {
+                  "name": "Ripper Grapple",
+                  "notable": false,
+                  "requires": [
+                    "canUseEnemies",
+                    "Grapple"
+                  ],
+                  "note": "Involves grappling off a Ripper 2."
+                },
+                {
+                  "name": "Use Frozen Enemies",
+                  "notable": false,
+                  "requires": ["canUseFrozenEnemies"],
+                  "note": "Use the moving platform (Kamer) to elevate the Gamets and then freeze them."
                 }
               ]
             }


### PR DESCRIPTION
Crocomire's Room:
- Add wall jump requirements to strats
- Reduce the acid frames needed to get the item (it's still somewhat lenient)

Post Crocomire Farming Room
- Add wall jump requirements
- Split the tricky hi jump strat to its own
- Add notes to clarify some of the less obvious strats
- Add damage to the d-boost