### PR TITLE
Add canConsecutiveWalljump throughout Zebes

### DIFF
--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -1143,7 +1143,7 @@
                   "requires": [
                     "Morph",
                       {"or": [
-                        "canWalljump",
+                        "canConsecutiveWalljump",
                         "h_canFly"
                       ]}
                   ], 
@@ -1165,7 +1165,7 @@
                   "requires": [
                     "h_canUsePowerBombs",
                       {"or": [
-                        "canWalljump",
+                        "canConsecutiveWalljump",
                         "h_canFly"
                       ]}
                   ],

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -787,7 +787,7 @@
                 {
                   "name": "Full Etecoon Walljump Climb",
                   "notable": true,
-                  "requires": ["canWalljump"],
+                  "requires": ["canConsecutiveWalljump"],
                   "note": "Not quite the full climb, but close enough."
                 },
                 {

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -406,12 +406,12 @@
                     {"or":[
                       "SpaceJump",
                       {"and": [
-                          "HiJump",
-                          "SpeedBooster"
-                        ]},
+                        "HiJump",
+                        "SpeedBooster"
+                      ]},
                       {"and": [
                         "HiJump",
-                        "canWalljump"
+                        "canConsecutiveWalljump"
                       ]}
                     ]}
                   ]

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -573,7 +573,13 @@
                 {
                   "name": "Gauntlet Walljumps",
                   "notable": true,
-                  "requires": ["canDelayedWalljump"]
+                  "requires": [
+                    "canDelayedWalljump",
+                    {"or": [
+                      "HiJump",
+                      "canConsecutiveWalljump"
+                    ]}
+                  ]
                 }
               ]
             }
@@ -1190,7 +1196,11 @@
                   "notable": true,
                   "requires": [
                     "Morph",
-                    "canPreciseWalljump"
+                    "canPreciseWalljump",
+                    {"or": [
+                      "HiJump",
+                      "canConsecutiveWalljump"
+                    ]}
                   ]
                 },
                 {

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -1573,6 +1573,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "Gravity",
+                    "canConsecutiveWalljump",
                     {"heatFrames": 800},
                     {"acidFrames": 650}
                   ]
@@ -1584,6 +1585,7 @@
                     "h_canNavigateHeatRooms",
                     "HiJump",
                     "canSuitlessLavaDive",
+                    "canConsecutiveWalljump",
                     {"heatFrames": 950},
                     {"acidFrames": 800}
                   ]
@@ -6030,7 +6032,7 @@
                 {
                   "name": "Lower Norfair Fireflea Hjless Walljump",
                   "notable": true,
-                  "requires": ["canWalljump"],
+                  "requires": ["canConsecutiveWalljump"],
                   "devNote": "Left as its own, notable strat because it can be kind of tricky."
                 }
               ]

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -6032,7 +6032,10 @@
                 {
                   "name": "Lower Norfair Fireflea Hjless Walljump",
                   "notable": true,
-                  "requires": ["canConsecutiveWalljump"],
+                  "requires": [
+                    "canConsecutiveWalljump",
+                    "canPreciseWalljump"
+                  ],
                   "devNote": "Left as its own, notable strat because it can be kind of tricky."
                 }
               ]

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -1005,10 +1005,6 @@
           ]
         },
         {
-          "from": 2,
-          "to": []
-        },
-        {
           "from": 3,
           "to": [
             {
@@ -1224,7 +1220,10 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["Gravity"]
+                  "requires": [
+                    "Gravity",
+                    "canConsecutiveWalljump"
+                  ]
                 },
                 {
                   "name": "Suitless",
@@ -1232,7 +1231,8 @@
                   "requires": [
                     "canSuitlessMaridia",
                     "SpaceJump",
-                    "HiJump"
+                    "HiJump",
+                    "canConsecutiveWalljump"
                   ],
                   "note": "SpaceJump is needed to break free of the water."
                 }

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -710,7 +710,10 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["Gravity"]
+                  "requires": [
+                    "Gravity",
+                    "canConsecutiveWalljump"
+                  ]
                 },
                 {
                   "name": "Grapple Jump",
@@ -2022,7 +2025,13 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["Gravity"]
+                  "requires": [
+                    "Gravity",
+                    {"or": [
+                      "HiJump",
+                      "canConsecutiveWalljump"
+                    ]}
+                  ]
                 },
                 {
                   "name": "Shinespark",
@@ -2073,7 +2082,16 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["Gravity"]
+                  "requires": [
+                    "Gravity",
+                    {"or": [
+                      "canWalljump",
+                      {"and": [
+                        "HiJump",
+                        "SpeedBooster"
+                      ]}
+                    ]}
+                  ]
                 },
                 {
                   "name": "Shinespark",
@@ -2409,8 +2427,14 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["Gravity"],
-                  "note" : "While that one walljump bear the end is a bit precise, it does not require a delayed walljump and so it is not considered a trickyWalljump."
+                  "requires": [
+                    "Gravity",
+                    {"or": [
+                      "HiJump",
+                      "canConsecutiveWalljump"
+                    ]}
+                  ],
+                  "note" : "While that one walljump near the end is a bit precise, it does not require a delayed walljump."
                 },
                 {
                   "name": "Space Jump",
@@ -2489,7 +2513,13 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["Gravity"]
+                  "requires": [
+                    "Gravity",
+                    {"or": [
+                      "HiJump",
+                      "canConsecutiveWalljump"
+                    ]}
+                  ]
                 },
                 {
                   "name": "Space Jump",
@@ -3722,7 +3752,8 @@
                   "notable": true,
                   "requires": [
                     "canPreciseWalljump",
-                    "Gravity"
+                    "Gravity",
+                    "canConsecutiveWalljump"
                   ]
                 },
                 {

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -879,8 +879,19 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [ "canConsecutiveWalljump" ],
-                  "devNote": "This should require something more to kill the Choot."
+                  "requires": [
+                    "canConsecutiveWalljump",
+                    {"or": [
+                      "canPreciseWalljump",
+                      "ScrewAttack",
+                      "h_canUsePowerBombs",
+                      {"enemyDamage": {
+                        "enemy": "Choot",
+                        "type": "contact",
+                        "hits": 1
+                      }}
+                    ]}
+                  ]
                 }
               ]
             }
@@ -1667,14 +1678,17 @@
                   "name": "Shinespark",
                   "notable": false,
                   "requires": [
-                    "canWalljump",
+                    {"or": [
+                      "HiJump",
+                      "canWalljump"
+                    ]},
                     {"canComeInCharged": {
                       "fromNode": 1,
                       "framesRemaining": 60,
                       "shinesparkFrames": 45
                     }}
                   ],
-                  "note": "One walljump on the left before a diagonal spark."
+                  "note": "Use Hijump or one walljump on the left before a diagonal spark."
                 }
               ],
               "note": "Only the the direct shinespark. Other strats should go 1 -> 2 -> 3."
@@ -1707,8 +1721,11 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      "HiJump",
                       "canConsecutiveWalljump"
+                      {"and":[
+                        "HiJump",
+                        "canWalljump"
+                      ]}
                     ]},
                     {"enemyKill":{
                       "enemies": [

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -879,7 +879,8 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": []
+                  "requires": [ "canConsecutiveWalljump" ],
+                  "devNote": "This should require something more to kill the Choot."
                 }
               ]
             }

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -854,7 +854,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": []
+                  "requires": [ "canConsecutiveWalljump" ]
                 }
               ]
             }
@@ -1666,6 +1666,7 @@
                   "name": "Shinespark",
                   "notable": false,
                   "requires": [
+                    "canWalljump",
                     {"canComeInCharged": {
                       "fromNode": 1,
                       "framesRemaining": 60,
@@ -1704,6 +1705,10 @@
                   "name": "Kill Rippers",
                   "notable": false,
                   "requires": [
+                    {"or": [
+                      "HiJump",
+                      "canConsecutiveWalljump"
+                    ]},
                     {"enemyKill":{
                       "enemies": [
                         [
@@ -1716,7 +1721,10 @@
                 {
                   "name": "Maridia Elevator Room Wall Climb",
                   "notable": true,
-                  "requires": ["canPreciseWalljump"],
+                  "requires": [
+                    "canPreciseWalljump",
+                    "canConsecutiveWalljump"
+                  ],
                   "note": "The walljumps are considered to require precision only if the Rippers are not killed"
                 },
                 {

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -1624,8 +1624,7 @@
                   "requires": [
                     "canUseFrozenEnemies",
                     "canManipulateMellas",
-                    "HiJump",
-                    "canConsecutiveWalljump"
+                    "HiJump"
                   ],
                   "obstacles": [
                     {

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -967,7 +967,7 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      "canWalljump",
+                      "canConsecutiveWalljump",
                       "h_canFly"
                     ]}
                   ]
@@ -1624,7 +1624,8 @@
                   "requires": [
                     "canUseFrozenEnemies",
                     "canManipulateMellas",
-                    "HiJump"
+                    "HiJump",
+                    "canConsecutiveWalljump"
                   ],
                   "obstacles": [
                     {
@@ -1644,7 +1645,8 @@
                   "requires": [
                     "canUseFrozenEnemies",
                     "canManipulateMellas",
-                    "canBePatient"
+                    "canBePatient",
+                    "canConsecutiveWalljump"
                   ],
                   "obstacles": [
                     {
@@ -1664,7 +1666,10 @@
                   "requires": [
                     "Morph",
                     "canMellaIceClip",
-                    "canWalljump"
+                    {"or":[
+                      "HiJump",
+                      "canConsecutiveWalljump"
+                    ]}
                   ],
                   "note": [
                     "Position the frozen Mella such that you can ice clip through the crumble block, then wall jump up the long channel and mid air morph to get out."

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -1667,8 +1667,11 @@
                     "Morph",
                     "canMellaIceClip",
                     {"or":[
-                      "HiJump",
-                      "canConsecutiveWalljump"
+                      "canConsecutiveWalljump",
+                      {"and":[
+                        "HiJump",
+                        "canWalljump"
+                      ]}
                     ]}
                   ],
                   "note": [

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -2196,7 +2196,10 @@
                 {
                   "name": "Bubble Mountain Delayed Walljump (Right)",
                   "notable": true,
-                  "requires": ["canDelayedWalljump"],
+                  "requires": [
+                    "canDelayedWalljump",
+                    "canConsecutiveWalljump"
+                  ],
                   "note": "A tricky, delayed walljump makes it possible to climb to top right in-room, with nothing."
                 },
                 {
@@ -3726,7 +3729,13 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canWalljump",
+                    {"or":[
+                      "canConsecutiveWalljump",
+                      {"and": [
+                        "HiJump",
+                        "canWalljump"
+                      ]}
+                    ]}
                     {"heatFrames": 250}
                   ]
                 },

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -2261,6 +2261,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "HiJump",
+                    "canConsecutiveWalljump",
                     {"heatFrames": 500}
                   ],
                   "note": "Walljump up the right, then setup a walljump on the top-right crumble platform directly from the right wall."
@@ -2271,6 +2272,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "canPreciseWalljump",
+                    "canConsecutiveWalljump",
                     {"heatFrames": 500}
                   ],
                   "note": "Walljump up the right, then walljump off the top-middle crumble platform then off the top-right one."
@@ -2291,6 +2293,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "canCrumbleJump",
+                    "canConsecutiveWalljump",
                     {"heatFrames": 600}
                   ],
                   "note": "Walljump up the right then do one crumble jump on the top middle platform."
@@ -2306,14 +2309,25 @@
                   "note": "Do 9 successive spring ball bounces up the platforms."
                 },
                 {
+                  "name": "Wall Jump with Space Jump",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "SpaceJump",
+                    "canConsecutiveWalljump",
+                    {"heatFrames": 500}
+                  ],
+                  "note": "Walljump up the right, then use SpaceJump at the top."
+                },
+                {
                   "name": "Space Jump",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "SpaceJump",
-                    {"heatFrames": 500}
+                    {"heatFrames": 1000}
                   ],
-                  "note": "Walljump up the right, then use SpaceJump at the top."
+                  "note": "Use SpaceJump to get to the top."
                 },
                 {
                   "name": "Crumble Shaft IBJ",
@@ -2355,6 +2369,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "canUseFrozenEnemies",
+                    "canConsecutiveWalljump",
                     {"heatFrames": 800}
                   ],
                   "note": "Climb up the left, freeze the top-left Sova, and use it as a platform to reach the door."
@@ -2390,6 +2405,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
+                    "canConsecutiveWalljump",
                     {"heatFrames": 550}
                   ]
                 }

--- a/tech.json
+++ b/tech.json
@@ -343,7 +343,7 @@
               "requires": [
                 "canWalljump"
               ],
-              "note" : "Climbing a wall with several consecutive walljumps.",
+              "note" : "Climbing a wall with three or more consecutive walljumps, where a single failure will require restarting.",
               "extensionTechs": [
                 {
                   "name": "canFastWalljumpClimb",

--- a/tech.json
+++ b/tech.json
@@ -38,7 +38,7 @@
               "requires": [
                 "canSuitlessMaridia",
                 "HiJump",
-                "canWalljump"
+                "canConsecutiveWalljump"
               ],
               "note": "Using a series of rapid, consecutive wall jumps underwater, on two nearby walls, to climb upwards.",
               "extensionTechs": [
@@ -320,7 +320,10 @@
                   "extensionTechs": [
                     {
                       "name": "canInsaneWalljump",
-                      "requires": [ "canDelayedWalljump" ],
+                      "requires": [
+                        "canDelayedWalljump",
+                        "canConsecutiveWalljump"
+                      ],
                       "note": "For delayed walljumps that require extreme precision, in the vicinity of pixel+frame perfect."
                     }
                   ]

--- a/tech.json
+++ b/tech.json
@@ -320,10 +320,7 @@
                   "extensionTechs": [
                     {
                       "name": "canInsaneWalljump",
-                      "requires": [
-                        "canDelayedWalljump",
-                        "canConsecutiveWalljump"
-                      ],
+                      "requires": [ "canDelayedWalljump" ],
                       "note": "For delayed walljumps that require extreme precision, in the vicinity of pixel+frame perfect."
                     }
                   ]
@@ -343,7 +340,7 @@
               "requires": [
                 "canWalljump"
               ],
-              "note" : "Climbing a wall with three or more consecutive walljumps, where a single failure will require restarting.",
+              "note" : "Climbing a wall with three or more consecutive walljumps without a mistake.",
               "extensionTechs": [
                 {
                   "name": "canFastWalljumpClimb",


### PR DESCRIPTION
- Update the description to be anywhere that requires 3+ consecutive wall jumps.
- It is now required for canSunkenDualWallClimb and canInsaneWalljump.