### PR TITLE
Add Moat Ceiling Bomb Jump

### DIFF
--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -205,8 +205,13 @@
                 },
                 {
                   "name": "Double Spring Ball Jump",
-                  "notable": true,
+                  "notable": false,
                   "requires": ["canDoubleSpringBallJumpMidAir"]
+                },
+                {
+                  "name": "Moat Ceiling Bomb Jump",
+                  "notable": true,
+                  "requires": ["canCeilingBombJump"]
                 }
               ],
               "note": "Because Moving from 1 to 3 is free, all strats are represented here even if they start at 1."


### PR DESCRIPTION
This relies on #496 and should fix #311 - An easier version of the suggested 1st and 3rd strats are already implemented and this adds the 2nd strat.
Changed the moat double spring ball jump to no longer be notable