### PR TITLE
Crateria removing some notable strats

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -78,7 +78,7 @@
               "strats": [
                 {
                   "name": "Gauntlet Wraparound Shot",
-                  "notable": true,
+                  "notable": false,
                   "requires": ["canWrapAroundShot"]
                 }
               ],
@@ -1209,7 +1209,7 @@
                 },
                 {
                   "name": "Parlor X-Ray Climb",
-                  "notable": true,
+                  "notable": false,
                   "requires": [
                     "canRightFacingDoorXRayClimb",
                     {"resetRoom":{
@@ -1267,7 +1267,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["h_canPassBombPassages"]
+                  "requires": ["h_canBombThings"]
                 },
                 {
                   "name": "Alcatraz Escape",
@@ -1283,7 +1283,7 @@
                 },
                 {
                   "name": "Space Jump Alcatraz Escape",
-                  "notable": true,
+                  "notable": false,
                   "requires": [
                     "Morph",
                     "SpaceJump"
@@ -1747,7 +1747,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [ "h_canPassBombPassages" ]
+                  "requires": [ "h_canBombThings" ]
                 }
               ]
             }
@@ -1762,7 +1762,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [ "h_canPassBombPassages" ]
+                  "requires": [ "h_canBombThings" ]
                 }
               ]
             }
@@ -1818,7 +1818,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["h_canPassBombPassages"]
+                  "requires": ["h_canBombThings"]
                 },
                 {
                   "name": "Behemoth Spark Top",
@@ -1847,7 +1847,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["h_canPassBombPassages"]
+                  "requires": ["h_canBombThings"]
                 },
                 {
                   "name": "Behemoth Spark Bottom",
@@ -2670,7 +2670,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [ "h_canPassBombPassages" ]
+                  "requires": [ "h_canBombThings" ]
                 }
               ]
             }

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -206,7 +206,7 @@
                       "Morph",
                       {"adjacentRunway": {
                         "fromNode": 1,
-                        "usedTiles": 0.5,
+                        "usedTiles": 1.5,
                         "overrideRunwayRequirements": true,
                         "physics": ["normal"],
                         "useFrames": 100
@@ -215,7 +215,7 @@
                   ],
                   "note": [
                     "Stand on the farthest pixel into the door possible using moonwalk or morphball turn around.",
-                    "Aligning with the door shell on the other side of the transition also works if possible and movement speed is not impeded.",
+                    "Aligning against the closed door shell on the other side of the transition also works if possible and movement speed is not impeded.",
                     "Run towards the water and jump on the last possible frame.",
                     "Perform the CWJ off of the item pedestal to cross to the other side."
                   ]

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -101,7 +101,7 @@
                 {
                   "name": "Pass Below",
                   "notable": false,
-                  "requires": ["h_canPassBombPassages"],
+                  "requires": ["h_canBombThings"],
                   "note": "In reality, bombs lead to 1 and not 3, but 1->3 and 3->1 are free so it doesn't matter."
                 },
                 {
@@ -198,12 +198,12 @@
                 },
                 {
                   "name": "Moat Continuous Walljump",
-                  "notable": true,
+                  "notable": false,
                   "requires": ["canCWJ"]
                 },
                 {
                   "name": "Moat Horizontal Bomb Jump",
-                  "notable": true,
+                  "notable": false,
                   "requires": ["canHBJ"]
                 },
                 {
@@ -213,7 +213,7 @@
                 },
                 {
                   "name": "Moat Ceiling Bomb Jump",
-                  "notable": true,
+                  "notable": false,
                   "requires": ["canCeilingBombJump"]
                 }
               ],
@@ -878,7 +878,7 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      "h_canPassBombPassages",
+                      "h_canBombThings",
                       "h_canUseSpringBall"
                     ]}
                   ],
@@ -906,7 +906,7 @@
                 },
                 {
                   "name": "West Ocean Central X-Ray Climb",
-                  "notable": true,
+                  "notable": false,
                   "requires": [
                     "canLeftFacingDoorXRayClimb",
                     { "resetRoom": {
@@ -1003,7 +1003,7 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      "h_canPassBombPassages",
+                      "h_canBombThings",
                       "h_canUseSpringBall"
                     ]}
                   ]
@@ -1164,7 +1164,7 @@
                 },
                 {
                   "name": "Beat West Ocean Super Block Respawn",
-                  "notable": true,
+                  "notable": false,
                   "requires": [],
                   "note": [
                     "It's possible to go 12 -> 14 -> 10 -> 14 -> 12 before the Super block respawns, if going quick enough.",

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -199,7 +199,26 @@
                 {
                   "name": "Moat Continuous Walljump",
                   "notable": false,
-                  "requires": ["canCWJ"]
+                  "requires": [
+                    "canCWJ",
+                    {"or": [
+                      "canMoonwalk",
+                      "Morph",
+                      {"adjacentRunway": {
+                        "fromNode": 1,
+                        "usedTiles": 0.5,
+                        "overrideRunwayRequirements": true,
+                        "physics": ["normal"],
+                        "useFrames": 100
+                      }}
+                     ]}
+                  ],
+                  "note": [
+                    "Stand on the farthest pixel into the door possible using moonwalk or morphball turn around.",
+                    "Aligning with the door shell on the other side of the transition also works if possible and movement speed is not impeded.",
+                    "Run towards the water and jump on the last possible frame.",
+                    "Perform the CWJ off of the item pedestal to cross to the other side."
+                  ]
                 },
                 {
                   "name": "Moat Horizontal Bomb Jump",
@@ -903,24 +922,6 @@
                     "This strat is a one-shot try and failure is a softlock."
                   ],
                   "devNote": "Could use a failure definition?"
-                },
-                {
-                  "name": "West Ocean Central X-Ray Climb",
-                  "notable": false,
-                  "requires": [
-                    "canLeftFacingDoorXRayClimb",
-                    { "resetRoom": {
-                      "nodes": [6],
-                      "mustStayPut": true
-                    }},
-                    {"adjacentRunway": {
-                      "fromNode": 6,
-                      "usedTiles": 0.5,
-                      "overrideRunwayRequirements": true,
-                      "physics": ["normal"],
-                      "useFrames": 200
-                    }}
-                  ]
                 }
               ]
             }

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -1260,13 +1260,13 @@
                   "requires": ["ScrewAttack"]
                 },
                 {
-                  "name": "Morph Bomb Gauntlet Entrance (Out)",
-                  "notable": true,
+                  "name": "Morph Bomb Gauntlet Entrance (Left to Right)",
+                  "notable": false,
                   "requires": ["h_canUseMorphBombs"]
                 },
                 {
-                  "name": "Power Bomb Gauntlet Entrance (Out)",
-                  "notable": true,
+                  "name": "Power Bomb Gauntlet Entrance (Left to Right)",
+                  "notable": false,
                   "requires": [
                     "Morph",
                     "PowerBomb",
@@ -1303,13 +1303,13 @@
                   "requires": ["ScrewAttack"]
                 },
                 {
-                  "name": "Morph Bomb Gauntlet Entrance (In)",
-                  "notable": true,
+                  "name": "Morph Bomb Gauntlet Entrance (Right to Left)",
+                  "notable": false,
                   "requires": ["h_canUseMorphBombs"]
                 },
                 {
-                  "name": "Power Bomb Gauntlet Entrance (In)",
-                  "notable": true,
+                  "name": "Power Bomb Gauntlet Entrance (Right to Left)",
+                  "notable": false,
                   "requires": [
                     "Morph",
                     "PowerBomb",
@@ -1488,7 +1488,12 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [],
+                  "requires": [
+                    {"or":[
+                      "canCarefulJump",
+                      {"acidFrames": 35}
+                    ]}
+                  ],
                   "obstacles": [
                     {
                       "id": "A",
@@ -1519,14 +1524,19 @@
                   ]
                 },
                 {
-                  "name": "Morph Bomb Gauntlet E-Tank Room (In)",
-                  "notable": true,
-                  "requires": [],
+                  "name": "Morph Bomb Gauntlet E-Tank Room (Left to Right)",
+                  "notable": false,
+                  "requires": [
+                    {"or":[
+                      "canCarefulJump",
+                      {"acidFrames": 35}
+                    ]}
+                  ],
                   "obstacles": [
                     {
                       "id": "A",
                       "requires": ["h_canUseMorphBombs"],
-                      "devNote": "FIXME health?"
+                      "devNote": "energy requirements are not included, because you can always backtrack to the farm fairly easily."
                     },
                     {
                       "id": "B",
@@ -1535,9 +1545,14 @@
                   ]
                 },
                 {
-                  "name": "Power Bomb Gauntlet E-Tank Room (In)",
-                  "notable": true,
-                  "requires": [],
+                  "name": "Power Bomb Gauntlet E-Tank Room (Left to Right)",
+                  "notable": false,
+                  "requires": [
+                    {"or":[
+                      "canCarefulJump",
+                      {"acidFrames": 35}
+                    ]}
+                  ],
                   "obstacles": [
                     {
                       "id": "A",
@@ -1548,8 +1563,7 @@
                           "type": "PowerBomb",
                           "count": 2
                         }}
-                      ],
-                      "devNote": "FIXME health?"
+                      ]
                     },
                     {
                       "id": "B",
@@ -1615,7 +1629,12 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [],
+                  "requires": [
+                    {"or":[
+                      "canCarefulJump",
+                      {"acidFrames": 35}
+                    ]}
+                  ],
                   "obstacles": [
                     {
                       "id": "A",
@@ -1628,25 +1647,58 @@
                   ]
                 },
                 {
-                  "name": "Morph Bomb Gauntlet E-Tank Room (Out)",
-                  "notable": true,
-                  "requires": [],
+                  "name": "Morph Bomb Gauntlet E-Tank Room (Right to Left)",
+                  "notable": false,
+                  "requires": [
+                    {"or":[
+                      "canCarefulJump",
+                      {"acidFrames": 35}
+                    ]}
+                  ],
                   "obstacles": [
                     {
                       "id": "A",
-                      "requires": ["h_canUseMorphBombs"],
-                      "devNote": "FIXME health?"
+                      "requires": [
+                        "h_canUseMorphBombs",
+                        {"or":[
+                          "canTrickyJump",
+                          {"and":[
+                            "canCarefulJump",
+                            "canBombHorizontally",
+                            {"acidFrames": 35}
+                          ]},
+                          {"acidFrames": 100}
+                        ]}
+                      ]
                     },
                     {
                       "id": "B",
-                      "requires": ["h_canUseMorphBombs"]
+                      "requires": [
+                        "h_canUseMorphBombs",
+                        {"or":[
+                          {"and":[
+                            "canTrickyJump",
+                            "canStaggeredWalljump"
+                          ]},
+                          {"and":[
+                            "canCarefulJump",
+                            {"acidFrames": 35}
+                          ]},
+                          {"acidFrames": 100}
+                        ]}
+                      ]
                     }
                   ]
                 },
                 {
-                  "name": "Power Bomb Gauntlet E-Tank Room (Out)",
-                  "notable": true,
-                  "requires": [],
+                  "name": "Power Bomb Gauntlet E-Tank Room (Right to Left)",
+                  "notable": false,
+                  "requires": [
+                    {"or":[
+                      "canCarefulJump",
+                      {"acidFrames": 35}
+                    ]}
+                  ],
                   "obstacles": [
                     {
                       "id": "A",
@@ -1657,8 +1709,7 @@
                           "type": "PowerBomb",
                           "count": 2
                         }}
-                      ],
-                      "devNote": "FIXME health?"
+                      ]
                     },
                     {
                       "id": "B",

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -1688,6 +1688,10 @@
                         ]}
                       ]
                     }
+                  ],
+                  "note": [
+                    "After destroying a single bomb block, Samus can spin jump into its spot to quickly escape the acid.",
+                    "To avoid the acid completely, morph quickly at the right height and place a bomb."
                   ]
                 },
                 {


### PR DESCRIPTION
Remove strats that are notable that shouldn't be because:
- They're intuitive and not too difficult,
- They are well represented by their tech, and not harder than it,
- Or, they are one of the primary examples of the given tech, and the place where/why you would likely learn the tech.

Updated h_canPassBombPassages -> h_canBombThings
Add energy and strat requirements to the gauntlet, resolving FIXME's