### PR TITLE
Update Tricky Ice Techs

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -1299,7 +1299,7 @@
                       "type": "Super",
                       "count": 2
                     }},
-                    "canUseFrozenEnemies"                    
+                    "canTrickyUseFrozenEnemies"                    
                   ],
                   "note": "Supers are for shaking down a Geemer into the hole and freeze it mid-air to act as a platform."
                 }

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -1188,7 +1188,7 @@
                 },
                 {
                   "name": "Main Street Bottom Crab Climb with Supers",
-                  "notable": true,
+                  "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
                     "canCrabClimb",
@@ -2488,12 +2488,12 @@
                   "name": "Short Crab Climb",
                   "notable": false,
                   "requires": [
-                    "canUseFrozenEnemies",
-                    {"ammo": {"type": "Super","count": 1}},
+                    "canTrickyUseFrozenEnemies",
+                    {"ammo": {"type": "Super", "count": 1}},
                     {"resetRoom": {
-                       "nodes": [3],
-                       "mustStayPut": true
-                     }}
+                      "nodes": [3],
+                      "mustStayPut": true
+                    }}
                   ],
                   "note": "Knock the crab off the wall immediately and then freeze.",
                   "devNote": "Kinda tough with no other beam/missile/super/movement."

--- a/tech.json
+++ b/tech.json
@@ -594,7 +594,10 @@
                 {
                   "name": "canTrickyUseFrozenEnemies",
                   "requires": [ "canUseFrozenEnemies" ],
-                  "note": "Can use Ice Beam to freeze enemies in especially precise positionings.",
+                  "note": [
+                    "Can use Ice Beam to freeze enemies in especially precise positionings.",
+                    "If supers are available, they can be used to knock wall crawlers off walls and freeze them mid air."
+                  ]
                   "extensionTechs": [
                     {
                       "name": "canNonTrivialIceClip",
@@ -603,7 +606,10 @@
                         "canTrickyUseFrozenEnemies",
                         {"or":[
                           "canPixelPerfectIceClip",
-                          "canXRayStandUp"
+                          {"and":[
+                            "Morph",
+                            "canXRayStandUp"
+                          ]}
                         ]}
                       ],
                       "note": [


### PR DESCRIPTION
- Clarify that using a super to knock off a wall crawler to freeze is assumed in `canTrickyUseFrozenEnemies`
- Add Morph to x-ray stand up ice clips