### PR TITLE
Remove Three Tech

### DIFF
--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -1210,13 +1210,13 @@
                 },
                 {
                   "name": "Pants Room Gravity Walljump",
-                  "notable": false,
+                  "notable": true,
                   "requires": [
-                    "Gravity",
                     "Grapple",
-                    "canGravityWalljump"
+                    "canGravityJump",
+                    "canWalljump"
                   ],
-                  "note": "Gets above the grapple block by doing a gravity jump off a wall jump on the side."
+                  "note": "Break the grapple block, then perform a wall jump on the side immediately followed by a gravity jump."
                 },
                 {
                   "name": "Suitless Pants Room SpringBall Climb",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -127,12 +127,23 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": ["Gravity"]
+                  "requires": [
+                    "Gravity",
+                    {"or": [
+                      "HiJump",
+                      "canWalljump",
+                      "h_canFly"
+                    ]}
+                  ]
                 },
                 {
-                  "name": "Crab Shaft Walljump Climb",
-                  "notable": false,
-                  "requires": ["canSunkenDualWallClimb"],
+                  "name": "Crab Shaft Suitless Walljump Climb",
+                  "notable": true,
+                  "requires": [
+                    "canSuitlessMaridia",
+                    "HiJump",
+                    "canConsecutiveWalljump"
+                  ],
                   "note": "It's a really long one"
                 },
                 {
@@ -5224,18 +5235,21 @@
                   ]
                 },
                 {
-                  "name": "West Sand Hole Break Free",
-                  "notable": false,
+                  "name": "West Sand Hole Suitless Wall Jump Break Free",
+                  "notable": true,
                   "requires": [
-                    "canSunkenDualWallClimb",
-                    "canWaterBreakFree"
+                    "canSuitlessMaridia",
+                    "HiJump",
+                    "canConsecutiveWalljump"
                   ]
                 },
                 {
                   "name": "West Sand Hole Space Wall Climb",
                   "notable": false,
                   "requires": [
-                    "canSunkenDualWallClimb",
+                    "canSuitlessMaridia",
+                    "HiJump",
+                    "canConsecutiveWalljump",
                     "SpaceJump"
                   ]
                 },

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1088,7 +1088,7 @@
                   "requires": ["SpeedBooster"]
                 },
                 {
-                  "name": "Frog Speedway Clip Right to Left",
+                  "name": "Frog Speedway Shot Block Overload (Speedless Speedway)",
                   "notable": true,
                   "requires": [
                     "Wave",
@@ -1097,7 +1097,10 @@
                       "Plasma"
                     ]}
                   ],
-                  "note": "This room has a bunch of offscreen shot blocks, and shooting enough of them with wave + spazer or wave + plasma allows you to run through the speed blocks when going right to left."
+                  "note": [
+                    "This strat is only usable right to left.",
+                    "This room has a bunch of offscreen shot blocks. Shooting enough of them with wave + spazer or wave + plasma allows you to pass through the speed blocks."
+                  ]
                 }
               ]
             }

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1088,16 +1088,16 @@
                   "requires": ["SpeedBooster"]
                 },
                 {
-                  "name": "Frog Speedway Clip",
-                  "notable": false,
+                  "name": "Frog Speedway Clip Right to Left",
+                  "notable": true,
                   "requires": [
-                    "canShotBlockOverload",
+                    "Wave",
                     {"or":[
                       "Spazer",
                       "Plasma"
                     ]}
                   ],
-                  "note": "This room has a bunch of offscreen shot blocks, and shooting enough of them with wave + spazer or plasma allows you to run through the speed blocks when going right to left."
+                  "note": "This room has a bunch of offscreen shot blocks, and shooting enough of them with wave + spazer or wave + plasma allows you to run through the speed blocks when going right to left."
                 }
               ]
             }

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -5343,7 +5343,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "Gravity",
-                    "canLavaGravityJump",
+                    "canGravityJump",
                     "HiJump",
                     {"heatFrames": 600},
                     {"lavaPhysicsFrames": 100}
@@ -5355,7 +5355,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "Gravity",
-                    "canLavaGravityJump",
+                    "canGravityJump",
                     "canSuitlessLavaDive",
                     "canStaggeredWalljump",
                     {"heatFrames": 750},

--- a/tech.json
+++ b/tech.json
@@ -198,28 +198,25 @@
         {
           "name": "canGravityJump",
           "requires": [ "Gravity" ],
-          "note": "Turning off Gravity Suit right after the start of an underwater jump to achieve higher height",
+          "note": [
+            "Turning off Gravity Suit right after the start of an underwater jump to achieve higher height.",
+            "Can be performed in water, lava, or acid."
+          ]
           "extensionTechs": [
-            {
-              "name": "canLavaGravityJump",
-              "requires": [ "canGravityJump" ],
-              "note": "Doing a gravity Jump in lava, causing Samus to take damage",
-              "devNote": "Does not require canSuitlessLavaDive because the amount of time spent in lava with Gravity off is very limited"
-            },
             {
               "name": "canGravityWalljump",
               "requires": [
                 "canGravityJump",
                 "canWalljump"
               ],
-              "note": "Executing a gravity jump off a wall jump"
+              "note": "Executing a gravity jump immediately off a wall jump."
             }
           ]
         },
         {
           "name": "canIframeSpikeJump",
-          "requires": [],
-          "note": "Using i-frames to setup a jump from a spike floor or wall"
+          "requires": [ "canCarefulJump" ],
+          "note": "Utilizing spikes i-frames to run and jump on spike floors or enemy i-frames to setup a jump from a spike wall."
         },
         {
           "name": "canStationarySpinJump",

--- a/tech.json
+++ b/tech.json
@@ -48,22 +48,6 @@
               ]
             },
             {
-              "name": "canSunkenDualWallClimb",
-              "requires": [
-                "canSuitlessMaridia",
-                "HiJump",
-                "canConsecutiveWalljump"
-              ],
-              "note": "Using a series of rapid, consecutive wall jumps underwater, on two nearby walls, to climb upwards.",
-              "extensionTechs": [
-                {
-                  "name": "canWaterBreakFree",
-                  "requires": [ "canSunkenDualWallClimb" ],
-                  "note": "Managing to break free of the water while doing a sunken dual wall climb, without the help of space jump"
-                }
-              ]
-            },
-            {
               "name": "canCrossRoomJumpIntoWater",
               "requires": [ "canSuitlessMaridia" ],
               "note": "Using the momentum from jumping through a doorway from normal to water physics."

--- a/tech.json
+++ b/tech.json
@@ -202,16 +202,6 @@
             "Turning off Gravity Suit right after the start of an underwater jump to achieve higher height.",
             "Can be performed in water, lava, or acid."
           ]
-          "extensionTechs": [
-            {
-              "name": "canGravityWalljump",
-              "requires": [
-                "canGravityJump",
-                "canWalljump"
-              ],
-              "note": "Executing a gravity jump immediately off a wall jump."
-            }
-          ]
         },
         {
           "name": "canIframeSpikeJump",
@@ -671,15 +661,6 @@
       "name": "Shots",
       "description": "Techs that revolve around shooting",
       "techs": [
-        {
-          "name": "canShotBlockOverload",
-          "requires": [ "Wave" ],
-          "note": [
-            "Shooting a large number of off-screen shot blocks, overloading the memory and making it possible to clip through otherwise solid blocks.",
-            "Made famous by its use in Frog Speedway."
-          ],
-          "devNote": "The tech itself doesn't require a specific beam besides Wave, but individual strats might."
-        },
         {
           "name": "canHitbox",
           "requires": [],


### PR DESCRIPTION
This ended up becoming 5 tech. Most of them are simply extensions of other tech, used only in very rare circumstances, and should simply be notable
- `canLavaGravityJump`: only used in 1 room, fundamentally the same thing as `canGravityJump`
- `canSunkenDualWallClimb`: only used in 2 rooms, uses are replaced as notable
- `canWaterBreakFree`: only used in 1 room, replaced as notable
- `canGravityWalljump`: kind of a silly tech and only used in 1 room, replaced as notable
- `canShotBlockOverload`: only used in 1 room, replaced as notable
- Update description and requirements of `canIframeSpikeJump`