### PR TITLE
Remove Hijump from canDoubleSpringBallJumpMidAir

### DIFF
--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -209,7 +209,10 @@
                 {
                   "name": "Double Spring Ball Jump",
                   "notable": false,
-                  "requires": ["canDoubleSpringBallJumpMidAir"]
+                  "requires": [
+                    "canDoubleSpringBallJumpMidAir",
+                    "HiJump"
+                  ]
                 },
                 {
                   "name": "Moat Ceiling Bomb Jump",

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -1589,7 +1589,8 @@
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
-                    "canDoubleSpringBallJumpMidAir"
+                    "canDoubleSpringBallJumpMidAir",
+                    "HiJump"
                   ]
                 },
                 {

--- a/tech.json
+++ b/tech.json
@@ -277,11 +277,10 @@
               "name": "canDoubleSpringBallJumpMidAir",
               "requires": [
                 "Morph",
-                "SpringBall",
-                "HiJump"
+                "SpringBall"
               ],
               "note": [
-                "Using the SpringBallJumpMidAir twice during a single jump to gain even more height. This only works underwater with HiJump.",
+                "Using the SpringBallJumpMidAir twice during a single jump to gain even more height. This typically only works underwater with HiJump.",
                 "This consists of a tight variant of SpringBallJumpMidAir, then turning off spring ball, then a second SpringBallJumpMidAir all while still climbing upwards."
               ]
             }


### PR DESCRIPTION
- Hijump is no longer required on canDoubleSpringBallJumpMidAir, as it is not always needed in lava
- Add Hijump to the places that use the tech that require it.