### PR TITLE
Add obstaclesCleared requirement

### DIFF
--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -267,10 +267,21 @@
             "title": "Thorn Hits",
             "description": "Fulfilled by spending an amount of energy that corresponds to taking a number of hits from thorns (the less damaging spikes found mainly in Brinstar)."
           },
+          "obstaclesCleared": {
+            "$id": "#/definitions/logicalRequirement/items/properties/obstaclesCleared",
+            "type": "array",
+            "title": "Obstacles Cleared",
+            "description": "Fulfilled by having all of the listed obstacles already cleared",
+            "items": {
+              "$id": "#/definitions/logicalRequirement/items/properties/obstaclesCleared/items",
+              "type": "string",
+              "minItems": 1,
+            }
+          },
           "resourceCapacity": {
             "$id": "#/definitions/logicalRequirement/items/properties/resourceCapacity",
             "type": "array",
-            "title": "Resource Capacity Requirement",
+            "title": "Resource Capacity",
             "description": "Fulfilled by having at least the maximum capacity for all given resource types",
             "items": {
               "$id": "#/definitions/logicalRequirement/items/properties/resourceCapacity/items",


### PR DESCRIPTION
Sometimes we want to be able to represent a requirement for an obstacle to already be cleared. In strats we have been doing this by having an "obstacles" field with `requires: ["never"]`, but this doesn't work in some other places where logical requirements may appear (such as in "farmCycles"). By adding obstaclesCleared as a first-class requirement type, we can use it anywhere.