### PR TITLE
Add Zebes Awake Flag Throughout

### DIFF
--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -73,7 +73,8 @@
               "note": [
                 "Obstacle requirements not repeated here to avoid duplication.",
                 "It can be destroyed either going 1 -> 6 or 6 -> 1."
-              ]
+              ],
+              "devNote":  "Technically this yields f_ZebesAwake, although it requires the same flag to spawn the enemies, so it's not possible here."
             }
           ]
         },

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -1516,7 +1516,8 @@
                     "Beyond that, the enemies can be killed with Power Beam."
                   ]
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         }
@@ -3083,7 +3084,9 @@
                   "requires": [],
                   "note": "The enemies can be killed with Power Beam"
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ],
+              "devNote":  "This is unlocked and yielded from killing the enemies, which are free to kill"
             }
           ]
         },
@@ -3119,7 +3122,9 @@
                   "requires": [],
                   "note": "The enemies can be killed with Power Beam"
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ],
+              "devNote":  "This is unlocked and yielded from killing the enemies, which are free to kill"
             }
           ]
         }

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -466,7 +466,8 @@
                   ],
                   "note": "This is a softlock if no means to kill Beetoms are available."
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         },
@@ -1024,7 +1025,8 @@
                   ],
                   "note": "Enemies can be killed by going between nodes 1 and 2."
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         },
@@ -1081,7 +1083,8 @@
                   ],
                   "note": "Enemies can be killed by going between nodes 1 and 2."
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         }

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -1219,6 +1219,7 @@
                       "requires": ["never"]
                     }
                   ],
+                  "yields": [ "f_ZebesAwake" ],
                   "note": "To avoid redundant requirements, obstacle must be destroyed by going to 4 and back."
                 }
               ]
@@ -1607,7 +1608,8 @@
                   ],
                   "note": "To avoid redundant requirements, obstacle must be destroyed by going to 3 (possibly via 2) and back."
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         },
@@ -1649,6 +1651,7 @@
                   ]
                 }
               ],
+              "yields": [ "f_ZebesAwake" ],
               "note": "To avoid redundant requirements, obstacle must be destroyed by going to 3 and back."
             }
           ]

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -1219,10 +1219,10 @@
                       "requires": ["never"]
                     }
                   ],
-                  "yields": [ "f_ZebesAwake" ],
                   "note": "To avoid redundant requirements, obstacle must be destroyed by going to 4 and back."
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         },

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -2113,7 +2113,8 @@
                   ],
                   "note": "To avoid redundant requirements, obstacle must be destroyed by going to 3 and back."
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         },

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -2985,6 +2985,7 @@
                   ]
                 }
               ],
+              "yields": [ "f_ZebesAwake" ],
               "devNote": "The requirements for obstacle A are on the obstacle itself."
             }
           ]
@@ -3893,6 +3894,7 @@
                   "note": "The obstacles have requirements of 'never' on the assumption that Samus travels to 7 or 6 and back to unlock the door."
                 }
               ],
+              "yields": [ "f_ZebesAwake" ],
               "devNote": [
                 "In reality, any combination of 5 enemies will unlock the door.",
                 "But this room is way too complicated to try and track all possibilities.",

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -2099,7 +2099,8 @@
                   ],
                   "note": "To avoid redundant requirements, obstacle must be destroyed by going to 2->3->1."
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         },

--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -242,7 +242,6 @@
               ]
             }
           ],
-          "yields": [ "f_KilledMetroidRoom1" ],
           "locks": [
             {
               "name": "Metroid Room 1 Grey Lock (to Metroid Room 2)",
@@ -260,7 +259,10 @@
                   ]
                 }
               ],
-              "yields": [ "f_ZebesAwake" ]
+              "yields": [
+                "f_KilledMetroidRoom1",
+                "f_ZebesAwake" 
+              ]
             }
           ]
         },
@@ -742,7 +744,6 @@
               "openEnd": 1
             }
           ],
-          "yields": [ "f_KilledMetroidRoom2" ],
           "locks": [
             {
               "name": "Metroid Room 2 Grey Lock (to Metroid Room 3)",
@@ -760,7 +761,10 @@
                   ]
                 }
               ],
-              "yields": [ "f_ZebesAwake" ]
+              "yields": [
+                "f_KilledMetroidRoom2",
+                "f_ZebesAwake"
+              ]
             }
           ]
         }
@@ -1102,7 +1106,6 @@
               ]
             }
           ],
-          "yields": [ "f_KilledMetroidRoom3" ],
           "locks": [
             {
               "name": "Metroid Room 3 Grey Lock (to Metroid Room 4)",
@@ -1120,7 +1123,10 @@
                   ]
                 }
               ],
-              "yields": [ "f_ZebesAwake" ]
+              "yields": [
+                "f_KilledMetroidRoom3",
+                "f_ZebesAwake"
+              ]
             }
           ]
         }
@@ -1418,7 +1424,6 @@
           "nodeSubType": "grey",
           "nodeAddress": "0x001a9fc",
           "doorEnvironments": [{"physics": "normal"}],
-          "yields": [ "f_KilledMetroidRoom4" ],
           "locks": [
             {
               "name": "Metroid Room 4 Grey Lock (to Blue Hoppers)",
@@ -1436,7 +1441,10 @@
                   ]
                 }
               ],
-              "yields": [ "f_ZebesAwake" ]
+              "yields": [
+                "f_KilledMetroidRoom4",
+                "f_ZebesAwake"
+              ]
             }
           ]
         }

--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -259,7 +259,8 @@
                     }
                   ]
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         },
@@ -758,7 +759,8 @@
                     }
                   ]
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         }
@@ -1117,7 +1119,8 @@
                     }
                   ]
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         }
@@ -1432,7 +1435,8 @@
                     }
                   ]
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ]
             }
           ]
         }

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -1197,7 +1197,9 @@
                   "requires": ["f_DefeatedPhantoon"],
                   "note": "The enemies are killable using Power Beam, once they actually spawn."
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ],
+              "devNote":  "This is unlocked and yielded from killing the enemies, which are free to kill"
             }
           ]
         },
@@ -1234,7 +1236,9 @@
                   "requires": [],
                   "note": "The enemies are killable using Power Beam, once they actually spawn."
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ],
+              "devNote":  "This is unlocked and yielded from killing the enemies, which are free to kill"
             }
           ]
         },
@@ -1285,7 +1289,9 @@
                   "requires": ["f_DefeatedPhantoon"],
                   "note": "The enemies are killable using Power Beam, once they actually spawn."
                 }
-              ]
+              ],
+              "yields": [ "f_ZebesAwake" ],
+              "devNote":  "This is unlocked and yielded from killing the enemies, which are free to kill"
             }
           ]
         }


### PR DESCRIPTION
This should fix #457.

Add f_ZebesAwake to all rooms except:
- Pit Room - Already had it
- Morph Ball Room - The flag can only be given here if the flag is already set, making it useless. A devNote was added to explain this.

Move f_KilledMetroidRoom1-4 from the node to the lock. Making it actually require killing the metroids. Technically this could still be a problem if a hack both ignores grey door locks and requires the metroid flags. However, this should be in a much better place than it was before.