### PR TITLE
Add Strats in Crumble Shaft

### DIFF
--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -2341,6 +2341,7 @@
                   ],
                   "note": [
                     "Kill the Sova on the bottom-right platform, then IBJ right next to the left of the platform.",
+                    "Samus can align with the left side of the platform by jumping into it.",
                     "Changing the IBJ speed may be necessary to get past the second Sova."
                   ]
                 },
@@ -2353,6 +2354,7 @@
                   ],
                   "note": [
                     "Kill the Sova on the bottom-right platform, then IBJ right next to the left of the platform.",
+                    "Samus can align with the left side of the platform by jumping into it.",
                     "Place bombs to kill the second Sova. Drop to the bottom and restart if necessary."
                   ]
                 },
@@ -2454,7 +2456,7 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged":{
                       "fromNode": 2,
-                      "framesRemaining": 60,
+                      "framesRemaining": 30,
                       "shinesparkFrames": 59
                     }},
                     {"heatFrames": 250}

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -2243,7 +2243,7 @@
                     "h_canUseSpringBall",
                     {"heatFrames": 200}
                   ],
-                  "note": "Shoot the shot block, the Spring Ball on the middle platform."
+                  "note": "Shoot the shot block, then Spring Ball on the middle platform."
                 }
               ],
               "note": "If none of the strats can be done, falling down to 2 and going back up to the item may still be doable."
@@ -2331,14 +2331,30 @@
                   "note": "Use SpaceJump to get to the top."
                 },
                 {
-                  "name": "Crumble Shaft IBJ",
+                  "name": "Crumble Shaft IBJ (Right)",
                   "notable": true,
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "canIBJ",
+                    "canStaggeredIBJ",
                     {"heatFrames": 4000}
                   ],
-                  "note": "Kill the two Sovas on right-side platforms, then IBJ right next to those platforms."
+                  "note": [
+                    "Kill the Sova on the bottom-right platform, then IBJ right next to the left of the platform.",
+                    "Changing the IBJ speed may be necessary to get past the second Sova."
+                  ]
+                },
+                {
+                  "name": "Heatproof Crumble Shaft IBJ",
+                  "notable": false,
+                  "requires": [
+                    "h_heatProof",
+                    "canIBJ"
+                  ],
+                  "note": [
+                    "Kill the Sova on the bottom-right platform, then IBJ right next to the left of the platform.",
+                    "Place bombs to kill the second Sova. Drop to the bottom and restart if necessary."
+                  ]
                 },
                 {
                   "name": "Crumble Shaft Springwall",
@@ -2346,6 +2362,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "canSpringwall",
+                    "canConsecutiveWalljump",
                     {"heatFrames": 500}
                   ],
                   "note": "Walljump up the right then do a springwall to get around the top right crumble platform."
@@ -2362,7 +2379,7 @@
                     }},
                     {"heatFrames": 250}
                   ],
-                  "note": "It has to be setup really close to the right platforms, else it requires a crumble jump too."
+                  "note": "It has to be setup really close to the left side of the right platforms, otherwise it also requires a crumble jump at the top."
                 },
                 {
                   "name": "Crumble Shaft Frozen Climb",
@@ -2409,6 +2426,40 @@
                     "canConsecutiveWalljump",
                     {"heatFrames": 550}
                   ]
+                },
+                {
+                  "name": "Crumble Shaft IBJ (Left)",
+                  "notable": true,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "canIBJ",
+                    "canStaggeredIBJ",
+                    {"heatFrames": 4000}
+                  ],
+                  "note": "IBJ against the left-most wall. Changing the IBJ speed may be necessary to get past the Sova."
+                },
+                {
+                  "name": "Heatproof Crumble Shaft IBJ",
+                  "notable": false,
+                  "requires": [
+                    "h_heatProof",
+                    "canIBJ"
+                  ],
+                  "note": "IBJ against the left-most wall. Place bombs to kill the Sova. Drop to the bottom and restart if necessary."
+                },
+                {
+                  "name": "Crumble Shaft Shinespark Climb",
+                  "notable": true,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    {"canComeInCharged":{
+                      "fromNode": 2,
+                      "framesRemaining": 60,
+                      "shinesparkFrames": 59
+                    }},
+                    {"heatFrames": 250}
+                  ],
+                  "note": "It is easiest to do a diagonal shinespark up the left wall, then hold left, angle down, and spam shoot to easily grab the item."
                 }
               ]
             }


### PR DESCRIPTION
- Make notes more clear and tech more accurate.
- Add strats to get to the item on the left side.