### PR TITLE
Lower norfair west speed check

### DIFF
--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -151,6 +151,19 @@
                     "f_UsedAcidChozoStatue",
                     {"heatFrames": 350}
                   ]
+                },
+                {
+                  "name": "Shinespark",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    {"canComeInCharged": {
+                      "framesRemaining": 0,
+                      "fromNode": 1,
+                      "shinesparkFrames": 36
+                    }},
+                    {"heatFrames": 125}
+                  ]
                 }
               ]
             },
@@ -182,6 +195,20 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     {"heatFrames": 400}
+                  ]
+                },
+                {
+                  "name": "Shinespark",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    {"canComeInCharged": {
+                      "framesRemaining": 0,
+                      "fromNode": 2,
+                      "shinesparkFrames": 41,
+                      "excessShinesparkFrames": 6
+                    }},
+                    {"heatFrames": 125}
                   ]
                 }
               ]

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -426,7 +426,7 @@
                   ],
                   "devNote": [
                     "Even if the door could be unlocked without killing GT, the runway wouldn't be usable unless it's dead.",
-                    "Before GT becomes active, this runway can be used however."
+                    "FIXME: This runway can be used coming in, or leaving, but not both.  And not if GT has been activated before leaving."
                   ]
                 }
               ],

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -1235,6 +1235,12 @@
           "obstacleType": "inanimate"
         }
       ],
+      "reusableRoomwideNotable": [
+        {
+          "name": "Screw Attack Room SpeedKeep and Shinespark Escape",
+          "note": "Use a speedkeep to simultaneously store a shinespark and break the Screw Attack Room bomb blocks in order to collect the item and shinespark out."
+        }
+      ],
       "enemies": [],
       "links": [
         {
@@ -1249,9 +1255,10 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 30,
-                      "shinesparkFrames": 35
-                    }},
+                      "framesRemaining": 25,
+                      "shinesparkFrames": 31,
+                      "excessShinesparkFrames": 10
+                     }},
                     { "heatFrames": 200 }
                   ],
                   "obstacles": [
@@ -1294,9 +1301,10 @@
                     "h_canNavigateHeatRooms",
                     { "canComeInCharged": {
                       "fromNode": 1,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 50
-                    }},
+                      "framesRemaining": 50,
+                      "shinesparkFrames": 41,
+                      "excessShinesparkFrames": 4
+                      }},
                     { "heatFrames": 250 }
                   ],
                   "obstacles": [
@@ -1399,9 +1407,10 @@
                     "h_canNavigateHeatRooms",
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "framesRemaining": 60,
-                      "shinesparkFrames": 35
-                    }},
+                      "framesRemaining": 50,
+                      "shinesparkFrames": 35,
+                      "excessShinesparkFrames": 4
+                     }},
                     {"heatFrames": 250}
                   ],
                   "obstacles": [
@@ -1410,6 +1419,38 @@
                       "requires": []
                     }
                   ]
+                },
+                {
+                  "name": "Jump into Room Shinespark",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "canMidairShinespark",
+                    "canShinechargeMovement",
+                    "canPrepareForNextRoom",
+                    {"canComeInCharged": {
+                      "fromNode": 2,
+                      "framesRemaining": 15,
+                      "shinesparkFrames": 18,
+                      "excessShinesparkFrames": 4
+                    }},
+                    {"adjacentRunway": {
+                      "fromNode": 2,
+                      "usedTiles": 0.5
+                    }},
+                    {"heatFrames": 250}
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": []
+                    }
+                  ],
+                  "note": [
+                    "Jump into Screw Attack Room and spark diagonally once above the center of the door vertically.",
+                    "Or diagonally spark anywhere that is not the bottom of the door in the previous room."
+                  ],
+                  "devNote": "TODO: Sparking diagonally through the door cannot be shown as an alternative."
                 },
                 {
                   "name": "Screw Attack Right-Side X-Ray Climb",
@@ -1487,6 +1528,54 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "name": "SpeedKeep",
+                  "notable": false,
+                  "requires": [
+                    "canSpeedKeep",
+                    "canPrepareForNextRoom",
+                    {"canComeInCharged": {
+                       "framesRemaining": 180,
+                       "fromNode": 2,
+                       "shinesparkFrames": 0
+                     }},
+                    {"adjacentRunway": {
+                      "fromNode": 2,
+                      "usedTiles": 1,
+                      "useFrames": 70
+                    }},
+                    {"heatFrames": 75}
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "B",
+                      "requires": []
+                    }
+                  ],
+                  "note": "This expects the more controlled speedkeep to fall though the blocks, not storing a shinecharge through the door."
+                },
+                { 
+                  "name": "Screw Attack Room SpeedKeep and Shinespark Escape Middle Door Part 1" ,
+                  "notable": true,
+                  "requires": [
+                    "canSpeedKeep",
+                    "canPrepareForNextRoom",
+                    {"canComeInCharged": {
+                       "framesRemaining": 180,
+                       "fromNode": 2,
+                       "shinesparkFrames": 0
+                     }},
+                    {"heatFrames": 75}
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "B",
+                      "requires": []
+                    }
+                  ],
+                  "reusableRoomwideNotable": "Screw Attack Room SpeedKeep and Shinespark Escape",
+                  "note": "Store the shinecharge while hitting the door transition to keep the ability to break blocks."
                 }
               ]
             },
@@ -1637,6 +1726,78 @@
                       ]
                     }
                   ]
+                },
+                {
+                  "name": "SpeedBooster",
+                  "notable": false,
+                  "requires": [
+                    {"heatFrames": 200}
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": [
+                        {"canComeInCharged": {
+                          "framesRemaining": 180,
+                          "fromNode": 3,
+                          "shinesparkFrames": 0
+                        }}
+                      ]
+                    }
+                  ],
+                  "devNote": [
+                    "TODO: Running in is not required.  Entering the room with canBlueSpaceJump could work, for example."
+                  ]
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "strats": [
+                {
+                  "name": "SpeedKeep",
+                  "notable": false,
+                  "requires": [
+                    {"heatFrames": 240}
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "B",
+                      "requires": [ 
+                        "canSpeedKeep",
+                        {"canComeInCharged": {
+                           "framesRemaining": 180,
+                           "fromNode": 3,
+                           "shinesparkFrames": 0
+                         }}
+                      ],
+                      "additionalObstacles": ["A"]
+                    }
+                  ],
+                  "note": "This expects the more controlled speedkeep to fall though the blocks, not storing a shinecharge on the first breakable block."
+                },
+                {
+                  "name": "Screw Attack Room SpeedKeep and Shinespark Escape Part 1",
+                  "notable": true,
+                  "requires": [
+                    {"heatFrames": 130}
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "B",
+                      "requires": [ 
+                        "canSpeedKeep",
+                        {"canComeInCharged": {
+                          "framesRemaining": 180,
+                          "fromNode": 3,
+                          "shinesparkFrames": 0
+                        }}
+                      ],
+                      "additionalObstacles": ["A"]
+                    }
+                  ],
+                  "reusableRoomwideNotable": "Screw Attack Room SpeedKeep and Shinespark Escape",
+                  "note": "Simultaneously store a shinespark and break through the bomb blocks down to the Screw Attack item location."
                 }
               ]
             }
@@ -1716,6 +1877,91 @@
                         {"heatFrames": 100}
                       ]
                     }
+                  ]
+                },
+                { 
+                  "name": "Screw Attack Room SpeedKeep and Shinespark Escape Mid Door Part 2",
+                  "notable": true,
+                  "requires": [
+                    {"or": [
+                      {"and": [
+                        {"previousNode": 2},
+                        {"canComeInCharged": {
+                          "framesRemaining": 180,
+                          "fromNode": 2,
+                          "shinesparkFrames": 31,
+                          "excessShinesparkFrames": 10
+                        }}
+                      ]},
+                      {"and": [
+                        {"previousNode": 3},
+                        {"canComeInCharged": {
+                          "framesRemaining": 180,
+                          "fromNode": 3,
+                          "shinesparkFrames": 31,
+                          "excessShinesparkFrames": 10
+                        }}
+                      ]}
+                    ]},
+                    "canShinechargeMovement",
+                    {"heatFrames": 200}
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "B",
+                      "requires": []
+                    }
+                  ],
+                  "reusableRoomwideNotable": "Screw Attack Room SpeedKeep and Shinespark Escape",
+                  "note": "Carry a shinecharge down though the bomb blocks and shinespark back up.",
+                  "devNote": "Useful only if you cannot reach the door at 2."
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "Screw Attack Room SpeedKeep and Shinespark Escape Top Door Part 2",
+                  "notable": true,
+                  "requires": [
+                    {"or": [
+                      {"and": [
+                        {"previousNode": 2},
+                        {"canComeInCharged": {
+                          "framesRemaining": 180,
+                          "fromNode": 2,
+                          "shinesparkFrames": 41,
+                          "excessShinesparkFrames": 4
+                        }}
+                      ]},
+                      {"and": [
+                        {"previousNode": 3},
+                        {"canComeInCharged": {
+                          "framesRemaining": 180,
+                          "fromNode": 3,
+                          "shinesparkFrames": 41,
+                          "excessShinesparkFrames": 4
+                        }}
+                      ]}
+                    ]},
+                    "canShinechargeMovement",
+                    {"heatFrames": 240}
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "A",
+                      "requires": []
+                    },
+                    {
+                      "id": "B",
+                      "requires": []
+                    }
+                  ],
+                  "reusableRoomwideNotable": "Screw Attack Room SpeedKeep and Shinespark Escape",
+                  "note": "Carry a shinecharge down though the bomb blocks and shinespark back up.",
+                  "devNote": [
+                    "Using this notable strat means Samus has a shinecharge ready to be used."
                   ]
                 }
               ]

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -1237,8 +1237,11 @@
       ],
       "reusableRoomwideNotable": [
         {
-          "name": "Screw Attack Room SpeedKeep and Shinespark Escape",
-          "note": "Use a speedkeep to simultaneously store a shinespark and break the Screw Attack Room bomb blocks in order to collect the item and shinespark out."
+          "name": "Screw Attack Room Descent and Shinespark Escape",
+          "note": [
+            "Use a speedkeep to simultaneously store a shinespark and break the Screw Attack Room bomb blocks in order to collect the item and shinespark out.",
+            "Screw Attack can be used instead of a speedkeep, but it does reduce the number of frames available for the shinespark after."
+          ]
         }
       ],
       "enemies": [],
@@ -1556,10 +1559,13 @@
                   "note": "This expects the more controlled speedkeep to fall though the blocks, not storing a shinecharge through the door."
                 },
                 { 
-                  "name": "Screw Attack Room SpeedKeep and Shinespark Escape Middle Door Part 1" ,
+                  "name": "Screw Attack Room Descent and Shinespark Escape Middle Door Part 1" ,
                   "notable": true,
                   "requires": [
-                    "canSpeedKeep",
+                    {"or": [
+                       "canSpeedKeep",
+                       "ScrewAttack"
+                     ]},
                     "canPrepareForNextRoom",
                     {"canComeInCharged": {
                        "framesRemaining": 180,
@@ -1574,7 +1580,7 @@
                       "requires": []
                     }
                   ],
-                  "reusableRoomwideNotable": "Screw Attack Room SpeedKeep and Shinespark Escape",
+                  "reusableRoomwideNotable": "Screw Attack Room Descent and Shinespark Escape",
                   "note": "Store the shinecharge while hitting the door transition to keep the ability to break blocks."
                 }
               ]
@@ -1777,7 +1783,7 @@
                   "note": "This expects the more controlled speedkeep to fall though the blocks, not storing a shinecharge on the first breakable block."
                 },
                 {
-                  "name": "Screw Attack Room SpeedKeep and Shinespark Escape Part 1",
+                  "name": "Screw Attack Room Descent and Shinespark Escape Part 1",
                   "notable": true,
                   "requires": [
                     {"heatFrames": 130}
@@ -1785,8 +1791,11 @@
                   "obstacles": [
                     {
                       "id": "B",
-                      "requires": [ 
-                        "canSpeedKeep",
+                      "requires": [
+                        {"or": [
+                           "canSpeedKeep",
+                           "ScrewAttack"
+                         ]},
                         {"canComeInCharged": {
                           "framesRemaining": 180,
                           "fromNode": 3,
@@ -1796,7 +1805,7 @@
                       "additionalObstacles": ["A"]
                     }
                   ],
-                  "reusableRoomwideNotable": "Screw Attack Room SpeedKeep and Shinespark Escape",
+                  "reusableRoomwideNotable": "Screw Attack Room Descent and Shinespark Escape",
                   "note": "Simultaneously store a shinespark and break through the bomb blocks down to the Screw Attack item location."
                 }
               ]
@@ -1880,7 +1889,7 @@
                   ]
                 },
                 { 
-                  "name": "Screw Attack Room SpeedKeep and Shinespark Escape Mid Door Part 2",
+                  "name": "Screw Attack Room Descent and Shinespark Escape Mid Door Part 2",
                   "notable": true,
                   "requires": [
                     {"or": [
@@ -1912,7 +1921,7 @@
                       "requires": []
                     }
                   ],
-                  "reusableRoomwideNotable": "Screw Attack Room SpeedKeep and Shinespark Escape",
+                  "reusableRoomwideNotable": "Screw Attack Room Descent and Shinespark Escape",
                   "note": "Carry a shinecharge down though the bomb blocks and shinespark back up.",
                   "devNote": "Useful only if you cannot reach the door at 2."
                 }
@@ -1922,7 +1931,7 @@
               "id": 3,
               "strats": [
                 {
-                  "name": "Screw Attack Room SpeedKeep and Shinespark Escape Top Door Part 2",
+                  "name": "Screw Attack Room Descent and Shinespark Escape Top Door Part 2",
                   "notable": true,
                   "requires": [
                     {"or": [
@@ -1958,7 +1967,7 @@
                       "requires": []
                     }
                   ],
-                  "reusableRoomwideNotable": "Screw Attack Room SpeedKeep and Shinespark Escape",
+                  "reusableRoomwideNotable": "Screw Attack Room Descent and Shinespark Escape",
                   "note": "Carry a shinecharge down though the bomb blocks and shinespark back up.",
                   "devNote": [
                     "Using this notable strat means Samus has a shinecharge ready to be used."

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -424,7 +424,10 @@
                     "h_canNavigateHeatRooms",
                     {"heatFrames": 280}
                   ],
-                  "note": "Even if the door could be unlocked without killing GT, the runway wouldn't be usable unless it's dead."
+                  "devNote": [
+                    "Even if the door could be unlocked without killing GT, the runway wouldn't be usable unless it's dead.",
+                    "Before GT becomes active, this runway can be used however."
+                  ]
                 }
               ],
                 "openEnd": 0
@@ -799,8 +802,9 @@
                     {"canComeInCharged": {
                       "fromNode": 1,
                       "framesRemaining": 0,
-                      "shinesparkFrames": 17
-                    }},
+                      "shinesparkFrames": 17,
+                      "excessShinesparkFrames": 3
+                     }},
                     {"heatFrames": 150}
                   ]
                 }

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -1783,7 +1783,7 @@
                   "note": "This expects the more controlled speedkeep to fall though the blocks, not storing a shinecharge on the first breakable block."
                 },
                 {
-                  "name": "Screw Attack Room Descent and Shinespark Escape Part 1",
+                  "name": "Screw Attack Room Descent and Shinespark Escape Top Door Part 1",
                   "notable": true,
                   "requires": [
                     {"heatFrames": 130}


### PR DESCRIPTION
These rooms need a general update as well.  Screw Attack Room diagram would need a redraw but I want to see if anything changes by adding general movement requirements first.

GTs arena can be used as a runway to reach the super location using single shinespark strats without fighting GT.  I haven't sorted out conditionally disallowing the exit runway though. 