### PR TITLE
Add precise wall jumps and modernize logic

### DIFF
--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -1211,7 +1211,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["h_canPassBombPassages"]
+                  "requires": [ "h_canBombThings" ]
                 },
                 {
                   "name": "Early Supers Quick Crumble Escape (Dual Quick Crumble)",
@@ -1287,7 +1287,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["h_canPassBombPassages"]
+                  "requires": [ "h_canBombThings" ]
                 }
               ]
             }
@@ -1327,7 +1327,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["h_canPassBombPassages"]
+                  "requires": [ "h_canBombThings" ]
                 }
               ]
             }
@@ -1453,7 +1453,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["h_canPassBombPassages"]
+                  "requires": [ "h_canBombThings" ]
                 },
                 {
                   "name": "Brinstar Reserve Hole-in-One",
@@ -1564,7 +1564,7 @@
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires":["h_canPassBombPassages"]
+                      "requires":[ "h_canBombThings" ]
                     }
                   ],
                   "note": [
@@ -1622,7 +1622,7 @@
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires":["h_canPassBombPassages"]
+                      "requires":[ "h_canBombThings" ]
                     }
                   ]
                 }
@@ -1643,7 +1643,7 @@
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires":["h_canPassBombPassages"]
+                      "requires":[ "h_canBombThings" ]
                     }
                   ]
                 }
@@ -3005,13 +3005,14 @@
                 },
                 {
                   "name": "Green Hill Zone Walljump",
-                  "notable": true,
-                  "requires": ["canWalljump"]
+                  "notable": false,
+                  "requires": [ "canPreciseWalljump" ],
+                  "note": "Wall jump on the top half of the Geega pipe, then on the overhang."
                 },
                 {
                   "name": "Use Frozen Enemy",
                   "notable": false,
-                  "requires": ["canUseFrozenEnemies"]
+                  "requires": [ "canUseFrozenEnemies" ]
                 }
               ]
             },

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -523,6 +523,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
+                    "canPreciseWalljump",
                     {"heatFrames": 400}
                   ],
                   "obstacles": [
@@ -2312,13 +2313,8 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "Morph",
-                    {"heatFrames": 120}
-                  ],
-                  "obstacles": [
-                    {
-                      "id": "B",
-                      "requires": ["never"]
-                    }
+                    {"heatFrames": 120},
+                    {"obstaclesCleared": ["B"]}
                   ],
                   "note": [
                     "It's not possible to reach node 3 without destroying obstacle B.",
@@ -2752,20 +2748,14 @@
                   "notable": false,
                   "requires": [
                     "h_heatProof",
-                    "Morph",
-                    "h_canUsePowerBombs",
-                    {"or":[
-                      "Bombs",
-                      {"ammo": {
-                        "type": "PowerBomb",
-                        "count": 1
-                      }}
-                    ]}
+                    "h_canBombThings",
+                    "h_canUsePowerBombs"
                   ],
-                  "devNote": [
+                  "note": [
                     "The hibashi hit can be avoided by waiting for the pillar to go up.",
                     "That requires the use of one PB and more time than is worth unless heat proof."
-                  ]
+                  ],
+                  "devNote": "Note that if using PBs, two is required. One each from h_canBombThings, h_canUsePowerBombs."
                 },
                 {
                   "name": "Morph Bombs",
@@ -2971,13 +2961,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [],
-                  "obstacles": [
-                    {
-                      "id": "A",
-                      "requires": ["never"]
-                    }
-                  ]
+                  "requires": [ {"obstaclesCleared": ["A"]} ]
                 }
               ],
               "yields": [ "f_ZebesAwake" ],
@@ -3121,13 +3105,8 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 200}
-                  ],
-                  "obstacles": [
-                    {
-                      "id": "A",
-                      "requires": ["never"]
-                    }
+                    {"heatFrames": 200},
+                    {"obstaclesCleared": ["A"]}
                   ]
                 },
                 {
@@ -4112,15 +4091,9 @@
                 {
                   "name": "Kill 5 Multiviolas",
                   "notable": false,
-                  "requires": [],
-                  "obstacles": [
-                    {
-                      "id": "D",
-                      "requires": [ "never" ]
-                    }
-                  ],
+                  "requires": [ {"obstaclesCleared": ["D"]} ],
                   "note": [
-                    "The Multiviolas are far away and can't be killed from here, hence the local requirement of 'never'.",
+                    "The Multiviolas are far away and can't be killed from here, hence the obstacle requirement.",
                     "The only path through this room where killing them and leaving here would be meaningful would have passed through node 4 at some point.",
                     "So this strat is only doable by killing the Multiviolas when going 4 -> 6."
                   ]
@@ -4128,18 +4101,11 @@
                 {
                   "name": "Kill Bottom Left",
                   "notable": false,
-                  "requires": [],
-                  "obstacles": [
-                    {
-                      "id": "C",
-                      "requires": ["never"]
-                    },
-                    {
-                      "id": "E",
-                      "requires": ["never"]
-                    }
+                  "requires": [
+                    {"obstaclesCleared": ["C"]},
+                    {"obstaclesCleared": ["E"]}
                   ],
-                  "note": "The obstacles have requirements of 'never' on the assumption that Samus travels to 7 or 6 and back to unlock the door."
+                  "note": "The obstacles must already be cleared on the assumption that Samus travels to 7 or 6 and back to unlock the door."
                 }
               ],
               "yields": [ "f_ZebesAwake" ],
@@ -4410,13 +4376,7 @@
                 {
                   "name": "Multiviola Already Dead",
                   "notable": false,
-                  "requires": [],
-                  "obstacles": [
-                    {
-                      "id": "E",
-                      "requires": ["never"]
-                    }
-                  ]
+                  "requires": [ {"obstaclesCleared": ["E"]} ]
                 }
               ]
             }
@@ -5125,7 +5085,8 @@
                       "shinesparkFrames": 0,
                       "openEnd": 0
                     }},
-                    {"heatFrames": 250}
+                    {"heatFrames": 250},
+                    {"obstaclesCleared": ["F"]}
                   ],
                   "obstacles": [
                     {
@@ -5135,10 +5096,6 @@
                     {
                       "id": "E",
                       "requires": []
-                    },
-                    {
-                      "id": "F",
-                      "requires": ["never"]
                     }
                   ],
                   "note": [
@@ -5162,12 +5119,11 @@
                 {
                   "name": "HeatProof Kill",
                   "notable": false,
-                  "requires": ["h_heatProof"],
+                  "requires": [
+                    "h_heatProof",
+                    {"obstaclesCleared": ["F"]}
+                  ],
                   "obstacles": [
-                    {
-                      "id": "F",
-                      "requires": ["never"]
-                    },
                     {
                       "id": "C",
                       "requires": [

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -2316,7 +2316,7 @@
                     {"heatFrames": 120},
                     {"obstaclesCleared": ["B"]}
                   ],
-                  "note": [
+                  "devNote": [
                     "It's not possible to reach node 3 without destroying obstacle B.",
                     "So no need to elaborate on how it can be destroyed from here and how many heat frames it would take."
                   ]
@@ -4092,7 +4092,7 @@
                   "name": "Kill 5 Multiviolas",
                   "notable": false,
                   "requires": [ {"obstaclesCleared": ["D"]} ],
-                  "note": [
+                  "devNote": [
                     "The Multiviolas are far away and can't be killed from here, hence the obstacle requirement.",
                     "The only path through this room where killing them and leaving here would be meaningful would have passed through node 4 at some point.",
                     "So this strat is only doable by killing the Multiviolas when going 4 -> 6."
@@ -4105,7 +4105,7 @@
                     {"obstaclesCleared": ["C"]},
                     {"obstaclesCleared": ["E"]}
                   ],
-                  "note": "The obstacles must already be cleared on the assumption that Samus travels to 7 or 6 and back to unlock the door."
+                  "devNote": "The obstacles must already be cleared on the assumption that Samus travels to 7 or 6 and back to unlock the door."
                 }
               ],
               "yields": [ "f_ZebesAwake" ],


### PR DESCRIPTION
Add canPreciseWalljump:
- Green Hill Zone: 1->2
- Fast Pillars Setup Room: 5->1

Modernize some of the code in these two files (LN East, Green Brinstar):
- h_canPassBombPassages -> h_canBombThings
- Replace obstacles with "never" with requires with "obstaclesCleared"
- Ensure bombs and power bomb usage is replaced with their helpers, where applicable.