### PR TITLE
Shine schema update

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -289,6 +289,7 @@ A `canComeInCharged` object represents the need to charge a shinespark in an adj
 * _inRoomPath:_ An array that indicates the path of node IDs that the player should travel, up to and including the node where the `adjacentRunway` logical element is, in order to be able to used the adjacent runway. If this is missing, the player is expected to enter the room at the current node and not move from there.
 * _framesRemaining:_ Indicates the minimum number of frames Samus needs to have left, upon entering the room, before the shinespark charge expires. A value of 0 indicates that shinesparking through the door works.
 * _shinesparkFrames:_ Indicates how many frames the shinespark that will be used lasts. This can be 0 in cases where only the blue suit is needed. During a shinespark, Samus is damaged by 1 every frame, and being able to spend that health is part of of being able to fulfill a `canComeInCharged` object.
+* _excessShinesparkFrames:_ Indicates how far beyond a breakable wall or ledge a shinespark will travel, in terms of frames.  This enables shinesparking at a lower health value but will still cost the full `shinesparkFrames` value if that health can be paid.
 
 __Example:__
 ```json
@@ -322,6 +323,7 @@ A `canShineCharge` object represents the need for Samus to be able to charge a s
   * _startingDownTiles:_  Indicates how many tiles slope downwards at the expected start of the running space. A stutter can't be executed on those tiles.
 * _openEnd:_ Any runway that is used to gain momentum has two ends. An open end is when a platform drops off into nothingness, as opposed to ending against a wall. Since those offer a bit more room, this property indicates the number of open ends that are available for charging (between 0 and 2).
 * _shinesparkFrames:_ Indicates how many frames the shinespark that will be used lasts. This can be 0 in cases where only the blue suit is needed. During a shinespark, Samus is damaged by 1 every frame, and being able to spend that health is part of of being able to fulfill a `canShineCharge` object.
+* _excessShinesparkFrames:_ Indicates how far beyond a breakable wall or ledge a shinespark will travel, in terms of frames.  This enables shinesparking at a lower health value but will still cost the full `shinesparkFrames` value if that health can be paid.
 
 __Example:__
 ```json

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -392,8 +392,9 @@
                     {"canComeInCharged": {
                       "fromNode": 3,
                       "framesRemaining": 180,
-                      "shinesparkFrames": 125
-                    }}
+                      "shinesparkFrames": 125,
+                      "excessShinesparkFrames": 33
+                     }}
                   ],
                   "obstacles": [
                     {
@@ -458,6 +459,7 @@
                       "steepUpTiles": 2,
                       "steepDownTiles": 1,
                       "shinesparkFrames": 125,
+                      "excessShinesparkFrames": 33,
                       "openEnd": 2
                     }}
                   ],
@@ -466,6 +468,31 @@
                       "id": "A",
                       "requires": []
                     }
+                  ]
+                },
+                {
+                  "name": "Big Jump Midair Shinespark",
+                  "notable": false,
+                  "requires": [
+                    "canConserveShinesparkHealthComplex",
+                    {"canShineCharge": {
+                      "usedTiles": 19,
+                      "steepUpTiles": 2,
+                      "steepDownTiles": 1,
+                      "shinesparkFrames": 95,
+                      "excessShinesparkFrames": 33,
+                      "openEnd": 2
+                    }}
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": []
+                    }
+                  ],
+                  "note": 
+                  ["Store the spark on the right side of the ledge.  Run left and do a big jump towards the gauntlet door and then midair spark at the right time.",
+                   "The lines in the background make for a good way to measure your height."
                   ]
                 },
                 {
@@ -511,6 +538,7 @@
                       "steepUpTiles": 2,
                       "steepDownTiles": 1,
                       "shinesparkFrames": 45,
+                      "excessShinesparkFrames": 13,
                       "openEnd": 2
                     }}
                   ]
@@ -552,6 +580,7 @@
                     {"canShineCharge": {
                       "usedTiles": 33,
                       "shinesparkFrames": 75,
+                      "excessShinesparkFrames": 10,
                       "openEnd": 2
                     }}
                   ]

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -424,6 +424,13 @@
                 "minimum": 0,
                 "title": "Shinespark Frames",
                 "description": "The duration (in frames) of the shinespark that must be executed. This defines the energy cost of the shinespark."
+              },
+              "excessShinesparkFrames": {
+                "$id": "#/definitions/logicalRequirement/items/properties/canComeInCharged/properties/excessShinesparkFrames",
+                "type": "integer",
+                "minimum": 0,
+                "title": "Excess Shinespark Frames",
+                "description": "The shinespark duration (in frames) that is not required to complete the objective of the shinespark.  With shinesparkFrames as the expected cost, this defines the lower limit of the shinespark energy cost."
               }
             }
           },
@@ -496,6 +503,13 @@
                 "minimum": 0,
                 "title": "Shinespark Frames",
                 "description": "The duration (in frames) of the shinespark that must be executed. This defines the energy cost of the shinespark."
+              },
+              "excessShinesparkFrames": {
+                "$id": "#/definitions/logicalRequirement/items/properties/canShineCharge/properties/excessShinesparkFrames",
+                "type": "integer",
+                "minimum": 0,
+                "title": "Excess Shinespark Frames",
+                "description": "The shinespark duration (in frames) that is not required to complete the objective of the shinespark.  With shinesparkFrames as the expected cost, this defines the lower limit of the shinespark energy cost."
               }
             }
           },

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -430,7 +430,7 @@
                 "type": "integer",
                 "minimum": 0,
                 "title": "Excess Shinespark Frames",
-                "description": "The shinespark duration (in frames) that is not required to complete the objective of the shinespark.  With shinesparkFrames as the expected cost, this defines the lower limit of the shinespark energy cost."
+                "description": "The shinespark duration (in frames) that is not required to complete the objective of the shinespark.  Subtracting this from the shinesparkFrames defines the lower limit of the shinespark energy cost."
               }
             }
           },
@@ -509,7 +509,7 @@
                 "type": "integer",
                 "minimum": 0,
                 "title": "Excess Shinespark Frames",
-                "description": "The shinespark duration (in frames) that is not required to complete the objective of the shinespark.  With shinesparkFrames as the expected cost, this defines the lower limit of the shinespark energy cost."
+                "description": "The shinespark duration (in frames) that is not required to complete the objective of the shinespark. Subtracting this from the shinesparkFrames defines the lower limit of the shinespark energy cost."
               }
             }
           },

--- a/tech.json
+++ b/tech.json
@@ -742,7 +742,7 @@
             "canShinespark", 
             "canMidairShinespark"
           ],
-          "note": "The ability to jump closer to the shinespark target with simple vertical jumps or a midair shinespark.  Trading shinespark charge timer for health savings.",
+          "note": "The ability to jump a little  closer to the shinespark target with simple vertical jumps or a midair shinespark.  Trading shinespark charge timer for health savings.",
           "extensionTechs": [
             {
               "name": "canConserveShinesparkHealthComplex",

--- a/tech.json
+++ b/tech.json
@@ -732,29 +732,43 @@
             {
               "name": "canMidairShinespark",
               "requires": ["canShinespark"],
-              "note": "The ability to jump before shinesparking vertically, horizontally, or diagonally"
-            }
-          ]
-        },
-        {
-          "name": "canConserveShinesparkHealth",
-          "requires": [ 
-            "canShinespark", 
-            "canMidairShinespark"
-          ],
-          "note": "The ability to jump a little  closer to the shinespark target with simple vertical jumps or a midair shinespark.  Trading shinespark charge timer for health savings.",
-          "extensionTechs": [
+              "note": "The ability to jump before shinesparking vertically, horizontally, or diagonally",
+              "extensionTechs": [
+                {
+                  "name": "canConserveShinesparkHealth",
+                  "requires": [ "canMidairShinespark" ],
+                  "note": "The ability to jump a little  closer to the shinespark target with simple vertical jumps or a midair shinespark.  Trading shinespark charge timer for health savings.",
+                  "extensionTechs": [
+                    {
+                      "name": "canConserveShinesparkHealthComplex",
+                      "requires": [ "canConserveShinesparkHealth" ],
+                      "note": "The ability to make multiple movement actions with a shinespark charge timer running in order to save a larger amount of health."
+                    }
+                  ]
+                }
+              ]
+            },
             {
-              "name": "canConserveShinesparkHealthComplex",
-              "requires": [ "canConserveShinesparkHealth" ],
-              "note": "The ability to make multiple movement actions with a shinespark charge timer running in order to save a larger amount of health."
+              "name": "canUseSpeedEchoes",
+              "requires": [ "canShinespark" ],
+              "note": "Using as a weapon the Samus echoes that are emitted after a shinespark bonk."
+            },
+            {
+              "name": "canSpeedZebetitesSkip",
+              "requires": [
+                "canShinespark",
+                {"enemyDamage": {
+                    "enemy": "Rinka",
+                    "type": "contact",
+                    "hits": 1
+                }}
+              ],
+              "note": [
+                "Being able to glitch through the Mother Brain zebetites by using a shinespark and iFrames.",
+                "The tech itself isn't that difficult, what makes it difficult with the vanilla layout is getting the short charge."
+              ]
             }
           ]
-        },
-        {
-          "name": "canUseSpeedEchoes",
-          "requires": [ "canShinespark" ],
-          "note": "Using as a weapon the Samus echoes that are emitted after a shinespark bonk."
         },
         {
           "name": "canBlueSpaceJump",
@@ -763,21 +777,6 @@
             "SpaceJump"
           ],
           "note": "Using SpaceJump to carry SpeedBooster's blue suit into some speed blocks that couldn't be reached just by running and jumping"
-        },
-        {
-          "name": "canSpeedZebetitesSkip",
-          "requires": [
-            "SpeedBooster",
-            {"enemyDamage": {
-                "enemy": "Rinka",
-                "type": "contact",
-                "hits": 1
-            }}
-          ],
-          "note": [
-            "Being able to glitch through the Mother Brain zebetites by using a shinespark and iFrames.",
-            "The tech itself isn't that difficult, what makes it difficult with the vanilla layout is getting the short charge."
-          ]
         }
       ]
     },

--- a/tech.json
+++ b/tech.json
@@ -727,7 +727,29 @@
         {
           "name": "canShinespark",
           "requires": [ "SpeedBooster" ],
-          "note": "The ability to use the Speed Booster to store a charge, then fly in a direction until an obstacle is hit."
+          "note": "The ability to use the Speed Booster to store a charge, then fly in a direction until an obstacle is hit.",
+          "extensionTechs": [
+            {
+              "name": "canMidairShinespark",
+              "requires": ["canShinespark"],
+              "note": "The ability to jump before shinesparking vertically, horizontally, or diagonally"
+            }
+          ]
+        },
+        {
+          "name": "canConserveShinesparkHealth",
+          "requires": [ 
+            "canShinespark", 
+            "canMidairShinespark"
+          ],
+          "note": "The ability to jump closer to the shinespark target with simple vertical jumps or a midair shinespark.  Trading shinespark charge timer for health savings.",
+          "extensionTechs": [
+            {
+              "name": "canConserveShinesparkHealthComplex",
+              "requires": [ "canConserveShinesparkHealth" ],
+              "note": "The ability to make multiple movement actions with a shinespark charge timer running in order to save a larger amount of health."
+            }
+          ]
         },
         {
           "name": "canUseSpeedEchoes",


### PR DESCRIPTION
-excessShinesparkFrames: How far  a shinespark goes past the desctructable blocks / ledge / other where it is ok if you stop early due to running out of health.  If you do not run out of health, the full shinesparkFrames value is used.

-canConserveShinesparkHealthComplex: Charging a shinespark then moving into a better position to spark that costs less health.

The Landingsite gauntlet door `canLeaveCharged` can be fulfilled with no `framesRemaining` and no `shinesparkFrames`.  This `should` result in a logical shinespark that accomplishes nothing, or an invalid way of entering with blue suit.

For #559 