### PR TITLE
Add missing free strat between Aqueduct items

### DIFF
--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -950,6 +950,16 @@
                   "requires": []
                 }
               ]
+            },
+            {
+              "id": 7,
+              "strats": [
+                {
+                  "name": "Base",
+                  "notable": false,
+                  "requires": []
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
This matters because an X-ray climb can get you to node 8 (the right item) and with that you should also be able to reach node 7 (the left item).