### PR TITLE
Add Metal Pirates Kill Strats and Move to Link

### DIFF
--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -2940,7 +2940,7 @@
               "framesRemaining": 120,
               "strats": [
                 {
-                  "name": "Kill the Pirates",
+                  "name": "Dead Pirates",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -2949,9 +2949,7 @@
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires": [
-                        {"heatFrames": 50}
-                      ]
+                      "requires": ["never"]
                     }
                   ]
                 },
@@ -2980,12 +2978,12 @@
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires": []
+                      "requires": ["never"]
                     }
                   ]
                 }
               ],
-              "devNote": "The requirements for obstacle A are on the obstacle itself."
+              "devNote": "The requirements for obstacle A are in a strat at node 2."
             }
           ]
         },
@@ -3020,7 +3018,7 @@
               "framesRemaining": 120,
               "strats": [
                 {
-                  "name": "Kill the Pirates",
+                  "name": "Dead Pirates",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -3029,9 +3027,7 @@
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires": [
-                        {"heatFrames": 50}
-                      ]
+                      "requires": ["never"]
                     }
                   ]
                 },
@@ -3055,47 +3051,7 @@
           "id": "A",
           "name": "Metal Pirates",
           "obstacleType": "enemies",
-          "requires": [
-            {"or": [
-              "h_heatProof",
-              "canHeatRun"
-            ]},
-            {"or": [
-              {"and": [
-                "Charge",
-                "Plasma",
-                {"or": [
-                  {"heatFrames": 950},
-                  {"and": [
-                    "Ice",
-                    {"or": [
-                      {"heatFrames": 700},
-                      {"and": [
-                        "Wave",
-                        {"heatFrames": 450}
-                      ]}
-                    ]}
-                  ]}
-                ]}
-              ]},
-              {"and": [
-                "Charge",
-                "Spazer",
-                "Ice",
-                "Wave",
-                {"heatFrames": 1750}
-              ]},
-              {"and": [
-                {"enemyKill":{
-                  "enemies": [
-                    [ "Space Pirate (fighting)", "Space Pirate (fighting)" ]
-                  ],
-                  "explicitWeapons": [ "Super" ]
-                }},
-                {"heatFrames": 450}
-              ]}
-            ]}
-          ]
+          "requires": ["never"]
         }
       ],
       "enemies": [
@@ -3142,11 +3098,188 @@
                   ]
                 }
               ]
+            },
+            {
+              "id": 2,
+              "strats": [
+                {
+                  "name": "Charge Plasma Kill",
+                  "notable": false,
+                  "requires": [],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": [
+                        "h_canNavigateHeatRooms",
+                        "Charge",
+                        "Plasma",
+                        {"or": [
+                          {"heatFrames": 950},
+                          {"and": [
+                            {"or":[
+                              "Ice",
+                              "Wave"
+                            ]},
+                            {"heatFrames": 700}
+                          ]},
+                          {"and": [
+                            "Ice",
+                            "Wave",
+                            {"heatFrames": 450}
+                          ]}
+                        ]}
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Charge Spazer Kill",
+                  "notable": false,
+                  "requires": [],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": [
+                        "h_canNavigateHeatRooms",
+                        "Charge",
+                        "Spazer",
+                        {"or": [
+                          {"heatFrames": 4400},
+                          {"and": [
+                            "Ice",
+                            {"heatFrames": 3000}
+                          ]},
+                          {"and": [
+                            "Wave",
+                            {"heatFrames": 2650}
+                          ]},
+                          {"and": [
+                            "Ice",
+                            "Wave",
+                            {"heatFrames": 1750}
+                          ]}
+                        ]}
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Plasma Kill",
+                  "notable": false,
+                  "requires": [],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": [
+                        "h_canNavigateHeatRooms",
+                        "Plasma",
+                        {"heatFrames": 2000}
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Slow Kill",
+                  "notable": false,
+                  "requires": [],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": [
+                        "h_heatProof",
+                        "Charge",
+                        "Wave"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Very Slow Kill",
+                  "notable": false,
+                  "requires": [],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": [
+                        "h_heatProof",
+                        "canBePatient",
+                        {"or": [
+                          "Spazer",
+                          "Charge"
+                        ]}
+                      ]
+                    }
+                  ],
+                  "note": "Uncharged Spazer does half damage.",
+                  "devNote": "This strat is only for uncharged spazer, or charge with or without ice"
+                },
+                {
+                  "name": "Super Kill",
+                  "notable": false,
+                  "requires": [],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": [
+                        "h_canNavigateHeatRooms",
+                        {"enemyKill":{
+                          "enemies": [
+                            [ "Space Pirate (fighting)", "Space Pirate (fighting)" ]
+                          ],
+                          "explicitWeapons": [ "Super" ]
+                        }},
+                        {"heatFrames": 450}
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Missile Kill",
+                  "notable": false,
+                  "requires": [],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": [
+                        "h_canNavigateHeatRooms",
+                        {"enemyKill":{
+                          "enemies": [
+                            [ "Space Pirate (fighting)", "Space Pirate (fighting)" ]
+                          ],
+                          "explicitWeapons": [ "Missile" ]
+                        }},
+                        {"heatFrames": 2700}
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Speed Echoes Kill",
+                  "notable": false,
+                  "requires": [],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": [
+                        "h_canNavigateHeatRooms",
+                        "canUseSpeedEchoes",
+                        "canHitbox",
+                        {"heatFrames": 450},
+                        {"canShineCharge": {
+                          "usedTiles": 33,
+                          "shinesparkFrames": 18,
+                          "openEnd": 2
+                        }}
+                      ]
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }
       ],
-      "devNote": "All unlock heatframes have been lowered by 250 to adjust for the regular requirement"
+      "devNote": "All kill heatframes have been lowered by 250 to adjust for the traversal requirement"
     },
     {
       "id": 140,


### PR DESCRIPTION
Moved strats to kill metal pirates from the obstacle to a 2->2 link. 
- This allows individual strats to be organized, named, and have notes. 
Added kill strats
- Missiles, shinespark echoes, charged spazer combos, weaker charge beams, and uncharged spazer