### PR TITLE
Cross room jump physics and notes changes

### DIFF
--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -221,11 +221,10 @@
                   "name": "Cross Room Jump with Speedbooster, Spring Ball",
                   "notable": false,
                   "requires": [
-                    "SpeedBooster",
+                    "canTrickyDashJump",
                     "canSpringBallJumpMidAir",
                     "canCrossRoomJumpIntoWater",
                     "canMomentumConservingTurnaround",
-                    "canTrickyDashJump",
                     {"adjacentRunway": {
                       "fromNode": 1,
                       "usedTiles": 7.5,
@@ -234,7 +233,7 @@
                     }}
                   ],
                   "note": [
-                    "Requires approximately 7.5 tiles in the adjacent room, to hit a peak in the speed / height relationship.",
+                    "Requires running a very precise distance of approximately 7.5 tiles in the adjacent room, to hit a peak in the speed / height relationship.",
                     "The spring ball jump is used after landing near the top, to get to the platform below the door."
                   ]
                 }
@@ -2856,7 +2855,6 @@
                   "name": "Cross Room Jump with Speedbooster",
                   "notable": false,
                   "requires": [
-                    "SpeedBooster",
                     "canTrickyDashJump",
                     "canCrossRoomJumpIntoWater",
                     "canMomentumConservingTurnaround",
@@ -2868,7 +2866,7 @@
                       "physics": ["normal"]
                     }}
                   ],
-                  "note": "Requires an adjacent runway of approximately 7.5 tiles, to hit a peak of the speed vs height graph."
+                  "note": "Requires running a very precise distance of approximately 7.5 tiles in the adjacent room, to hit a peak of the speed vs height graph."
                 },
                 {
                   "name": "Cross Room Jump with Spring Ball",

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -296,7 +296,7 @@
                       "fromNode": 1,
                       "usedTiles": 0.5,
                       "inRoomPath": [ 1, 4 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": [
@@ -337,7 +337,7 @@
                       "fromNode": 2,
                       "usedTiles": 19,
                       "inRoomPath": [ 2, 4 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": [
@@ -400,7 +400,7 @@
                       "fromNode": 3,
                       "usedTiles": 0.5,
                       "inRoomPath": [ 3, 4 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": [
@@ -985,7 +985,7 @@
                       "fromNode": 2,
                       "usedTiles": 0.5,
                       "inRoomPath": [ 2, 3 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }},
                     {"or":[
                       "Gravity",
@@ -1511,7 +1511,7 @@
                       "fromNode": 1,
                       "usedTiles": 5,
                       "inRoomPath": [ 1, 4 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": "Requires a runway of approximately 5 tiles in the adjacent room."
@@ -1526,7 +1526,7 @@
                       "fromNode": 1,
                       "usedTiles": 19,
                       "inRoomPath": [ 1, 4 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": "Requires a runway of approximately 19 tiles in the adjacent room."
@@ -1604,7 +1604,7 @@
                       "fromNode": 1,
                       "usedTiles": 3,
                       "inRoomPath": [ 1, 5 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": "Requires a runway of approximately 3 tiles in the adjacent room."
@@ -1620,7 +1620,7 @@
                       "fromNode": 1,
                       "usedTiles": 4.5,
                       "inRoomPath": [ 1, 5 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": "Requires a runway of approximately 4.5 tiles in the adjacent room."
@@ -1635,7 +1635,7 @@
                       "fromNode": 1,
                       "usedTiles": 7.5,
                       "inRoomPath": [ 1, 5 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": "Requires running a very precise distance of approximately 7.5 tiles in the adjacent room, to hit a peak of the speed vs height graph."
@@ -1650,7 +1650,7 @@
                       "fromNode": 1,
                       "usedTiles": 12,
                       "inRoomPath": [ 1, 5 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": "Requires a runway of approximately 12 tiles in the adjacent room."
@@ -2542,7 +2542,7 @@
                       "fromNode": 4,
                       "usedTiles": 8.5,
                       "inRoomPath": [ 4, 1 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": [
@@ -2575,7 +2575,7 @@
                       "fromNode": 4,
                       "usedTiles": 8.5,
                       "inRoomPath": [ 4, 9 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": [
@@ -2595,7 +2595,7 @@
                       "fromNode": 4,
                       "usedTiles": 7.5,
                       "inRoomPath": [ 4, 9 ],
-                      "physics": ["normal"]
+                      "physics": ["air"]
                     }}
                   ],
                   "note": [


### PR DESCRIPTION
- Fix new coss room jumps to require air physics in Outer Maridia, since they were added at the same time as the physics changes
- Clarify how precise tricky cross room strats are