### PR TITLE
Reduce heatFrames in Speed Booster Hall

### DIFF
--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -3200,7 +3200,7 @@
                     }},
                     {"and":[
                       "SpeedBooster",
-                      {"heatFrames": 400}
+                      {"heatFrames": 360}
                     ]}
                   ]
                 }
@@ -3236,7 +3236,7 @@
                       "nodesToAvoid": [1]
                     }},
                     "SpeedBooster",
-                    {"heatFrames": 400}
+                    {"heatFrames": 360}
                   ]
                 }
               ]


### PR DESCRIPTION
I noticed in a recent Croakomire video that he was able to get through here with no ETanks: https://clips.twitch.tv/DignifiedAbstruseClamPeteZaroll-mvUHUTWl73LfxhXt

The logic currently has this as requiring 400 heat frames (100 energy), which seems like too large a gap from what is actually doable without much difficulty. In this case it resulted in an ETank being easily obtainable out of logic. We fix this by reducing the heatFrames from 400 to 360.