### PR TITLE
Update Shinespark tech names and descriptions

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -474,7 +474,7 @@
                   "name": "Big Jump Midair Shinespark",
                   "notable": false,
                   "requires": [
-                    "canShinesparkSetupComplex",
+                    "canShinechargeMovementComplex",
                     {"canShineCharge": {
                       "usedTiles": 19,
                       "steepUpTiles": 2,

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -474,7 +474,7 @@
                   "name": "Big Jump Midair Shinespark",
                   "notable": false,
                   "requires": [
-                    "canConserveShinesparkHealthComplex",
+                    "canShinesparkSetupComplex",
                     {"canShineCharge": {
                       "usedTiles": 19,
                       "steepUpTiles": 2,

--- a/tech.json
+++ b/tech.json
@@ -742,7 +742,7 @@
               "note": "The ability to jump and shinespark midair: vertically, horizontally, or diagonally. This is not used to simply save energy."
             },
             {
-              "name": "canShinesparkSetup",
+              "name": "canShinechargeMovement",
               "requires": [ "canShinespark" ],
               "note": [
                 "The ability to perform simple jumps with a shinespark charge timer running to get into position to shinespark.",
@@ -750,8 +750,8 @@
               ],
               "extensionTechs": [
                 {
-                  "name": "canShinesparkSetupComplex",
-                  "requires": [ "canShinesparkSetup" ],
+                  "name": "canShinechargeMovementComplex",
+                  "requires": [ "canShinechargeMovement" ],
                   "note": [
                     "The ability to make multiple movement actions with a shinespark charge timer running to get into position to shinespark.",
                     "This reposition may be necessary to avoid obstacles, conserve energy, etc."

--- a/tech.json
+++ b/tech.json
@@ -738,19 +738,23 @@
           "extensionTechs": [
             {
               "name": "canMidairShinespark",
-              "requires": ["canShinespark"],
-              "note": "The ability to jump before shinesparking vertically, horizontally, or diagonally",
+              "requires": [ "canShinespark" ],
+              "note": "The ability to jump and shinespark midair: vertically, horizontally, or diagonally. This is not used to simply save energy."
+            },
+            {
+              "name": "canShinesparkSetup",
+              "requires": [ "canShinespark" ],
+              "note": [
+                "The ability to perform simple jumps with a shinespark charge timer running to get into position to shinespark.",
+                "This reposition may be necessary to avoid obstacles, conserve energy, etc."
+              ],
               "extensionTechs": [
                 {
-                  "name": "canConserveShinesparkHealth",
-                  "requires": [ "canMidairShinespark" ],
-                  "note": "The ability to jump a little  closer to the shinespark target with simple vertical jumps or a midair shinespark.  Trading shinespark charge timer for health savings.",
-                  "extensionTechs": [
-                    {
-                      "name": "canConserveShinesparkHealthComplex",
-                      "requires": [ "canConserveShinesparkHealth" ],
-                      "note": "The ability to make multiple movement actions with a shinespark charge timer running in order to save a larger amount of health."
-                    }
+                  "name": "canShinesparkSetupComplex",
+                  "requires": [ "canShinesparkSetup" ],
+                  "note": [
+                    "The ability to make multiple movement actions with a shinespark charge timer running to get into position to shinespark.",
+                    "This reposition may be necessary to avoid obstacles, conserve energy, etc."
                   ]
                 }
               ]
@@ -774,6 +778,12 @@
                 "Being able to glitch through the Mother Brain zebetites by using a shinespark and iFrames.",
                 "The tech itself isn't that difficult, what makes it difficult with the vanilla layout is getting the short charge."
               ]
+            },
+            {
+              "name": "canShinesparkWithReserve",
+              "requires": [ "canShinespark" ],
+              "note": "Manually triggering reserve energy during a shinespark to extend the distance travelled.",
+              "devNote": "This tech shouldn't need to be added to strat requirements."
             }
           ]
         },


### PR DESCRIPTION
- canConserveShinesparkHealth -> canShinechargeMovement
- canConserveShinesparkHealthComplex -> canShinechargeMovementComplex
- Add canShinesparkWithReserve
- canShinechargeMovement no longer requires canMidairShinespark