### PR TITLE
Add G-mode tech, requirements, and node properties

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -328,6 +328,10 @@
       "note": [
         "These are ways to navigate stairs and small platforms for strats assuming G-mode artificial morph.",
         "Having Morph means we can unmorph, jump, and remorph, as using artificial morph is not needed in that case."
+      ],
+      "devNote": [
+        "Morph will not be a usable alternative to get up very constrained ledges, such as in a morph tunnel.",
+        "IBJ is not usable for underwater rooms without Gravity."
       ]
     }
   ]

--- a/helpers.json
+++ b/helpers.json
@@ -308,6 +308,16 @@
           "canRJump"
         ]}
       ]
+    },
+    {
+      "name": "h_canArtificialMorphMovement",
+      "requires": [
+        {"or": [
+          "Bombs",
+          "SpringBall"
+        ]}
+      ],
+      "devNote": "FIXME: Add a canIBJ tech requirement to the Bombs case, after Morph is removed as a requirement from canIBJ."
     }
   ]
 }

--- a/helpers.json
+++ b/helpers.json
@@ -310,14 +310,20 @@
       ]
     },
     {
+      "name": "h_canArtificialMorphIBJ",
+      "requires": [
+        "Bombs"
+      ],
+      "devNote": "FIXME: Add a canIBJ tech requirement after Morph is removed as a requirement."
+    },
+    {
       "name": "h_canArtificialMorphMovement",
       "requires": [
         {"or": [
-          "Bombs",
-          "SpringBall"
+          "SpringBall",
+          "h_canArtificialMorphIBJ"
         ]}
-      ],
-      "devNote": "FIXME: Add a canIBJ tech requirement to the Bombs case, after Morph is removed as a requirement from canIBJ."
+      ]
     }
   ]
 }

--- a/helpers.json
+++ b/helpers.json
@@ -324,6 +324,10 @@
           "h_canArtificialMorphIBJ",
           "Morph"
         ]}
+      ],
+      "note": [
+        "These are ways to navigate stairs and small platforms for strats assuming G-mode artificial morph.",
+        "Having Morph means we can unmorph, jump, and remorph, as using artificial morph is not needed in that case."
       ]
     }
   ]

--- a/helpers.json
+++ b/helpers.json
@@ -321,7 +321,8 @@
       "requires": [
         {"or": [
           "SpringBall",
-          "h_canArtificialMorphIBJ"
+          "h_canArtificialMorphIBJ",
+          "Morph"
         ]}
       ]
     }

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -372,7 +372,7 @@ Please refer to the sections on `leaveWithGModeSetup` in [the Region documentati
 A `comeInWithGMode` object represents the need to either have or obtain G-mode when entering the room. It has the following properties:
 * _fromNodes:_ Indicates from what doors this logical requirement expects Samus to enter the room.
 * _mode:_ Takes one of three possible values, "direct", "indirect", or "any", indicating whether this logical requirement expects Samus to enter in direct G-mode, indirect G-mode, or either. Direct G-mode is the state obtained when G-mode is first entered (i.e., the next room after the G-mode setup is performed), while indirect G-mode is the state after passing a door transition with G-mode (usually back into the room where the G-mode setup was performed).
-* _artificialMorph:_ A boolean indicating whether the logical requirement expects Samus to either obtain or already have an artificially morphed state when coming into the room.
+* _artificialMorph:_ A boolean indicating whether the logical requirement expects Samus to either obtain or already have an artificially morphed state when coming into the room, or to have collected the Morph item.
 
 __Example:__
 ```json
@@ -395,7 +395,7 @@ __Additional considerations__
     * Any additional requirements in the `requires` property of the `leaveWithGModeSetup`.
   * A `leaveWithGMode` object must satisfy the following requirements in order to match:
     * The `mode` in the `comeInWithGMode` object must be "indirect" or "any".
-    * If `artificialMorph` is `true`, then the `leavesWithArtificialMorph` property of the `leaveWithGMode` object must be `true`.
+    * If `artificialMorph` is `true`, then either the `leavesWithArtificialMorph` property of the `leaveWithGMode` object must be `true` or there is an additional requirement that the Morph item be collected.
     * Any additional requirements in the `requires` property of the `leaveWithGMode` object.
 * In the case of direct G-mode, `comeInWithGMode` object implicitly requires an energy drain caused by the reserve trigger and preceding setup:
   * If the tech `canEnterGModeImmobile` is enabled and the `gModeImmobile` on the corresponding door is satisfied, then Samus' regular energy will become whatever reserve energy she had before the transition, truncated to her maximum amount of regular energy (based on the number of ETanks collected).

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -370,15 +370,13 @@ A `comeInWithGMode` object represents the need to either have or obtain G-mode w
 * _fromNodes:_ Indicates from what doors this logical requirement expects Samus to enter the room.
 * _mode:_ Takes one of three possible values, "direct", "indirect", or "any", indicating whether this logical requirement expects Samus to enter in direct G-mode, indirect G-mode, or either. Direct G-mode is the state obtained when G-mode is first entered (i.e., the next room after the G-mode setup is performed), while indirect G-mode is the state after passing a door transition with G-mode (usually back into the room where the G-mode setup was performed).
 * _artificialMorph:_ A boolean indicating whether the logical requirement expects Samus to either obtain or already have an artificially morphed state when coming into the room.
-* _immobile:_ A boolean indicating whether the logical requirement expects Samus to enter in a G-mode immobile state, which means an enemy must be able to hit Samus where she spawns in the destination room in order to regain control.
 
 __Example:__
 ```json
 {"comeInWithGMode": {
   "fromNodes": [1],
   "mode": "any",
-  "artificialMorph": false,
-  "immobile": false
+  "artificialMorph": false
 }}
 ```
 
@@ -386,7 +384,6 @@ __Additional considerations__
 
 * A `comeInWithGMode` object implicitly requires X-Ray Scope and a Reserve Tank.
 * A `comeInWithGMode` object implicitly requires the `canEnterGMode` tech.
-  * If `immobile` is `true` then it also requires the `canEnterGModeImmobile` tech.
   * If `artificialMorph` is `true` then it also requires the `canArtificialMorph` tech.
 * A `comeInWithGMode` requires that one of the indicating nodes in `fromNodes` has a matching `leaveWithGModeSetup` or `leaveWithGMode` object in the corresponding door node of the neighboring room:
   * A `leaveWithGModeSetup` object must satisfy following requirements in order to match:

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -343,6 +343,67 @@ __Additional considerations__
 * A `canShineCharge` object implicitly requires the Speed Booster.
 * A `canShineCharge` object implicitly requires the `canShineCharge` tech if it has more than 0 `shinesparkFrames`.
 
+#### comeInWithRMode object
+A `comeInWithRMode` object represents the need to obtain R-mode when entering the room. It has the following properties:
+* _fromNodes:_ Indicates from what doors this logical requirement expects Samus to enter the room.
+
+__Example:__
+```json
+{"comeInWithRMode": {
+  "fromNodes": [1],
+}}
+```
+
+__Additional considerations__
+
+* A `comeInWithRMode` object implicitly requires X-Ray Scope and a Reserve Tank.
+* A `comeInWithRMode` object implicitly requires the `canEnterRMode` tech.
+* A `comeInWithRMode` requires that one of the indicating nodes in `fromNodes` has a matching `leaveWithDamage`.
+  * The `leaveWithDamage` object must satisfy following requirements in order to match:
+    * Samus must have non-zero reserve energy.
+    * Any additional requirements in the `requires` property of the `leaveWithDamage` object.
+
+Please refer to the sections on `leaveWithDamage` in [the Region documentation](region/region-readme.md) for a more detailed explanation of this object.
+
+#### comeInWithGMode object
+A `comeInWithGMode` object represents the need to either have or obtain G-mode when entering the room. It has the following properties:
+* _fromNodes:_ Indicates from what doors this logical requirement expects Samus to enter the room.
+* _mode:_ Takes one of three possible values, "direct", "indirect", or "any", indicating whether this logical requirement expects Samus to enter in direct G-mode, indirect G-mode, or either.
+* _artificialMorph:_ A boolean indicating whether the logical requirement expects Samus to enter in an artificially morphed state (without necessarily having collected the Morph item).
+* _previouslyOverloadedPLMs:_ A boolean indicating whether the logical requirement expects that PLMs have already been overloaded when entering the room. This is only applicable to indirect G-mode.
+* _immobile:_ A boolean indicating whether the logical requirement expects Samus to enter in a G-mode immobile state, which means an enemy must be available in the right location to hit Samus and return control.
+
+__Example:__
+```json
+{"comeInWithGMode": {
+  "fromNodes": [1],
+  "mode": "any",
+  "artificialMorph": false,
+  "previouslyOverloadedPLMs": false,
+  "immobile": false
+}}
+```
+
+__Additional considerations__
+
+* A `comeInWithGMode` object implicitly requires X-Ray Scope and a Reserve Tank.
+* A `comeInWithGMode` object implicitly requires the `canEnterGMode` tech.
+  * If `immobile` is `true` then it also requires the `canEnterGModeImmobile` tech.
+  * If `artificialMorph` is `true` then it also requires the `canArtificialMorph` tech.
+* A `comeInWithGMode` requires that one of the indicating nodes in `fromNodes` has a matching `leaveWithDamage` or `leaveWithGMode` object in the corresponding door node of the neighboring room:
+  * A `leaveWithDamage` object must satisfy following requirements in order to match:
+    * The `mode` in the `comeInWithGMode` object must be "direct" or "any".
+    * Samus must have non-zero reserve energy.
+    * Any additional requirements in the `requires` property of the `leaveWithDamage`.
+  * A `leaveWithGMode` object must satisfy the following requirements in order to match:
+    * The `mode` in the `comeInWithGMode` object must be "indirect" or "any".
+    * If `artificialMorph` is `true`, then the `leavesWithArtificialMorph` property of the `leaveWithGMode` object must be `true`.
+    * If `previouslyOverloadedPLMs` is `true`, then the `leavesWithOverloadedPLMs` property of the `leaveWithGMode` object must be `true`.
+    * Any additional requirements in the `requires` property of the `leaveWithGMode` object.
+
+Please refer to the sections on `leaveWithDamage` and `leaveWithGMode` in [the Region documentation](region/region-readme.md) for a more detailed explanation of these objects.
+
+
 ### Room Pathing Objects
 This section contains logical elements that are affected by Samus' pathing within a room.
 

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -399,7 +399,7 @@ __Additional considerations__
     * Any additional requirements in the `requires` property of the `leaveWithGMode` object.
 * In the case of direct G-mode, `comeInWithGMode` object implicitly requires an energy drain caused by the reserve trigger and preceding setup:
   * If the tech `canEnterGModeImmobile` is enabled and the `gModeImmobile` on the corresponding door is satisfied, then Samus' regular energy will become whatever reserve energy she had before the transition, truncated to her maximum amount of regular energy (based on the number of ETanks collected).
-  * Otherwise, Samus' regular energy will become 4, or whatever reserve energy she had before the transition if it was less than 4.
+  * Otherwise, Samus' regular energy will become 4, reflecting the need  or whatever reserve energy she had before the transition if it was less than 4.
   * Samus' reserve energy will always become zero.
 
 Please refer to the sections on `leaveWithGModeSetup`, `leaveWithGMode`, and `gModeImmobile` in [the Region documentation](region/region-readme.md) for a more detailed explanation of these objects.

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -398,11 +398,11 @@ __Additional considerations__
     * If `artificialMorph` is `true`, then the `leavesWithArtificialMorph` property of the `leaveWithGMode` object must be `true`.
     * Any additional requirements in the `requires` property of the `leaveWithGMode` object.
 * In the case of direct G-mode, `comeInWithGMode` object implicitly requires an energy drain caused by the reserve trigger and preceding setup:
-  * If the tech `canEnterGModeImmobile` is enabled and the `gModeImmobileRequires` on the corresponding door is satisfied, then Samus' regular energy will become whatever reserve energy she had before the transition, truncated to her maximum amount of regular energy (based on the number of ETanks collected).
+  * If the tech `canEnterGModeImmobile` is enabled and the `gModeImmobile` on the corresponding door is satisfied, then Samus' regular energy will become whatever reserve energy she had before the transition, truncated to her maximum amount of regular energy (based on the number of ETanks collected).
   * Otherwise, Samus' regular energy will become 4, or whatever reserve energy she had before the transition if it was less than 4.
   * Samus' reserve energy will always become zero.
 
-Please refer to the sections on `leaveWithGModeSetup`, `leaveWithGMode`, and `gModeImmobileRequires` in [the Region documentation](region/region-readme.md) for a more detailed explanation of these objects.
+Please refer to the sections on `leaveWithGModeSetup`, `leaveWithGMode`, and `gModeImmobile` in [the Region documentation](region/region-readme.md) for a more detailed explanation of these objects.
 
 
 ### Room Pathing Objects

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -387,7 +387,7 @@ __Additional considerations__
 
 * A `comeInWithGMode` object implicitly requires X-Ray Scope and a Reserve Tank.
 * A `comeInWithGMode` object implicitly requires the `canEnterGMode` tech.
-  * If `artificialMorph` is `true` then it also requires the `canArtificialMorph` tech.
+  * If `artificialMorph` is `true` then it also requires either the `canArtificialMorph` tech or the Morph item.
 * A `comeInWithGMode` requires that one of the indicating nodes in `fromNodes` has a matching `leaveWithGModeSetup` or `leaveWithGMode` object in the corresponding door node of the neighboring room:
   * A `leaveWithGModeSetup` object must satisfy the following requirements in order to match:
     * The `mode` in the `comeInWithGMode` object must be "direct" or "any".

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -368,10 +368,10 @@ Please refer to the sections on `leaveWithGModeSetup` in [the Region documentati
 #### comeInWithGMode object
 A `comeInWithGMode` object represents the need to either have or obtain G-mode when entering the room. It has the following properties:
 * _fromNodes:_ Indicates from what doors this logical requirement expects Samus to enter the room.
-* _mode:_ Takes one of three possible values, "direct", "indirect", or "any", indicating whether this logical requirement expects Samus to enter in direct G-mode, indirect G-mode, or either.
-* _artificialMorph:_ A boolean indicating whether the logical requirement expects Samus to enter in an artificially morphed state (without necessarily having collected the Morph item).
+* _mode:_ Takes one of three possible values, "direct", "indirect", or "any", indicating whether this logical requirement expects Samus to enter in direct G-mode, indirect G-mode, or either. Direct G-mode is the state obtained when G-mode is first entered (i.e., the next room after the G-mode setup is performed), while indirect G-mode is the state after passing a door transition with G-mode (usually back into the room where the G-mode setup was performed).
+* _artificialMorph:_ A boolean indicating whether the logical requirement expects Samus to either obtain or already have an artificially morphed state when coming into the room.
 * _previouslyOverloadedPLMs:_ A boolean indicating whether the logical requirement expects that PLMs have already been overloaded when entering the room. This is only applicable to indirect G-mode.
-* _immobile:_ A boolean indicating whether the logical requirement expects Samus to enter in a G-mode immobile state, which means an enemy must be available in the right location to hit Samus and return control.
+* _immobile:_ A boolean indicating whether the logical requirement expects Samus to enter in a G-mode immobile state, which means an enemy must be able to hit Samus where she spawns in the destination room in order to regain control.
 
 __Example:__
 ```json

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -362,6 +362,9 @@ __Additional considerations__
   * The `leaveWithGModeSetup` object must satisfy following requirements in order to match:
     * Samus must have non-zero reserve energy.
     * Any additional requirements in the `requires` property of the `leaveWithGModeSetup` object.
+* A `comeInWithRMode` object implicitly requires a reserve trigger.
+  * Therefore Samus' regular energy will become whatever reserve energy she had before the transition, truncated to her maximum amount of regular energy (based on the number of ETanks collected).
+  * Samus' reserve energy will become zero.
 
 Please refer to the sections on `leaveWithGModeSetup` in [the Region documentation](region/region-readme.md) for a more detailed explanation of this object.
 
@@ -396,10 +399,10 @@ __Additional considerations__
     * Any additional requirements in the `requires` property of the `leaveWithGMode` object.
 * In the case of direct G-mode, `comeInWithGMode` object implicitly requires an energy drain caused by the reserve trigger and preceding setup:
   * If the tech `canEnterGModeImmobile` is enabled and the `gModeImmobileRequires` on the corresponding door is satisfied, then Samus' regular energy will become whatever reserve energy she had before the transition, truncated to her maximum amount of regular energy (based on the number of ETanks collected).
-  * Otherwise, Samus' regular energy will become 4, or whatever her reserve energy was before the transition if it was less than 4.
-  * Samus' reserve energy will always be drained to zero.
+  * Otherwise, Samus' regular energy will become 4, or whatever reserve energy she had before the transition if it was less than 4.
+  * Samus' reserve energy will always become zero.
 
-Please refer to the sections on `leaveWithGModeSetup` and `leaveWithGMode` in [the Region documentation](region/region-readme.md) for a more detailed explanation of these objects.
+Please refer to the sections on `leaveWithGModeSetup`, `leaveWithGMode`, and `gModeImmobileRequires` in [the Region documentation](region/region-readme.md) for a more detailed explanation of these objects.
 
 
 ### Room Pathing Objects

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -359,7 +359,7 @@ __Additional considerations__
 * A `comeInWithRMode` object implicitly requires X-Ray Scope and a Reserve Tank.
 * A `comeInWithRMode` object implicitly requires the `canEnterRMode` tech.
 * A `comeInWithRMode` requires that one of the indicating nodes in `fromNodes` has a matching `leaveWithGModeSetup`.
-  * The `leaveWithGModeSetup` object must satisfy following requirements in order to match:
+  * The `leaveWithGModeSetup` object must satisfy the following requirements in order to match:
     * Samus must have non-zero reserve energy.
     * Any additional requirements in the `requires` property of the `leaveWithGModeSetup` object.
 * A `comeInWithRMode` object implicitly requires a reserve trigger.
@@ -389,7 +389,7 @@ __Additional considerations__
 * A `comeInWithGMode` object implicitly requires the `canEnterGMode` tech.
   * If `artificialMorph` is `true` then it also requires the `canArtificialMorph` tech.
 * A `comeInWithGMode` requires that one of the indicating nodes in `fromNodes` has a matching `leaveWithGModeSetup` or `leaveWithGMode` object in the corresponding door node of the neighboring room:
-  * A `leaveWithGModeSetup` object must satisfy following requirements in order to match:
+  * A `leaveWithGModeSetup` object must satisfy the following requirements in order to match:
     * The `mode` in the `comeInWithGMode` object must be "direct" or "any".
     * Samus must have non-zero reserve energy.
     * Any additional requirements in the `requires` property of the `leaveWithGModeSetup`.

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -358,12 +358,12 @@ __Additional considerations__
 
 * A `comeInWithRMode` object implicitly requires X-Ray Scope and a Reserve Tank.
 * A `comeInWithRMode` object implicitly requires the `canEnterRMode` tech.
-* A `comeInWithRMode` requires that one of the indicating nodes in `fromNodes` has a matching `leaveWithDamage`.
-  * The `leaveWithDamage` object must satisfy following requirements in order to match:
+* A `comeInWithRMode` requires that one of the indicating nodes in `fromNodes` has a matching `leaveWithGModeSetup`.
+  * The `leaveWithGModeSetup` object must satisfy following requirements in order to match:
     * Samus must have non-zero reserve energy.
-    * Any additional requirements in the `requires` property of the `leaveWithDamage` object.
+    * Any additional requirements in the `requires` property of the `leaveWithGModeSetup` object.
 
-Please refer to the sections on `leaveWithDamage` in [the Region documentation](region/region-readme.md) for a more detailed explanation of this object.
+Please refer to the sections on `leaveWithGModeSetup` in [the Region documentation](region/region-readme.md) for a more detailed explanation of this object.
 
 #### comeInWithGMode object
 A `comeInWithGMode` object represents the need to either have or obtain G-mode when entering the room. It has the following properties:
@@ -390,18 +390,18 @@ __Additional considerations__
 * A `comeInWithGMode` object implicitly requires the `canEnterGMode` tech.
   * If `immobile` is `true` then it also requires the `canEnterGModeImmobile` tech.
   * If `artificialMorph` is `true` then it also requires the `canArtificialMorph` tech.
-* A `comeInWithGMode` requires that one of the indicating nodes in `fromNodes` has a matching `leaveWithDamage` or `leaveWithGMode` object in the corresponding door node of the neighboring room:
-  * A `leaveWithDamage` object must satisfy following requirements in order to match:
+* A `comeInWithGMode` requires that one of the indicating nodes in `fromNodes` has a matching `leaveWithGModeSetup` or `leaveWithGMode` object in the corresponding door node of the neighboring room:
+  * A `leaveWithGModeSetup` object must satisfy following requirements in order to match:
     * The `mode` in the `comeInWithGMode` object must be "direct" or "any".
     * Samus must have non-zero reserve energy.
-    * Any additional requirements in the `requires` property of the `leaveWithDamage`.
+    * Any additional requirements in the `requires` property of the `leaveWithGModeSetup`.
   * A `leaveWithGMode` object must satisfy the following requirements in order to match:
     * The `mode` in the `comeInWithGMode` object must be "indirect" or "any".
     * If `artificialMorph` is `true`, then the `leavesWithArtificialMorph` property of the `leaveWithGMode` object must be `true`.
     * If `previouslyOverloadedPLMs` is `true`, then the `leavesWithOverloadedPLMs` property of the `leaveWithGMode` object must be `true`.
     * Any additional requirements in the `requires` property of the `leaveWithGMode` object.
 
-Please refer to the sections on `leaveWithDamage` and `leaveWithGMode` in [the Region documentation](region/region-readme.md) for a more detailed explanation of these objects.
+Please refer to the sections on `leaveWithGModeSetup` and `leaveWithGMode` in [the Region documentation](region/region-readme.md) for a more detailed explanation of these objects.
 
 
 ### Room Pathing Objects

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -397,9 +397,9 @@ __Additional considerations__
     * The `mode` in the `comeInWithGMode` object must be "indirect" or "any".
     * If `artificialMorph` is `true`, then either the `leavesWithArtificialMorph` property of the `leaveWithGMode` object must be `true` or there is an additional requirement that the Morph item be collected.
     * Any additional requirements in the `requires` property of the `leaveWithGMode` object.
-* In the case of direct G-mode, `comeInWithGMode` object implicitly requires an energy drain caused by the reserve trigger and preceding setup:
+* In the case of direct G-mode, `comeInWithGMode` object implicitly requires an energy drain caused by the reserve trigger and the need to damage down in the preceding setup:
   * If the tech `canEnterGModeImmobile` is enabled and the `gModeImmobile` on the corresponding door is satisfied, then Samus' regular energy will become whatever reserve energy she had before the transition, truncated to her maximum amount of regular energy (based on the number of ETanks collected).
-  * Otherwise, Samus' regular energy will become 4, reflecting the need  or whatever reserve energy she had before the transition if it was less than 4.
+  * Otherwise, Samus' regular energy will become 4, or whatever reserve energy she had before the transition if it was less than 4.
   * Samus' reserve energy will always become zero.
 
 Please refer to the sections on `leaveWithGModeSetup`, `leaveWithGMode`, and `gModeImmobile` in [the Region documentation](region/region-readme.md) for a more detailed explanation of these objects.

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -370,7 +370,6 @@ A `comeInWithGMode` object represents the need to either have or obtain G-mode w
 * _fromNodes:_ Indicates from what doors this logical requirement expects Samus to enter the room.
 * _mode:_ Takes one of three possible values, "direct", "indirect", or "any", indicating whether this logical requirement expects Samus to enter in direct G-mode, indirect G-mode, or either. Direct G-mode is the state obtained when G-mode is first entered (i.e., the next room after the G-mode setup is performed), while indirect G-mode is the state after passing a door transition with G-mode (usually back into the room where the G-mode setup was performed).
 * _artificialMorph:_ A boolean indicating whether the logical requirement expects Samus to either obtain or already have an artificially morphed state when coming into the room.
-* _previouslyOverloadedPLMs:_ A boolean indicating whether the logical requirement expects that PLMs have already been overloaded when entering the room. This is only applicable to indirect G-mode.
 * _immobile:_ A boolean indicating whether the logical requirement expects Samus to enter in a G-mode immobile state, which means an enemy must be able to hit Samus where she spawns in the destination room in order to regain control.
 
 __Example:__
@@ -379,7 +378,6 @@ __Example:__
   "fromNodes": [1],
   "mode": "any",
   "artificialMorph": false,
-  "previouslyOverloadedPLMs": false,
   "immobile": false
 }}
 ```
@@ -398,7 +396,6 @@ __Additional considerations__
   * A `leaveWithGMode` object must satisfy the following requirements in order to match:
     * The `mode` in the `comeInWithGMode` object must be "indirect" or "any".
     * If `artificialMorph` is `true`, then the `leavesWithArtificialMorph` property of the `leaveWithGMode` object must be `true`.
-    * If `previouslyOverloadedPLMs` is `true`, then the `leavesWithOverloadedPLMs` property of the `leaveWithGMode` object must be `true`.
     * Any additional requirements in the `requires` property of the `leaveWithGMode` object.
 
 Please refer to the sections on `leaveWithGModeSetup` and `leaveWithGMode` in [the Region documentation](region/region-readme.md) for a more detailed explanation of these objects.

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -397,7 +397,7 @@ __Additional considerations__
     * The `mode` in the `comeInWithGMode` object must be "indirect" or "any".
     * If `artificialMorph` is `true`, then either the `leavesWithArtificialMorph` property of the `leaveWithGMode` object must be `true` or there is an additional requirement that the Morph item be collected.
     * Any additional requirements in the `requires` property of the `leaveWithGMode` object.
-* In the case of direct G-mode, `comeInWithGMode` object implicitly requires an energy drain caused by the reserve trigger and the need to damage down in the preceding setup:
+* In the case of direct G-mode, `comeInWithGMode` object implicitly requires an energy drain caused by the reserve trigger and the need to damage down (and possibly drain most of reserves) in the preceding setup:
   * If the tech `canEnterGModeImmobile` is enabled and the `gModeImmobile` on the corresponding door is satisfied, then Samus' regular energy will become whatever reserve energy she had before the transition, truncated to her maximum amount of regular energy (based on the number of ETanks collected).
   * Otherwise, Samus' regular energy will become 4, or whatever reserve energy she had before the transition if it was less than 4.
   * Samus' reserve energy will always become zero.

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -394,6 +394,10 @@ __Additional considerations__
     * The `mode` in the `comeInWithGMode` object must be "indirect" or "any".
     * If `artificialMorph` is `true`, then the `leavesWithArtificialMorph` property of the `leaveWithGMode` object must be `true`.
     * Any additional requirements in the `requires` property of the `leaveWithGMode` object.
+* In the case of direct G-mode, `comeInWithGMode` object implicitly requires an energy drain caused by the reserve trigger and preceding setup:
+  * If the tech `canEnterGModeImmobile` is enabled and the `gModeImmobileRequires` on the corresponding door is satisfied, then Samus' regular energy will become whatever reserve energy she had before the transition, truncated to her maximum amount of regular energy (based on the number of ETanks collected).
+  * Otherwise, Samus' regular energy will become 4, or whatever her reserve energy was before the transition if it was less than 4.
+  * Samus' reserve energy will always be drained to zero.
 
 Please refer to the sections on `leaveWithGModeSetup` and `leaveWithGMode` in [the Region documentation](region/region-readme.md) for a more detailed explanation of these objects.
 

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -352,8 +352,7 @@
                     {"comeInWithGMode": {
                       "fromNodes": [1],
                       "mode": "any",
-                      "artificialMorph": false,
-                      "immobile": false
+                      "artificialMorph": false
                     }}
                   ],
                   "note": [
@@ -631,8 +630,7 @@
                     {"comeInWithGMode": {
                       "fromNodes": [1, 2, 4],
                       "mode": "any",
-                      "artificialMorph": true,
-                      "immobile": false
+                      "artificialMorph": true
                     }}
                   ],
                   "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
@@ -667,8 +665,7 @@
                     {"comeInWithGMode": {
                       "fromNodes": [2, 3, 4],
                       "mode": "any",
-                      "artificialMorph": true,
-                      "immobile": false
+                      "artificialMorph": true
                     }}
                   ],
                   "note": [
@@ -934,8 +931,7 @@
                     {"comeInWithGMode": {
                       "fromNodes": [2],
                       "artificialMorph": false,
-                      "mode": "any",
-                      "immobile": false
+                      "mode": "any"
                     }}
                   ]
                 }
@@ -951,8 +947,7 @@
                     {"comeInWithGMode": {
                       "fromNodes": [2],
                       "artificialMorph": true,
-                      "mode": "any",
-                      "immobile": false
+                      "mode": "any"
                     }}
                   ]
                 }
@@ -992,8 +987,7 @@
                     {"comeInWithGMode": {
                       "fromNodes": [1],
                       "artificialMorph": false,
-                      "mode": "any",
-                      "immobile": false
+                      "mode": "any"
                     }}
                   ]
                 }
@@ -1009,8 +1003,7 @@
                     {"comeInWithGMode": {
                       "fromNodes": [1],
                       "artificialMorph": true,
-                      "mode": "any",
-                      "immobile": false
+                      "mode": "any"
                     }}
                   ]
                 }
@@ -1159,6 +1152,14 @@
               "openEnd": 0
             }
           ],
+          "gModeImmobileRequires": [
+            {"enemyDamage": {
+              "enemy": "Geemer (blue)",
+              "type": "contact",
+              "hits": 1
+            }},
+            "f_ZebesAwake"
+          ],
           "locks": [
             {
               "name": "Parlor Middle Left Escape Lock (to Save)",
@@ -1196,6 +1197,14 @@
               ],
               "openEnd": 1
             }
+          ],
+          "gModeImmobileRequires": [
+            {"enemyDamage": {
+              "enemy": "Geemer (blue)",
+              "type": "contact",
+              "hits": 1
+            }},
+            "f_ZebesAwake"
           ],
           "locks": [
             {
@@ -1281,6 +1290,14 @@
                 }
               ]
             }
+          ],
+          "gModeImmobileRequires": [
+            {"enemyDamage": {
+              "enemy": "Geemer (blue)",
+              "type": "contact",
+              "hits": 1
+            }},
+            "f_ZebesAwake"
           ]
         },
         {
@@ -1304,6 +1321,15 @@
               ],
               "openEnd": 0
             }
+          ],
+          "gModeImmobileRequires": [
+            {"enemyDamage": {
+              "enemy": "Geemer (blue)",
+              "type": "contact",
+              "hits": 1
+            }},
+            "f_ZebesAwake",
+            "canBePatient"
           ]
         },
         {
@@ -1353,6 +1379,14 @@
                 }
               ]
             }
+          ],
+          "gModeImmobileRequires": [
+            {"enemyDamage": {
+              "enemy": "Geemer (blue)",
+              "type": "contact",
+              "hits": 1
+            }},
+            "f_ZebesAwake"
           ]
         },
         {
@@ -1375,6 +1409,14 @@
                 }
               ]
             }
+          ],
+          "gModeImmobileRequires": [
+            {"enemyDamage": {
+              "enemy": "Geemer (blue)",
+              "type": "contact",
+              "hits": 1
+            }},
+            "f_ZebesAwake"
           ]
         },
         {

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -304,6 +304,13 @@
           "nodeType": "junction",
           "nodeSubType": "junction",
           "note": "Represents the ledge on the way to gauntlet, but on the right side of the bomb blocks."
+        },
+        {
+          "id": 8,
+          "name": "G-Mode Morph Junction (Ship)",
+          "nodeType": "junction",
+          "nodeSubType": "junction",
+          "note": "Represents being at the Ship with G-Mode Morph (artificial morph)"
         }
       ],
       "enemies": [],
@@ -323,30 +330,6 @@
         {
           "from": 1,
           "to": [
-            {
-              "id": 3,
-              "strats": [
-                {
-                  "name": "G-Mode Morph IBJ",
-                  "notable": false,
-                  "requires": [
-                    "Bombs",
-                    {"comeInWithGMode": {
-                      "fromNodes": [1],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }}
-                  ],
-                  "note": [
-                    "Overload the scroll PLMs which are one tile to the left of the bomb blocks leading to Gauntlet.",
-                    "Then pass through the bomb blocks (which will have become air).",
-                    "Without unmorphing, use IBJ to get all the way up to the top right."
-                  ],
-                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
-                }
-              ],
-              "note": "This link is only for G-Mode strats. All other strats should go 1 -> 7 -> 5 -> 3."
-            },
             {
               "id": 4,
               "strats": [
@@ -407,6 +390,30 @@
                   ]
                 }
               ]
+            },
+            {
+              "id": 8,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    "Bombs",
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }}
+                  ],
+                  "note": [
+                    "Overload the scroll PLMs which are one tile to the left of the bomb blocks leading to Gauntlet.",
+                    "Then pass through the bomb blocks (which will have become air)."
+                  ],
+                  "devNote": [
+                    "Other items (SpringBall or Power Bombs) could be used to get through but these cases are not relevant, as Bombs are needed to do anything useful with G-Mode Morph after this point."
+                  ]
+                }
+              ]
             }
           ]
         },
@@ -420,6 +427,22 @@
                   "name": "Base",
                   "notable": false,
                   "requires": []
+                }
+              ]
+            },
+            {
+              "id": 8,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }}
+                  ]
                 }
               ]
             }
@@ -499,25 +522,6 @@
                     "With the door closed, run the full upper runway and jump at the end.",
                     "Morph after bumping the top of the sky to bounce through the bomb blocks to the Gauntlet."
                   ]
-                },
-                {
-                  "name": "G-Mode Morph Power Bomb",
-                  "notable": false,
-                  "requires": [
-                    "Bombs",
-                    "PowerBombs",
-                    {"ammo": {"type": "PowerBomb", "count": 1}},
-                    {"comeInWithGMode": {
-                      "fromNodes": [3],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }}
-                  ],
-                  "note": [
-                    "Using IBJ to reach the right location, place a Power Bomb and it will hit but not break the blocks.",
-                    "After unmorphing and using X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
-                  ],
-                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
                 }
               ],
               "note": "This link is only for sparking, breaking the blocks with temp blue suit, and G-mode. All other strats should go 3 -> 4 -> 5 -> 7 -> 1."
@@ -529,6 +533,22 @@
                   "name": "Base",
                   "notable": false,
                   "requires": []
+                }
+              ]
+            },
+            {
+              "id": 8,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [3],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }}
+                  ]
                 }
               ]
             }
@@ -630,25 +650,6 @@
                     "Starting near the right runway, run through the bomb block passage, then jump right after exiting.",
                     "Using HiJump and space jump, Samus is able to elevate enough to break through the bomb blocks blocking the Gauntlet entrance."
                   ]
-                },
-                {
-                  "name": "G-Mode Morph Power Bomb",
-                  "notable": false,
-                  "requires": [
-                    "Bombs",
-                    "PowerBombs",
-                    {"ammo": {"type": "PowerBomb", "count": 1}},
-                    {"comeInWithGMode": {
-                      "fromNodes": [4],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }}
-                  ],
-                  "note": [
-                    "Using IBJ to reach the right location, place a Power Bomb and it will hit but not break the blocks.",
-                    "After unmorphing and using X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
-                  ],
-                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
                 }
               ],
               "devNote": "This link is only for sparking, blue space jump, and G-mode. All other strats should go 4 -> 5 -> 7 -> 1."
@@ -683,19 +684,6 @@
                     "HiJump",
                     "canSpringBallJumpMidAir"
                   ]
-                },
-                {
-                  "name": "G-Mode Morph IBJ",
-                  "notable": false,
-                  "requires": [
-                    "Bombs",
-                    {"comeInWithGMode": {
-                      "fromNodes": [4],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }}
-                  ],
-                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
                 }
               ]
             },
@@ -708,36 +696,29 @@
                   "requires": []
                 }
               ]
+            },
+            {
+              "id": 8,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    "h_canArtificialMorphMovement",
+                    {"comeInWithGMode": {
+                      "fromNodes": [4],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }}
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "from": 5,
           "to": [
-            {
-              "id": 1,
-              "strats": [
-                {
-                  "name": "G-Mode Morph Power Bomb",
-                  "notable": false,
-                  "requires": [
-                    "Bombs",
-                    "PowerBombs",
-                    {"ammo": {"type": "PowerBomb", "count": 1}},
-                    {"comeInWithGMode": {
-                      "fromNodes": [2],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }}
-                  ],
-                  "note": [
-                    "Using IBJ to reach the right location, place a Power Bomb and it will hit but not break the blocks.",
-                    "After unmorphing and using X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
-                  ],
-                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
-                }
-              ]
-            },
             {
               "id": 2,
               "strats": [
@@ -958,6 +939,41 @@
                   "name": "Base",
                   "notable": false,
                   "requires": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "from": 8,
+          "to": [
+            {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "G-Mode Morph Power Bomb",
+                  "notable": false,
+                  "requires": [
+                    "Bombs",
+                    "PowerBombs",
+                    {"ammo": {"type": "PowerBomb", "count": 1}}
+                  ],
+                  "note": [
+                    "Using IBJ to reach the right location, place a Power Bomb and it will hit but not break the blocks.",
+                    "After unmorphing and using X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
+                  ],
+                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "G-Mode Morph IBJ",
+                  "notable": false,
+                  "requires": ["Bombs"],
+                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
                 }
               ]
             }

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2591,7 +2591,7 @@
               ]
             }
           ],
-          "leaveWithDamage": [
+          "leaveWithGModeSetup": [
             {
               "strats": [
                 {
@@ -2639,7 +2639,7 @@
               ]
             }
           ],
-          "leaveWithDamage": [
+          "leaveWithGModeSetup": [
             {
               "strats": [
                 {

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -623,7 +623,7 @@
                   ]
                 },
                 {
-                  "name": "G-Mode Artificial Morph IBJ",
+                  "name": "G-Mode Morph IBJ",
                   "notable": false,
                   "requires": [
                     "Bombs",
@@ -656,7 +656,7 @@
               "id": 1,
               "strats": [
                 {
-                  "name": "G-Mode Artificial Morph Power Bomb",
+                  "name": "G-Mode Morph Power Bomb",
                   "notable": false,
                   "requires": [
                     "Bombs",
@@ -941,7 +941,7 @@
               "leavesWithArtificialMorph": true,
               "strats": [
                 {
-                  "name": "Carry G-Mode Artificial Morph Through Tube (Right to Left)",
+                  "name": "Carry G-Mode Morph Through Tube (Right to Left)",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
@@ -997,7 +997,7 @@
               "leavesWithArtificialMorph": true,
               "strats": [
                 {
-                  "name": "Carry G-Mode Artificial Morph Through Tube (Left to Right)",
+                  "name": "Carry G-Mode Morph Through Tube (Left to Right)",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -366,6 +366,10 @@
                     "Overload the scroll PLMs which are one tile to the left of the bomb blocks leading to Gauntlet.",
                     "Then pass through the bomb blocks (which will have become air).",
                     "If needed, continue on through the next set of bomb blocks (which will also be air) to reach the bottom right door."
+                  ],
+                  "devNote": [
+                    "FIXME: add something to indicate we can refill at the Ship on the way (e.g. if we add a logical requirement type for this).",
+                    "This only affects the logic in the case where we can't walljump or get over the top in some other way."
                   ]
                 }
               ],

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -120,7 +120,7 @@
           ],
           "leaveWithGMode": [
             {
-              "leavesWithPLMsOverloaded": true,
+              "leavesWithOverloadedPLMs": true,
               "leavesWithArtificialMorph": false,
               "strats": [
                 {
@@ -142,7 +142,7 @@
               ]
             },
             {
-              "leavesWithPLMsOverloaded": true,
+              "leavesWithOverloadedPLMs": true,
               "leavesWithArtificialMorph": true,
               "strats": [
                 {
@@ -208,7 +208,7 @@
           "leaveWithGMode": [
             {
               "leavesWithArtificialMorph": false,
-              "leavesWithPLMsOverloaded": true,
+              "leavesWithOverloadedPLMs": true,
               "strats": [
                 {
                   "name": "Overload Scroll PLMs",
@@ -257,7 +257,7 @@
           "leaveWithGMode": [
             {
               "leavesWithArtificialMorph": false,
-              "leavesWithPLMsOverloaded": true,
+              "leavesWithOverloadedPLMs": true,
               "strats": [
                 {
                   "name": "Overload Scroll PLMs",
@@ -366,7 +366,7 @@
           "leaveWithGMode": [
             {
               "leavesWithArtificialMorph": false,
-              "leavesWithPLMsOverloaded": true,
+              "leavesWithOverloadedPLMs": true,
               "strats": [
                 {
                   "name": "Overload Scroll PLMs",
@@ -2590,6 +2590,17 @@
                 }
               ]
             }
+          ],
+          "leaveWithDamage": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Mellow",
+                  "notable": false,
+                  "requires": []
+                }
+              ]
+            }
           ]
         },
         {
@@ -2624,6 +2635,17 @@
                   "name": "Base",
                   "notable": false,
                   "requires": [ "canShinechargeMovement" ]
+                }
+              ]
+            }
+          ],
+          "leaveWithDamage": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Mellow",
+                  "notable": false,
+                  "requires": []
                 }
               ]
             }

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -136,7 +136,7 @@
                     }}
                   ],
                   "note": [
-                    "Enter with direct G-mode, overload the scroll PLMs, then exit back through the same door."
+                    "Enter with direct G-mode, overload the scroll PLMs which are one tile to the left of the bomb blocks, then exit back through the same door."
                   ]
                 }
               ]
@@ -162,7 +162,7 @@
                     }}
                   ],
                   "note": [
-                    "Enter with direct G-mode and artificial morph, overload the scroll PLMs, then exit back through the same door.",
+                    "Enter with direct G-mode and artificial morph, overload the scroll PLMs which are one tile to the left of the bomb blocks, then exit back through the same door.",
                     "Use Bombs or SpringBall to navigate back and forth without unmorphing."
                   ]
                 }
@@ -204,6 +204,32 @@
               ],
               "openEnd": 1
             }
+          ],
+          "leaveWithGMode": [
+            {
+              "leavesWithArtificialMorph": false,
+              "leavesWithPLMsOverloaded": true,
+              "strats": [
+                {
+                  "name": "Overload Scroll PLMs",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "SpeedBooster",
+                      {"and": [
+                        "ScrewAttack",
+                        "canDelayedWalljump"
+                      ]}
+                    ]}
+                  ],
+                  "note": [
+                    "Use SpeedBooster or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
+                    "Use the scroll PLMs one tile to the left of those blocks to finish overloading PLMs."
+                  ],
+                  "devNote": "There are no energy requirements for sparking, since we can refill at the Ship before and after."
+                }
+              ]
+            }
           ]
         },
         {
@@ -226,6 +252,49 @@
                 }
               ],
               "openEnd": 1
+            }
+          ],
+          "leaveWithGMode": [
+            {
+              "leavesWithArtificialMorph": false,
+              "leavesWithPLMsOverloaded": true,
+              "strats": [
+                {
+                  "name": "Overload Scroll PLMs",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "SpeedBooster",
+                      "ScrewAttack"
+                    ]},
+                    {"or": [
+                      "h_canFly",
+                      {"and": [
+                        "canTrickyDashJump",
+                        "HiJump",
+                        "canSpringBallJumpMidAir"
+                      ]},
+                      {"canShineCharge": {
+                        "usedTiles": 19,
+                        "steepUpTiles": 2,
+                        "steepDownTiles": 1,
+                        "shinesparkFrames": 45,
+                        "excessShinesparkFrames": 13,
+                        "openEnd": 2
+                      }}
+                    ]}
+                  ],
+                  "note": [
+                    "Use SpeedBooster or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
+                    "Use the scroll PLMs one tile to the left of those blocks to overload PLMs.",
+                    "Return to the door with either SpaceJump, a SpringBall jump (with HiJump), or shinesparking."
+                  ],
+                  "devNote": [
+                    "There are no energy requirement for sparking through the blocks on the Gauntlet ledge, since we can refill at the Ship before and after.",
+                    "The only spark we consider for the return path is the short-charge on the plateau, since this has minimal energy requirements."
+                  ]
+                }
+              ]
             }
           ],
           "locks": [
@@ -292,6 +361,32 @@
               ],
               "openEnd": 1,
               "devNote": "SpeedBooster is here without a shineCharge on the knowledge that you can reach the ship for free and break the blocks from there."
+            }
+          ],
+          "leaveWithGMode": [
+            {
+              "leavesWithArtificialMorph": false,
+              "leavesWithPLMsOverloaded": true,
+              "strats": [
+                {
+                  "name": "Overload Scroll PLMs",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "SpeedBooster",
+                      {"and": [
+                        "ScrewAttack",
+                        "canDelayedWalljump"
+                      ]}
+                    ]}
+                  ],
+                  "note": [
+                    "Use SpeedBooster or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
+                    "Use the scroll PLMs one tile to the left of those blocks to overload PLMs."
+                  ],
+                  "devNote": "There are no energy requirements for sparking, since we can refill at the Ship before and after."
+                }
+              ]
             }
           ],
           "locks": [

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -946,7 +946,7 @@
                     {"ammo": {"type": "PowerBomb", "count": 1}}
                   ],
                   "note": [
-                    "Using IBJ to reach the right location, place a Power Bomb and it will hit but not break the blocks.",
+                    "Using IBJ to reach the Gauntlet entrance bomb blocks, place a Power Bomb and it will hit but not break the blocks.",
                     "After unmorphing and using X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
                   ]
                 }

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -743,19 +743,6 @@
                       "openEnd": 2
                     }}
                   ]
-                },
-                {
-                  "name": "G-Mode Morph IBJ",
-                  "notable": false,
-                  "requires": [
-                    "Bombs",
-                    {"comeInWithGMode": {
-                      "fromNodes": [2],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }}
-                  ],
-                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
                 }
               ],
               "note": "This link is only for sparking and G-Mode. All other strats should go 5 -> 4 -> 3."
@@ -954,15 +941,14 @@
                   "name": "G-Mode Morph Power Bomb",
                   "notable": false,
                   "requires": [
-                    "Bombs",
+                    "h_canArtificialMorphIBJ",
                     "PowerBombs",
                     {"ammo": {"type": "PowerBomb", "count": 1}}
                   ],
                   "note": [
                     "Using IBJ to reach the right location, place a Power Bomb and it will hit but not break the blocks.",
                     "After unmorphing and using X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
-                  ],
-                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
+                  ]
                 }
               ]
             },
@@ -972,8 +958,7 @@
                 {
                   "name": "G-Mode Morph IBJ",
                   "notable": false,
-                  "requires": ["Bombs"],
-                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
+                  "requires": ["h_canArtificialMorphIBJ"]
                 }
               ]
             }

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -219,7 +219,16 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      "SpeedBooster",
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 19,
+                          "steepUpTiles": 2,
+                          "steepDownTiles": 1,
+                          "shinesparkFrames": 0,
+                          "openEnd": 2
+                        }},
+                        "canShinechargeMovementComplex"
+                      ]},
                       {"and": [
                         "ScrewAttack",
                         "canDelayedWalljump"
@@ -227,10 +236,13 @@
                     ]}
                   ],
                   "note": [
-                    "Use SpeedBooster or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
+                    "Use a shinespark or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
                     "Use the scroll PLMs one tile to the left of those blocks to finish overloading PLMs."
                   ],
-                  "devNote": "There are no energy requirements for sparking, since we can refill at the Ship before and after."
+                  "devNote": [
+                    "There are no energy requirements for sparking, since we can refill at the Ship before and after.",
+                    "For simplicity we only consider the Big Jump spark from the plateau since this can be done without using tanks."
+                  ]
                 }
               ]
             }
@@ -268,7 +280,10 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      "SpeedBooster",
+                      {"and": [
+                        "SpeedBooster",
+                        "canShinechargeMovementComplex"
+                      ]},
                       "ScrewAttack"
                     ]},
                     {"or": [
@@ -289,13 +304,14 @@
                     ]}
                   ],
                   "note": [
-                    "Use SpeedBooster or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
+                    "Use a shinespark or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
                     "Use the scroll PLMs one tile to the left of those blocks to overload PLMs.",
-                    "Return to the door with either SpaceJump, a SpringBall jump (with HiJump), or shinesparking."
+                    "Return to the top right door with either SpaceJump, a SpringBall jump (with HiJump), or shinespark."
                   ],
                   "devNote": [
-                    "There are no energy requirement for sparking through the blocks on the Gauntlet ledge, since we can refill at the Ship before and after.",
-                    "The only spark we consider for the return path is the short-charge on the plateau, since this has minimal energy requirements."
+                    "For getting through the bomb blocks, for simplicity we only consider the Big Jump spark from the plateau since this can be done without using tanks.",
+                    "We don't include energy requirements for sparking through the blocks on the Gauntlet ledge, since we can refill at the Ship before and after.",
+                    "The only spark we consider for the return path is again the short-charge on the plateau."
                   ]
                 }
               ]
@@ -377,7 +393,16 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      "SpeedBooster",
+                      {"and": [
+                        {"canShineCharge": {
+                          "usedTiles": 19,
+                          "steepUpTiles": 2,
+                          "steepDownTiles": 1,
+                          "shinesparkFrames": 0,
+                          "openEnd": 2
+                        }},
+                        "canShinechargeMovementComplex"
+                      ]},
                       {"and": [
                         "ScrewAttack",
                         "canDelayedWalljump"
@@ -385,10 +410,13 @@
                     ]}
                   ],
                   "note": [
-                    "Use SpeedBooster or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
-                    "Use the scroll PLMs one tile to the left of those blocks to overload PLMs."
+                    "Use a shinespark or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
+                    "Use the scroll PLMs one tile to the left of those blocks to finish overloading PLMs."
                   ],
-                  "devNote": "There are no energy requirements for sparking, since we can refill at the Ship before and after."
+                  "devNote": [
+                    "There are no energy requirements for sparking, since we can refill at the Ship before and after.",
+                    "For simplicity we only consider the Big Jump spark from the plateau since this can be done without using tanks."
+                  ]
                 }
               ]
             }

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -118,6 +118,57 @@
               ]
             }
           ],
+          "leaveWithGMode": [
+            {
+              "leavesWithPLMsOverloaded": true,
+              "leavesWithArtificialMorph": false,
+              "strats": [
+                {
+                  "name": "Overload Scroll PLMs",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "direct",
+                      "artificialMorph": false,
+                      "previouslyOverloadedPLMs": false,
+                      "immobile": false
+                    }}
+                  ],
+                  "note": [
+                    "Enter with direct G-mode, overload the scroll PLMs, then exit back through the same door."
+                  ]
+                }
+              ]
+            },
+            {
+              "leavesWithPLMsOverloaded": true,
+              "leavesWithArtificialMorph": true,
+              "strats": [
+                {
+                  "name": "Artificial Morph Overload Scroll PLMs",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "Bombs",
+                      "SpringBall"
+                    ]},
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "direct",
+                      "artificialMorph": true,
+                      "previouslyOverloadedPLMs": false,
+                      "immobile": false
+                    }}
+                  ],
+                  "note": [
+                    "Enter with direct G-mode and artificial morph, overload the scroll PLMs, then exit back through the same door.",
+                    "Use Bombs or SpringBall to navigate back and forth without unmorphing."
+                  ]
+                }
+              ]
+            }
+          ],
           "locks": [
             {
               "name": "Landing Site Top Left Escape Lock (to Gauntlet)",
@@ -324,6 +375,29 @@
           "from": 1,
           "to": [
             {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "G-Mode Artificial Morph into IBJ",
+                  "notable": false,
+                  "requires": [
+                    "Bombs",
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true,
+                      "previouslyOverloadedPLMs": false,
+                      "immobile": false
+                    }}
+                  ],
+                  "note": [
+                    "Overload the scroll PLMs which are one tile to the left of the bomb blocks.",
+                    "Then pass through the bomb blocks (which will have become air) while maintaining artificial morph, and IBJ to the top right."
+                  ]
+                }
+              ]
+            },
+            {
               "id": 4,
               "strats": [
                 {
@@ -364,6 +438,23 @@
                       "id": "A",
                       "requires": ["h_canDestroyBombWalls"]
                     }
+                  ]
+                },
+                {
+                  "name": "G-Mode through Bomb Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": false,
+                      "previouslyOverloadedPLMs": false,
+                      "immobile": false
+                    }}
+                  ],
+                  "note": [
+                    "Overload the scroll PLMs which are one tile to the left of the bomb blocks.",
+                    "Then pass through the bomb blocks (which will have become air)."
                   ]
                 }
               ]

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -150,8 +150,12 @@
                   "notable": false,
                   "requires": [
                     {"or": [
+                      "SpringBall",
                       "Bombs",
-                      "SpringBall"
+                      {"and": [
+                        "canBombHorizontally",
+                        {"ammo": {"type": "PowerBomb", "count": 4 }}
+                      ]}
                     ]},
                     {"comeInWithGMode": {
                       "fromNodes": [1],
@@ -163,7 +167,7 @@
                   ],
                   "note": [
                     "Enter with direct G-mode and artificial morph, overload the scroll PLMs which are one tile to the left of the bomb blocks, then exit back through the same door.",
-                    "Use Bombs or SpringBall to navigate back and forth without unmorphing."
+                    "Use SpringBall, Bombs, or Power Bombs to navigate without unmorphing."
                   ]
                 }
               ]

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -118,61 +118,6 @@
               ]
             }
           ],
-          "leaveWithGMode": [
-            {
-              "leavesWithOverloadedPLMs": true,
-              "leavesWithArtificialMorph": false,
-              "strats": [
-                {
-                  "name": "Overload Scroll PLMs",
-                  "notable": false,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [1],
-                      "mode": "direct",
-                      "artificialMorph": false,
-                      "previouslyOverloadedPLMs": false,
-                      "immobile": false
-                    }}
-                  ],
-                  "note": [
-                    "Enter with direct G-mode, overload the scroll PLMs which are one tile to the left of the bomb blocks, then exit back through the same door."
-                  ]
-                }
-              ]
-            },
-            {
-              "leavesWithOverloadedPLMs": true,
-              "leavesWithArtificialMorph": true,
-              "strats": [
-                {
-                  "name": "Artificial Morph Overload Scroll PLMs",
-                  "notable": false,
-                  "requires": [
-                    {"or": [
-                      "SpringBall",
-                      "Bombs",
-                      {"and": [
-                        "canBombHorizontally",
-                        {"ammo": {"type": "PowerBomb", "count": 4 }}
-                      ]}
-                    ]},
-                    {"comeInWithGMode": {
-                      "fromNodes": [1],
-                      "mode": "direct",
-                      "artificialMorph": true,
-                      "previouslyOverloadedPLMs": false,
-                      "immobile": false
-                    }}
-                  ],
-                  "note": [
-                    "Enter with direct G-mode and artificial morph, overload the scroll PLMs which are one tile to the left of the bomb blocks, then exit back through the same door.",
-                    "Use SpringBall, Bombs, or Power Bombs to navigate without unmorphing."
-                  ]
-                }
-              ]
-            }
-          ],
           "locks": [
             {
               "name": "Landing Site Top Left Escape Lock (to Gauntlet)",
@@ -208,44 +153,6 @@
               ],
               "openEnd": 1
             }
-          ],
-          "leaveWithGMode": [
-            {
-              "leavesWithArtificialMorph": false,
-              "leavesWithOverloadedPLMs": true,
-              "strats": [
-                {
-                  "name": "Overload Scroll PLMs",
-                  "notable": false,
-                  "requires": [
-                    {"or": [
-                      {"and": [
-                        {"canShineCharge": {
-                          "usedTiles": 19,
-                          "steepUpTiles": 2,
-                          "steepDownTiles": 1,
-                          "shinesparkFrames": 0,
-                          "openEnd": 2
-                        }},
-                        "canShinechargeMovementComplex"
-                      ]},
-                      {"and": [
-                        "ScrewAttack",
-                        "canDelayedWalljump"
-                      ]}
-                    ]}
-                  ],
-                  "note": [
-                    "Use a shinespark or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
-                    "Use the scroll PLMs one tile to the left of those blocks to finish overloading PLMs."
-                  ],
-                  "devNote": [
-                    "There are no energy requirements for sparking, since we can refill at the Ship before and after.",
-                    "For simplicity we only consider the Big Jump spark from the plateau since this can be done without using tanks."
-                  ]
-                }
-              ]
-            }
           ]
         },
         {
@@ -268,53 +175,6 @@
                 }
               ],
               "openEnd": 1
-            }
-          ],
-          "leaveWithGMode": [
-            {
-              "leavesWithArtificialMorph": false,
-              "leavesWithOverloadedPLMs": true,
-              "strats": [
-                {
-                  "name": "Overload Scroll PLMs",
-                  "notable": false,
-                  "requires": [
-                    {"or": [
-                      {"and": [
-                        "SpeedBooster",
-                        "canShinechargeMovementComplex"
-                      ]},
-                      "ScrewAttack"
-                    ]},
-                    {"or": [
-                      "h_canFly",
-                      {"and": [
-                        "canTrickyDashJump",
-                        "HiJump",
-                        "canSpringBallJumpMidAir"
-                      ]},
-                      {"canShineCharge": {
-                        "usedTiles": 19,
-                        "steepUpTiles": 2,
-                        "steepDownTiles": 1,
-                        "shinesparkFrames": 45,
-                        "excessShinesparkFrames": 13,
-                        "openEnd": 2
-                      }}
-                    ]}
-                  ],
-                  "note": [
-                    "Use a shinespark or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
-                    "Use the scroll PLMs one tile to the left of those blocks to overload PLMs.",
-                    "Return to the top right door with either SpaceJump, a SpringBall jump (with HiJump), or shinespark."
-                  ],
-                  "devNote": [
-                    "For getting through the bomb blocks, for simplicity we only consider the Big Jump spark from the plateau since this can be done without using tanks.",
-                    "We don't include energy requirements for sparking through the blocks on the Gauntlet ledge, since we can refill at the Ship before and after.",
-                    "The only spark we consider for the return path is again the short-charge on the plateau."
-                  ]
-                }
-              ]
             }
           ],
           "locks": [
@@ -381,44 +241,6 @@
               ],
               "openEnd": 1,
               "devNote": "SpeedBooster is here without a shineCharge on the knowledge that you can reach the ship for free and break the blocks from there."
-            }
-          ],
-          "leaveWithGMode": [
-            {
-              "leavesWithArtificialMorph": false,
-              "leavesWithOverloadedPLMs": true,
-              "strats": [
-                {
-                  "name": "Overload Scroll PLMs",
-                  "notable": false,
-                  "requires": [
-                    {"or": [
-                      {"and": [
-                        {"canShineCharge": {
-                          "usedTiles": 19,
-                          "steepUpTiles": 2,
-                          "steepDownTiles": 1,
-                          "shinesparkFrames": 0,
-                          "openEnd": 2
-                        }},
-                        "canShinechargeMovementComplex"
-                      ]},
-                      {"and": [
-                        "ScrewAttack",
-                        "canDelayedWalljump"
-                      ]}
-                    ]}
-                  ],
-                  "note": [
-                    "Use a shinespark or Screw Attack to break through the bomb blocks on the Gauntlet ledge.",
-                    "Use the scroll PLMs one tile to the left of those blocks to finish overloading PLMs."
-                  ],
-                  "devNote": [
-                    "There are no energy requirements for sparking, since we can refill at the Ship before and after.",
-                    "For simplicity we only consider the Big Jump spark from the plateau since this can be done without using tanks."
-                  ]
-                }
-              ]
             }
           ],
           "locks": [
@@ -502,29 +324,6 @@
           "from": 1,
           "to": [
             {
-              "id": 3,
-              "strats": [
-                {
-                  "name": "G-Mode Artificial Morph into IBJ",
-                  "notable": false,
-                  "requires": [
-                    "Bombs",
-                    {"comeInWithGMode": {
-                      "fromNodes": [1],
-                      "mode": "any",
-                      "artificialMorph": true,
-                      "previouslyOverloadedPLMs": false,
-                      "immobile": false
-                    }}
-                  ],
-                  "note": [
-                    "Overload the scroll PLMs which are one tile to the left of the bomb blocks.",
-                    "Then pass through the bomb blocks (which will have become air) while maintaining artificial morph, and IBJ to the top right."
-                  ]
-                }
-              ]
-            },
-            {
               "id": 4,
               "strats": [
                 {
@@ -575,7 +374,6 @@
                       "fromNodes": [1],
                       "mode": "any",
                       "artificialMorph": false,
-                      "previouslyOverloadedPLMs": false,
                       "immobile": false
                     }}
                   ],
@@ -823,6 +621,20 @@
                     "HiJump",
                     "canSpringBallJumpMidAir"
                   ]
+                },
+                {
+                  "name": "G-Mode Artificial Morph IBJ",
+                  "notable": false,
+                  "requires": [
+                    "Bombs",
+                    {"comeInWithGMode": {
+                      "fromNodes": [1, 2, 4],
+                      "mode": "any",
+                      "artificialMorph": true,
+                      "immobile": false
+                    }}
+                  ],
+                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
                 }
               ]
             },
@@ -1038,6 +850,26 @@
                     }
                   ],
                   "devNote": "This is for sparking from 5 -> 1."
+                },
+                {
+                  "name": "G-Mode Artificial Morph Power Bomb",
+                  "notable": false,
+                  "requires": [
+                    "Bombs",
+                    "PowerBombs",
+                    {"ammo": {"type": "PowerBomb", "count": 1}},
+                    {"comeInWithGMode": {
+                      "fromNodes": [2, 3, 4],
+                      "mode": "any",
+                      "artificialMorph": true,
+                      "immobile": false
+                    }}
+                  ],
+                  "note": [
+                    "Using IBJ to reach the right location, place a Power Bomb and it will hit but not break the blocks.",
+                    "After unmorphing and using X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
+                  ],
+                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
                 }
               ]
             },

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -1152,14 +1152,16 @@
               "openEnd": 0
             }
           ],
-          "gModeImmobileRequires": [
-            {"enemyDamage": {
-              "enemy": "Geemer (blue)",
-              "type": "contact",
-              "hits": 1
-            }},
-            "f_ZebesAwake"
-          ],
+          "gModeImmobile": {
+            "requires": [
+              {"enemyDamage": {
+                "enemy": "Geemer (blue)",
+                "type": "contact",
+                "hits": 1
+              }},
+              "f_ZebesAwake"
+            ]
+          },
           "locks": [
             {
               "name": "Parlor Middle Left Escape Lock (to Save)",
@@ -1198,14 +1200,16 @@
               "openEnd": 1
             }
           ],
-          "gModeImmobileRequires": [
-            {"enemyDamage": {
-              "enemy": "Geemer (blue)",
-              "type": "contact",
-              "hits": 1
-            }},
-            "f_ZebesAwake"
-          ],
+          "gModeImmobile": {
+            "requires": [
+              {"enemyDamage": {
+                "enemy": "Geemer (blue)",
+                "type": "contact",
+                "hits": 1
+              }},
+              "f_ZebesAwake"
+            ]
+          },
           "locks": [
             {
               "name": "Parlor Bottom Left Escape Lock (to Final Missile Bombway)",
@@ -1291,14 +1295,16 @@
               ]
             }
           ],
-          "gModeImmobileRequires": [
-            {"enemyDamage": {
-              "enemy": "Geemer (blue)",
-              "type": "contact",
-              "hits": 1
-            }},
-            "f_ZebesAwake"
-          ]
+          "gModeImmobile": {
+            "requires": [
+              {"enemyDamage": {
+                "enemy": "Geemer (blue)",
+                "type": "contact",
+                "hits": 1
+              }},
+              "f_ZebesAwake"
+            ]
+          }
         },
         {
           "id": 5,
@@ -1322,15 +1328,18 @@
               "openEnd": 0
             }
           ],
-          "gModeImmobileRequires": [
-            {"enemyDamage": {
-              "enemy": "Geemer (blue)",
-              "type": "contact",
-              "hits": 1
-            }},
-            "f_ZebesAwake",
-            "canBePatient"
-          ]
+          "gModeImmobile": {
+            "requires": [
+              {"enemyDamage": {
+                "enemy": "Geemer (blue)",
+                "type": "contact",
+                "hits": 1
+              }},
+              "f_ZebesAwake",
+              "canBePatient"
+            ],
+            "note": "It takes over 3 minutes for a global Geemer to reach this location."
+          }
         },
         {
           "id": 6,
@@ -1380,14 +1389,16 @@
               ]
             }
           ],
-          "gModeImmobileRequires": [
-            {"enemyDamage": {
-              "enemy": "Geemer (blue)",
-              "type": "contact",
-              "hits": 1
-            }},
-            "f_ZebesAwake"
-          ]
+          "gModeImmobile": {
+            "requires": [
+              {"enemyDamage": {
+                "enemy": "Geemer (blue)",
+                "type": "contact",
+                "hits": 1
+              }},
+              "f_ZebesAwake"
+            ]
+          }
         },
         {
           "id": 7,
@@ -1410,14 +1421,16 @@
               ]
             }
           ],
-          "gModeImmobileRequires": [
-            {"enemyDamage": {
-              "enemy": "Geemer (blue)",
-              "type": "contact",
-              "hits": 1
-            }},
-            "f_ZebesAwake"
-          ]
+          "gModeImmobile": {
+            "requires": [
+              {"enemyDamage": {
+                "enemy": "Geemer (blue)",
+                "type": "contact",
+                "hits": 1
+              }},
+              "f_ZebesAwake"
+            ]
+          }
         },
         {
           "id": 8,

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -876,7 +876,7 @@
                     }
                   ],
                   "devNote": "This is for sparking from 5 -> 1."
-                },
+                }
               ]
             },
             {
@@ -922,6 +922,42 @@
               ],
               "openEnd": 1
             }
+          ],
+          "leaveWithGMode": [
+            {
+              "leavesWithArtificialMorph": false,
+              "strats": [
+                {
+                  "name": "Carry G-Mode Through Tube (Right to Left)",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "artificialMorph": false,
+                      "mode": "any",
+                      "immobile": false
+                    }}
+                  ]
+                }
+              ]
+            },
+            {
+              "leavesWithArtificialMorph": true,
+              "strats": [
+                {
+                  "name": "Carry G-Mode Artificial Morph Through Tube (Right to Left)",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "artificialMorph": true,
+                      "mode": "any",
+                      "immobile": false
+                    }}
+                  ]
+                }
+              ]
+            }
           ]
         },
         {
@@ -943,6 +979,42 @@
                 }
               ],
               "openEnd": 1
+            }
+          ],
+          "leaveWithGMode": [
+            {
+              "leavesWithArtificialMorph": false,
+              "strats": [
+                {
+                  "name": "Carry G-Mode Through Tube (Left to Right)",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "artificialMorph": false,
+                      "mode": "any",
+                      "immobile": false
+                    }}
+                  ]
+                }
+              ]
+            },
+            {
+              "leavesWithArtificialMorph": true,
+              "strats": [
+                {
+                  "name": "Carry G-Mode Artificial Morph Through Tube (Left to Right)",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "artificialMorph": true,
+                      "mode": "any",
+                      "immobile": false
+                    }}
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -344,11 +344,28 @@
                       "requires": []
                     }
                   ]
+                },
+                {
+                  "name": "G-Mode through Bomb Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": false,
+                      "immobile": false
+                    }}
+                  ],
+                  "note": [
+                    "Overload the scroll PLMs which are one tile to the left of the bomb blocks leading to Gauntlet.",
+                    "Then pass through the bomb blocks (which will have become air).",
+                    "If needed, continue on through the next set of bomb blocks (which will also be air) to reach the bottom right door."
+                  ]
                 }
               ],
               "note": "Shinespark through the top of the door to reach the breakable blocks.",
               "devNote": [
-                "This link is only for sparking. All other strats should go 1 -> 7 -> 5 -> 4.",
+                "This link is only for sparking and G-mode. All other strats should go 1 -> 7 -> 5 -> 4.",
                 "The shinespark may end early dropping Samus into 7, or 5.  But speed alone is enough to reach any of 4,5, and 7."
               ]
             },
@@ -364,22 +381,6 @@
                       "id": "A",
                       "requires": ["h_canDestroyBombWalls"]
                     }
-                  ]
-                },
-                {
-                  "name": "G-Mode through Bomb Blocks",
-                  "notable": false,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [1],
-                      "mode": "any",
-                      "artificialMorph": false,
-                      "immobile": false
-                    }}
-                  ],
-                  "note": [
-                    "Overload the scroll PLMs which are one tile to the left of the bomb blocks.",
-                    "Then pass through the bomb blocks (which will have become air)."
                   ]
                 }
               ]
@@ -654,6 +655,31 @@
           "from": 5,
           "to": [
             {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "G-Mode Artificial Morph Power Bomb",
+                  "notable": false,
+                  "requires": [
+                    "Bombs",
+                    "PowerBombs",
+                    {"ammo": {"type": "PowerBomb", "count": 1}},
+                    {"comeInWithGMode": {
+                      "fromNodes": [2, 3, 4],
+                      "mode": "any",
+                      "artificialMorph": true,
+                      "immobile": false
+                    }}
+                  ],
+                  "note": [
+                    "Using IBJ to reach the right location, place a Power Bomb and it will hit but not break the blocks.",
+                    "After unmorphing and using X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
+                  ],
+                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
+                }
+              ]
+            },
+            {
               "id": 2,
               "strats": [
                 {
@@ -851,26 +877,6 @@
                   ],
                   "devNote": "This is for sparking from 5 -> 1."
                 },
-                {
-                  "name": "G-Mode Artificial Morph Power Bomb",
-                  "notable": false,
-                  "requires": [
-                    "Bombs",
-                    "PowerBombs",
-                    {"ammo": {"type": "PowerBomb", "count": 1}},
-                    {"comeInWithGMode": {
-                      "fromNodes": [2, 3, 4],
-                      "mode": "any",
-                      "artificialMorph": true,
-                      "immobile": false
-                    }}
-                  ],
-                  "note": [
-                    "Using IBJ to reach the right location, place a Power Bomb and it will hit but not break the blocks.",
-                    "After unmorphing and using X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
-                  ],
-                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
-                }
               ]
             },
             {

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -324,6 +324,30 @@
           "from": 1,
           "to": [
             {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "G-Mode Morph IBJ",
+                  "notable": false,
+                  "requires": [
+                    "Bombs",
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }}
+                  ],
+                  "note": [
+                    "Overload the scroll PLMs which are one tile to the left of the bomb blocks leading to Gauntlet.",
+                    "Then pass through the bomb blocks (which will have become air).",
+                    "Without unmorphing, use IBJ to get all the way up to the top right."
+                  ],
+                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
+                }
+              ],
+              "note": "This link is only for G-Mode strats. All other strats should go 1 -> 7 -> 5 -> 3."
+            },
+            {
               "id": 4,
               "strats": [
                 {
@@ -475,9 +499,28 @@
                     "With the door closed, run the full upper runway and jump at the end.",
                     "Morph after bumping the top of the sky to bounce through the bomb blocks to the Gauntlet."
                   ]
+                },
+                {
+                  "name": "G-Mode Morph Power Bomb",
+                  "notable": false,
+                  "requires": [
+                    "Bombs",
+                    "PowerBombs",
+                    {"ammo": {"type": "PowerBomb", "count": 1}},
+                    {"comeInWithGMode": {
+                      "fromNodes": [3],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }}
+                  ],
+                  "note": [
+                    "Using IBJ to reach the right location, place a Power Bomb and it will hit but not break the blocks.",
+                    "After unmorphing and using X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
+                  ],
+                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
                 }
               ],
-              "note": "This link is only for sparking or breaking the blocks with temp blue suit. All other strats should go 3 -> 4 -> 5 -> 7 -> 1."
+              "note": "This link is only for sparking, breaking the blocks with temp blue suit, and G-mode. All other strats should go 3 -> 4 -> 5 -> 7 -> 1."
             },
             {
               "id": 4,
@@ -587,9 +630,28 @@
                     "Starting near the right runway, run through the bomb block passage, then jump right after exiting.",
                     "Using HiJump and space jump, Samus is able to elevate enough to break through the bomb blocks blocking the Gauntlet entrance."
                   ]
+                },
+                {
+                  "name": "G-Mode Morph Power Bomb",
+                  "notable": false,
+                  "requires": [
+                    "Bombs",
+                    "PowerBombs",
+                    {"ammo": {"type": "PowerBomb", "count": 1}},
+                    {"comeInWithGMode": {
+                      "fromNodes": [4],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }}
+                  ],
+                  "note": [
+                    "Using IBJ to reach the right location, place a Power Bomb and it will hit but not break the blocks.",
+                    "After unmorphing and using X-Ray to cancel G-mode, the blocks will be broken, allowing Samus to pass through."
+                  ],
+                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
                 }
               ],
-              "devNote": "This link is only for sparking or blue space jump. All other strats should go 4 -> 5 -> 7 -> 1."
+              "devNote": "This link is only for sparking, blue space jump, and G-mode. All other strats should go 4 -> 5 -> 7 -> 1."
             },
             {
               "id": 3,
@@ -628,7 +690,7 @@
                   "requires": [
                     "Bombs",
                     {"comeInWithGMode": {
-                      "fromNodes": [1, 2, 4],
+                      "fromNodes": [4],
                       "mode": "any",
                       "artificialMorph": true
                     }}
@@ -663,7 +725,7 @@
                     "PowerBombs",
                     {"ammo": {"type": "PowerBomb", "count": 1}},
                     {"comeInWithGMode": {
-                      "fromNodes": [2, 3, 4],
+                      "fromNodes": [2],
                       "mode": "any",
                       "artificialMorph": true
                     }}
@@ -700,9 +762,22 @@
                       "openEnd": 2
                     }}
                   ]
+                },
+                {
+                  "name": "G-Mode Morph IBJ",
+                  "notable": false,
+                  "requires": [
+                    "Bombs",
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }}
+                  ],
+                  "devNote": "FIXME: We should add a tech canIBJ requirement, after removing its dependence on Morph."
                 }
               ],
-              "note": "This link is only for sparking. All other strats should go 5 -> 4 -> 3."
+              "note": "This link is only for sparking and G-Mode. All other strats should go 5 -> 4 -> 3."
             },
             {
               "id": 4,

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -164,7 +164,7 @@ Represents the ability to exit through the door while in G-mode. This is an arra
 
 The only known way to enter G-mode is to have or obtain G-mode while entering the room. Therefore, each strat in a `leaveWithGMode` object will need to include a `comeInWithGMode` requirement. Since it is not possible to shoot open doors while in G-mode, and only the door behind Samus remains open in direct G-mode, the only way to leave with G-mode through a different door is in cases where there is no door cap (e.g. elevators, sand, tunnels) or if there is some way to bypass the door cap.
 
-A `leaveWithGMode` object does not need to be included for strats which simply turn around and immediately exit back through the same door. Specifically, for every door node that exits to the left, right, or down, there are two implicit `leaveWithGMode` objects, one of the form
+A `leaveWithGMode` object does not need to be included for strats which simply turn around and immediately exit back through the same door. Specifically, for every door node without a `spawnAt` property, there are two implicit `leaveWithGMode` objects, one of the form
 
 ```json
 {"leaveWithGMode": {

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -184,7 +184,7 @@ A `leaveWithGMode` object does not need to be included for strats which simply t
 }}
 ```
 
-where 0 is replaced with the node ID of the given node, and another where the `false` values in `leavesWithArtificialMorph` and `artificialMorph` are replaced with `true`.
+where 0 is replaced with the node ID of the given node, and another where the `false` values in `leavesWithArtificialMorph` and `artificialMorph` are replaced with `true`. Here we are referring to nodes with `"nodeType": "door"`, which excludes sand entrances (which instead have `"nodeType": "entrance"`).
 
 #### gModeImmobile
 

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -167,7 +167,7 @@ The only known way to enter G-mode is to have or obtain G-mode while entering th
 
 ##### Implicit leaveWithGMode
 
-A `leaveWithGMode` object does not need to be included for strats which simply turn around and immediately exit back through the same door without overloading PLMs or doing anything else. Specifically, for every door node that has no `spawnAt` property and exits to the left, right, or down, there are two implicit `leaveWithGMode` objects of the form
+A `leaveWithGMode` object does not need to be included for strats which simply turn around and immediately exit back through the same door without overloading PLMs or doing anything else. Specifically, for every door node that has no `spawnAt` property and exits to the left, right, or down, there are two implicit `leaveWithGMode` objects, one of the form
 
 ```json
 {"leaveWithGMode": {
@@ -189,27 +189,7 @@ A `leaveWithGMode` object does not need to be included for strats which simply t
 }}
 ```
 
-```json
-{"leaveWithGMode": {
-  "leavesWithOverloadedPLMs": false,
-  "leavesWithArtificialMorph": true,
-  "strats": {
-    "name": "Base",
-    "notable": false,
-    "requires": [
-      {"comeInWithGMode": {
-        "fromNodes": [0],
-        "mode": "direct",
-        "artificialMorph": true,
-        "previouslyOverloadedPLMs": false,
-        "immobile": false
-      }}
-    ]
-  }
-}}
-```
-
-where in `"fromNodes": [0]`, the 0 is replaced with the node ID of the given node.
+where 0 is replaced with the node ID of the given node, and another where the `false` values in `leavesWithArtificialMorph` and `artificialMorph` are replaced with `true`.
 
 #### twinDoorAddresses
 A door node is considered to have a twin when the game has two sections that are visually identical, but are separate in the game's memory. The player will not know during gameplay that the two twin doors aren't actually the same. Both twins lead to the same destination door, but that destination door only ever leads to one of the twins, with the other only being reachable from within its room. An example (and the only known one currently) is East Pants Room, which has a another version of itself within Pants Room.

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -186,6 +186,10 @@ A `leaveWithGMode` object does not need to be included for strats which simply t
 
 where 0 is replaced with the node ID of the given node, and another where the `false` values in `leavesWithArtificialMorph` and `artificialMorph` are replaced with `true`.
 
+#### gModeImmobileRequires
+
+Logical requirements to be able to restore control to Samus when entering the room with G-mode immobile. This should include an `enemyDamage` requirement to account for the damage Samus takes from the hit, or it may be `"never"` if there is no applicable enemy.
+
 #### twinDoorAddresses
 A door node is considered to have a twin when the game has two sections that are visually identical, but are separate in the game's memory. The player will not know during gameplay that the two twin doors aren't actually the same. Both twins lead to the same destination door, but that destination door only ever leads to one of the twins, with the other only being reachable from within its room. An example (and the only known one currently) is East Pants Room, which has a another version of itself within Pants Room.
 

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -186,9 +186,9 @@ A `leaveWithGMode` object does not need to be included for strats which simply t
 
 where 0 is replaced with the node ID of the given node, and another where the `false` values in `leavesWithArtificialMorph` and `artificialMorph` are replaced with `true`.
 
-#### gModeImmobileRequires
+#### gModeImmobile
 
-Logical requirements to be able to restore control to Samus when entering the room with G-mode immobile. This should include an `enemyDamage` requirement to account for the damage Samus takes from the hit, or it may be `"never"` if there is no applicable enemy.
+This should be populated if there is an enemy in the room that will eventually hit Samus at the location where she spawns when coming into the room through this door. Being hit by such an enemy will restore control to Samus after entering the room with G-mode immobile. This object contains `requires` which are logical requirements for Samus to take the enemy hit. This should include an `enemyDamage` requirement to account for the damage that Samus takes.
 
 #### twinDoorAddresses
 A door node is considered to have a twin when the game has two sections that are visually identical, but are separate in the game's memory. The player will not know during gameplay that the two twin doors aren't actually the same. Both twins lead to the same destination door, but that destination door only ever leads to one of the twins, with the other only being reachable from within its room. An example (and the only known one currently) is East Pants Room, which has a another version of itself within Pants Room.

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -145,9 +145,9 @@ Generating a shinespark charge using the door's runway (assuming the runway has 
 
 Much like using runways, a `canLeaveCharged` can only be executed if the associated door can be interacted with.
 
-#### leaveWithDamage
+#### leaveWithGModeSetup
 
-Represents the ability to exit through the door while taking damage from an enemy during the transition. This can be achieved with enemies that are able to follow Samus into the doorway during the transition. It will not work with enemy projectiles since these do not move during transitions. Under certain conditions, taking damage in this way can be used to set up R-mode or G-mode in the next room. Note that the damage must happen *during* (not *before*) the transition, so being able to take a hit that knocks Samus into the door transition does not count. The node property `leaveWithDamage` is an array of `leaveWithDamage` objects which each currently have a single property:
+Represents the ability to exit through the door while taking damage from an enemy during the transition. This can be achieved with enemies that are able to follow Samus into the doorway during the transition. It will not work with enemy projectiles since these do not move during transitions. Under certain conditions, taking damage in this way can be used to set up R-mode or G-mode in the next room. Note that the damage must happen *during* (not *before*) the transition, so being able to take a hit that knocks Samus into the door transition does not count. The node property `leaveWithGModeSetup` is an array of `leaveWithGModeSetup` objects which each currently have a single property:
 
 * _strats_: An array of [strats](../strats.md), each of which may be executed to leave through the door while taking damage.
 

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -151,7 +151,7 @@ Represents the ability to exit through the door while taking damage during the t
 
 The only known way to achieve this is to use an enemy that can follow Samus into the doorway during the transition. It will not work with enemy projectiles since these do not move during transitions, and environmental damage such as heat, lava, acid do not work as these are not active during the transition. Also note that the damage must happen *during* (not *before*) the transition, so being able to take a hit that knocks Samus into the door transition does not work.
 
-The node property `leaveWithGModeSetup` is an array of objects which each currently have a single property:
+The node property `leaveWithGModeSetup` is an array of objects each of which has one main property:
 
 * _strats_: An array of [strats](../strats.md), each of which may be executed to leave through the door while taking damage.
 

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -145,6 +145,24 @@ Generating a shinespark charge using the door's runway (assuming the runway has 
 
 Much like using runways, a `canLeaveCharged` can only be executed if the associated door can be interacted with.
 
+#### leaveWithDamage
+
+Represents the ability to exit through the door while taking damage from an enemy during the transition. This can be achieved with enemies that are able to follow Samus into the doorway during the transition. It will not work with enemy projectiles since these do not move during transitions. Under certain conditions, taking damage in this way can be used to set up R-mode or G-mode in the next room. Note that the damage must happen *during* (not *before*) the transition, so being able to take a hit that knocks Samus into the door transition does not count. The node property `leaveWithDamage` is an array of `leaveWithDamage` objects which each currently have a single property:
+
+* _strats_: An array of [strats](../strats.md), each of which may be executed to leave through the door while taking damage.
+
+#### leaveWithGMode
+
+Represents the ability to exit through the door while in G-mode. This is an array of `leaveWithGMode` objects which have the following properties:
+
+* _leavesWithOverloadedPLMs_: A boolean indicating if these strats ensure that PLMs have been overloaded before exiting through the door.
+* _leavesWithArtificialMorph_: A boolean indicating if these strats exit through the door while in an artificially morphed state (i.e. without the Morph item necessarily having been collected).
+* _strats_: An array of [strats](../strats.md), each of which may be executed to leave through the door while in G-mode with the given conditions.
+
+The only known way to enter G-mode is to have or obtain G-mode while entering the room. Therefore, each strat in a `leaveWithGMode` object will need to include a `comeInWithGMode` requirement. Since it is not possible to shoot open doors while in G-mode, and only the door behind Samus remains open in direct G-mode, typically strats for `leaveWithGMode` will require `comeInWithGMode` with `fromNodes` consisting of only the same node on which the `leaveWithGMode` is placed. There are some cases where this may not be true, such as in rooms with door transitions having no door cap (e.g. elevators, sand, tunnels), or if there is some way to bypass the door cap of another door.
+
+A `leaveWithGMode` object does not need to be included for strats which simply turn around and immediately exit back through the same door, as this is always an implicit possibility (except at door nodes with a `spawnAt` property). In typical cases, the purpose of a `leaveWithGMode` strat is to express that PLMs may be overloaded in the room before returning back through the door.
+
 #### twinDoorAddresses
 A door node is considered to have a twin when the game has two sections that are visually identical, but are separate in the game's memory. The player will not know during gameplay that the two twin doors aren't actually the same. Both twins lead to the same destination door, but that destination door only ever leads to one of the twins, with the other only being reachable from within its room. An example (and the only known one currently) is East Pants Room, which has a another version of itself within Pants Room.
 

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -159,19 +159,15 @@ The node property `leaveWithGModeSetup` is an array of objects which each curren
 
 Represents the ability to exit through the door while in G-mode. This is an array of objects which have the following properties:
 
-* _leavesWithOverloadedPLMs_: A boolean indicating if these strats ensure that PLMs have been overloaded before exiting through the door.
 * _leavesWithArtificialMorph_: A boolean indicating if these strats exit through the door while in an artificially morphed state (i.e. without the Morph item necessarily having been collected).
 * _strats_: An array of [strats](../strats.md), each of which may be executed to leave through the door while in G-mode with the given conditions.
 
-The only known way to enter G-mode is to have or obtain G-mode while entering the room. Therefore, each strat in a `leaveWithGMode` object will need to include a `comeInWithGMode` requirement. Since it is not possible to shoot open doors while in G-mode, and only the door behind Samus remains open in direct G-mode, typically strats for `leaveWithGMode` will require `comeInWithGMode` with `fromNodes` consisting of only the same node on which the `leaveWithGMode` is placed. There are some cases where this may not be true, such as in rooms with door transitions having no door cap (e.g. elevators, sand, tunnels), or if there is some way to bypass the door cap of another door. But in typical cases, the purpose of a `leaveWithGMode` strat is to express that PLMs may be overloaded in the room before returning back through the door.
+The only known way to enter G-mode is to have or obtain G-mode while entering the room. Therefore, each strat in a `leaveWithGMode` object will need to include a `comeInWithGMode` requirement. Since it is not possible to shoot open doors while in G-mode, and only the door behind Samus remains open in direct G-mode, the only way to leave with G-mode through a different door is in cases where there is no door cap (e.g. elevators, sand, tunnels) or if there is some way to bypass the door cap.
 
-##### Implicit leaveWithGMode
-
-A `leaveWithGMode` object does not need to be included for strats which simply turn around and immediately exit back through the same door without overloading PLMs or doing anything else. Specifically, for every door node that has no `spawnAt` property and exits to the left, right, or down, there are two implicit `leaveWithGMode` objects, one of the form
+A `leaveWithGMode` object does not need to be included for strats which simply turn around and immediately exit back through the same door. Specifically, for every door node that exits to the left, right, or down, there are two implicit `leaveWithGMode` objects, one of the form
 
 ```json
 {"leaveWithGMode": {
-  "leavesWithOverloadedPLMs": false,
   "leavesWithArtificialMorph": false,
   "strats": {
     "name": "Base",
@@ -181,7 +177,6 @@ A `leaveWithGMode` object does not need to be included for strats which simply t
         "fromNodes": [0],
         "mode": "direct",
         "artificialMorph": false,
-        "previouslyOverloadedPLMs": false,
         "immobile": false
       }}
     ]

--- a/region/region-readme.md
+++ b/region/region-readme.md
@@ -147,21 +147,69 @@ Much like using runways, a `canLeaveCharged` can only be executed if the associa
 
 #### leaveWithGModeSetup
 
-Represents the ability to exit through the door while taking damage from an enemy during the transition. This can be achieved with enemies that are able to follow Samus into the doorway during the transition. It will not work with enemy projectiles since these do not move during transitions. Under certain conditions, taking damage in this way can be used to set up R-mode or G-mode in the next room. Note that the damage must happen *during* (not *before*) the transition, so being able to take a hit that knocks Samus into the door transition does not count. The node property `leaveWithGModeSetup` is an array of `leaveWithGModeSetup` objects which each currently have a single property:
+Represents the ability to exit through the door while taking damage during the transition, in a pose such that X-Ray can be used on the first frame of control in the next room. Under certain conditions, taking damage in this way can be used to set up R-mode or G-mode in the next room. 
+
+The only known way to achieve this is to use an enemy that can follow Samus into the doorway during the transition. It will not work with enemy projectiles since these do not move during transitions, and environmental damage such as heat, lava, acid do not work as these are not active during the transition. Also note that the damage must happen *during* (not *before*) the transition, so being able to take a hit that knocks Samus into the door transition does not work.
+
+The node property `leaveWithGModeSetup` is an array of objects which each currently have a single property:
 
 * _strats_: An array of [strats](../strats.md), each of which may be executed to leave through the door while taking damage.
 
 #### leaveWithGMode
 
-Represents the ability to exit through the door while in G-mode. This is an array of `leaveWithGMode` objects which have the following properties:
+Represents the ability to exit through the door while in G-mode. This is an array of objects which have the following properties:
 
 * _leavesWithOverloadedPLMs_: A boolean indicating if these strats ensure that PLMs have been overloaded before exiting through the door.
 * _leavesWithArtificialMorph_: A boolean indicating if these strats exit through the door while in an artificially morphed state (i.e. without the Morph item necessarily having been collected).
 * _strats_: An array of [strats](../strats.md), each of which may be executed to leave through the door while in G-mode with the given conditions.
 
-The only known way to enter G-mode is to have or obtain G-mode while entering the room. Therefore, each strat in a `leaveWithGMode` object will need to include a `comeInWithGMode` requirement. Since it is not possible to shoot open doors while in G-mode, and only the door behind Samus remains open in direct G-mode, typically strats for `leaveWithGMode` will require `comeInWithGMode` with `fromNodes` consisting of only the same node on which the `leaveWithGMode` is placed. There are some cases where this may not be true, such as in rooms with door transitions having no door cap (e.g. elevators, sand, tunnels), or if there is some way to bypass the door cap of another door.
+The only known way to enter G-mode is to have or obtain G-mode while entering the room. Therefore, each strat in a `leaveWithGMode` object will need to include a `comeInWithGMode` requirement. Since it is not possible to shoot open doors while in G-mode, and only the door behind Samus remains open in direct G-mode, typically strats for `leaveWithGMode` will require `comeInWithGMode` with `fromNodes` consisting of only the same node on which the `leaveWithGMode` is placed. There are some cases where this may not be true, such as in rooms with door transitions having no door cap (e.g. elevators, sand, tunnels), or if there is some way to bypass the door cap of another door. But in typical cases, the purpose of a `leaveWithGMode` strat is to express that PLMs may be overloaded in the room before returning back through the door.
 
-A `leaveWithGMode` object does not need to be included for strats which simply turn around and immediately exit back through the same door, as this is always an implicit possibility (except at door nodes with a `spawnAt` property). In typical cases, the purpose of a `leaveWithGMode` strat is to express that PLMs may be overloaded in the room before returning back through the door.
+##### Implicit leaveWithGMode
+
+A `leaveWithGMode` object does not need to be included for strats which simply turn around and immediately exit back through the same door without overloading PLMs or doing anything else. Specifically, for every door node that has no `spawnAt` property and exits to the left, right, or down, there are two implicit `leaveWithGMode` objects of the form
+
+```json
+{"leaveWithGMode": {
+  "leavesWithOverloadedPLMs": false,
+  "leavesWithArtificialMorph": false,
+  "strats": {
+    "name": "Base",
+    "notable": false,
+    "requires": [
+      {"comeInWithGMode": {
+        "fromNodes": [0],
+        "mode": "direct",
+        "artificialMorph": false,
+        "previouslyOverloadedPLMs": false,
+        "immobile": false
+      }}
+    ]
+  }
+}}
+```
+
+```json
+{"leaveWithGMode": {
+  "leavesWithOverloadedPLMs": false,
+  "leavesWithArtificialMorph": true,
+  "strats": {
+    "name": "Base",
+    "notable": false,
+    "requires": [
+      {"comeInWithGMode": {
+        "fromNodes": [0],
+        "mode": "direct",
+        "artificialMorph": true,
+        "previouslyOverloadedPLMs": false,
+        "immobile": false
+      }}
+    ]
+  }
+}}
+```
+
+where in `"fromNodes": [0]`, the 0 is replaced with the node ID of the given node.
 
 #### twinDoorAddresses
 A door node is considered to have a twin when the game has two sections that are visually identical, but are separate in the game's memory. The player will not know during gameplay that the two twin doors aren't actually the same. Both twins lead to the same destination door, but that destination door only ever leads to one of the twins, with the other only being reachable from within its room. An example (and the only known one currently) is East Pants Room, which has a another version of itself within Pants Room.

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -863,7 +863,7 @@
                 "leaveWithGModeSetup": {
                   "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup",
                   "type": "array",
-                  "title": "Leave With G-mode Setup",
+                  "title": "Leave With G-Mode Setup",
                   "description": "An array of ways Samus can leave through this door while taking damage through the transition, in a pose that would allow using X-Ray on the first frame after the transition. This is for setting up to enter R-mode or direct G-mode in the next room.",
                   "items": {
                     "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup/items",
@@ -877,8 +877,8 @@
                       "strats": {
                         "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup/properties/strats",
                         "type": "array",
-                        "title": "Leave With Damage Strats",
-                        "description": "An array of strats that can be executed to leave the room while taking damage. All strats implicitly use canUseEnemies tech since the only way to take damage through a transition is by an enemy.",
+                        "title": "Leave With G-Mode Setup Strats",
+                        "description": "An array of strats that can be executed to leave the room in a G-Mode setup. All strats implicitly use canUseEnemies tech since the only way to take damage through a transition is by an enemy.",
                         "items": {
                           "$ref" : "#/definitions/strat",
                           "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup/properties/strats/items"
@@ -890,7 +890,7 @@
                 "leaveWithGMode": {
                   "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode",
                   "type": "array",
-                  "title": "Leave With G-mode",
+                  "title": "Leave With G-Mode",
                   "description": "An array of ways Samus can leave through this door while in G-mode, resulting in indirect G-mode in the next room.",
                   "items": {
                     "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/items",
@@ -911,7 +911,7 @@
                       "strats": {
                         "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/properties/strats",
                         "type": "array",
-                        "title": "Leave With G-mode Strats",
+                        "title": "Leave With G-Mode Strats",
                         "description": "An array of strats that can be executed to leave this node while in G-mode.",
                         "items": {
                           "$ref" : "#/definitions/strat",

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -860,28 +860,28 @@
                     }
                   }
                 },
-                "leaveWithDamage": {
-                  "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithDamage",
+                "leaveWithGModeSetup": {
+                  "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup",
                   "type": "array",
                   "title": "Leave With Damage",
                   "description": "An array of ways Samus can leave through this door while taking damage through the transition (e.g. for setting up R-mode or direct G-mode in the neighboring room).",
                   "items": {
-                    "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithDamage/items",
+                    "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup/items",
                     "type": "object",
-                    "title": "leaveWithDamage Object",
+                    "title": "leaveWithGModeSetup Object",
                     "required": [
                       "strats"
                     ],
                     "additionalProperties": false,
                     "properties": {
                       "strats": {
-                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithDamage/properties/strats",
+                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup/properties/strats",
                         "type": "array",
                         "title": "Leave With Damage Strats",
                         "description": "An array of strats that can be executed to leave the room while taking damage. All strats implicitly use canUseEnemies tech since the only way to take damage through a transition is by an enemy.",
                         "items": {
                           "$ref" : "#/definitions/strat",
-                          "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithDamage/properties/strats/items"
+                          "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup/properties/strats/items"
                         }
                       }
                     }

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -863,7 +863,7 @@
                 "leaveWithGModeSetup": {
                   "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup",
                   "type": "array",
-                  "title": "Leave With Damage",
+                  "title": "Leave With G-mode Setup",
                   "description": "An array of ways Samus can leave through this door while taking damage through the transition, in a pose that would allow using X-Ray on the first frame after the transition. This is for setting up to enter R-mode or direct G-mode in the next room.",
                   "items": {
                     "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup/items",

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -897,20 +897,20 @@
                     "type": "object",
                     "title": "leaveWithGMode Object",
                     "required": [
-                      "leavesWithPLMsOverloaded",
+                      "leavesWithOverloadedPLMs",
                       "leavesWithArtificialMorph",
                       "strats"
                     ],
                     "additionalProperties": false,
                     "properties": {
-                      "leavesWithPLMsOverloaded": {
-                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/properties/leavesWithPLMsOverloaded",
+                      "leavesWithOverloadedPLMs": {
+                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/properties/leavesWithOverloadedPLMs",
                         "type": "boolean",
                         "title": "Leaves With PLMs Overloaded",
                         "description": "If true, then all of these strats will result in PLMs being overloaded by the time we leave the room. If false, then no guarantees are made about PLMs being overloaded or not."
                       },
                       "leavesWithArtificialMorph": {
-                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/properties/leavesWithPLMsOverloaded",
+                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/properties/leavesWithArtificialMorph",
                         "type": "boolean",
                         "title": "Leaves With Artificial Morph",
                         "description": "If true, then all of these strats will result in leaving the room while maintaining artificial morph."

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -860,6 +860,74 @@
                     }
                   }
                 },
+                "leaveWithDamage": {
+                  "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithDamage",
+                  "type": "array",
+                  "title": "Leave With Damage",
+                  "description": "An array of ways Samus can leave through this door while taking damage through the transition (e.g. for setting up R-mode or direct G-mode in the neighboring room).",
+                  "items": {
+                    "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithDamage/items",
+                    "type": "object",
+                    "title": "leaveWithDamage Object",
+                    "required": [
+                      "strats"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "strats": {
+                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithDamage/properties/strats",
+                        "type": "array",
+                        "title": "Leave With Damage Strats",
+                        "description": "An array of strats that can be executed to leave the room while taking damage. All strats implicitly use canUseEnemies tech since the only way to take damage through a transition is by an enemy.",
+                        "items": {
+                          "$ref" : "#/definitions/strat",
+                          "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithDamage/properties/strats/items"
+                        }
+                      }
+                    }
+                  }
+                },
+                "leaveWithGMode": {
+                  "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode",
+                  "type": "array",
+                  "title": "Leave With G-mode",
+                  "description": "An array of ways Samus can leave through this door while in G-mode, resulting in indirect G-mode in the next room.",
+                  "items": {
+                    "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/items",
+                    "type": "object",
+                    "title": "leaveWithGMode Object",
+                    "required": [
+                      "leavesWithPLMsOverloaded",
+                      "leavesWithArtificialMorph",
+                      "strats"
+                    ],
+                    "additionalProperties": false,
+                    "properties": {
+                      "leavesWithPLMsOverloaded": {
+                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/properties/leavesWithPLMsOverloaded",
+                        "type": "boolean",
+                        "title": "Leaves With PLMs Overloaded",
+                        "description": "If true, then all of these strats will result in PLMs being overloaded by the time we leave the room. If false, then no guarantees are made about PLMs being overloaded or not."
+                      },
+                      "leavesWithArtificialMorph": {
+                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/properties/leavesWithPLMsOverloaded",
+                        "type": "boolean",
+                        "title": "Leaves With Artificial Morph",
+                        "description": "If true, then all of these strats will result in leaving the room while maintaining artificial morph."
+                      },
+                      "strats": {
+                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/properties/strats",
+                        "type": "array",
+                        "title": "Leave With G-mode Strats",
+                        "description": "An array of strats that can be executed to leave this node while in G-mode.",
+                        "items": {
+                          "$ref" : "#/definitions/strat",
+                          "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/properties/strats/items"
+                        }
+                      }
+                    }
+                  }
+                },
                 "spawnAt": {
                   "$id": "#/properties/rooms/items/properties/nodes/items/properties/spawnAt",
                   "type": "integer",

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -897,18 +897,11 @@
                     "type": "object",
                     "title": "leaveWithGMode Object",
                     "required": [
-                      "leavesWithOverloadedPLMs",
                       "leavesWithArtificialMorph",
                       "strats"
                     ],
                     "additionalProperties": false,
                     "properties": {
-                      "leavesWithOverloadedPLMs": {
-                        "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/properties/leavesWithOverloadedPLMs",
-                        "type": "boolean",
-                        "title": "Leaves With PLMs Overloaded",
-                        "description": "If true, then all of these strats will result in PLMs being overloaded by the time we leave the room. If false, then no guarantees are made about PLMs being overloaded or not."
-                      },
                       "leavesWithArtificialMorph": {
                         "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGMode/properties/leavesWithArtificialMorph",
                         "type": "boolean",

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -935,11 +935,11 @@
                     },
                     "note": {
                       "$ref" : "m3-note.schema.json#/definitions/note",
-                      "$id": "#/properties/rooms/items/properties/nodes/items/properties/locks/items/properties/note"
+                      "$id": "#/properties/rooms/items/properties/nodes/items/properties/gModeImmobile/properties/note"
                     },
                     "devNote": {
                       "$ref" : "m3-note.schema.json#/definitions/devNote",
-                      "$id": "#/properties/rooms/items/properties/nodes/items/properties/locks/items/properties/devNote"
+                      "$id": "#/properties/rooms/items/properties/nodes/items/properties/gModeImmobile/properties/devNote"
                     }
                   }
                 },

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -921,6 +921,13 @@
                     }
                   }
                 },
+                "gModeImmobileRequires": {
+                  "$id": "#/properties/rooms/items/properties/nodes/items/properties/enemyForGModeImmobile",
+                  "$ref": "m3-requirements.schema.json#/definitions/logicalRequirements",
+                  "default": "never",
+                  "title": "G-Mode Immobile Requirements",
+                  "description": "Logical requirements in order to allow control to be returned to Samus when coming into this door with G-mode immobile"
+                },
                 "spawnAt": {
                   "$id": "#/properties/rooms/items/properties/nodes/items/properties/spawnAt",
                   "type": "integer",

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -864,7 +864,7 @@
                   "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup",
                   "type": "array",
                   "title": "Leave With Damage",
-                  "description": "An array of ways Samus can leave through this door while taking damage through the transition (e.g. for setting up R-mode or direct G-mode in the neighboring room).",
+                  "description": "An array of ways Samus can leave through this door while taking damage through the transition, in a pose that would allow using X-Ray on the first frame after the transition. This is for setting up to enter R-mode or direct G-mode in the next room.",
                   "items": {
                     "$id": "#/properties/rooms/items/properties/nodes/items/properties/leaveWithGModeSetup/items",
                     "type": "object",

--- a/schema/m3-region.schema.json
+++ b/schema/m3-region.schema.json
@@ -921,12 +921,27 @@
                     }
                   }
                 },
-                "gModeImmobileRequires": {
-                  "$id": "#/properties/rooms/items/properties/nodes/items/properties/enemyForGModeImmobile",
-                  "$ref": "m3-requirements.schema.json#/definitions/logicalRequirements",
-                  "default": "never",
-                  "title": "G-Mode Immobile Requirements",
-                  "description": "Logical requirements in order to allow control to be returned to Samus when coming into this door with G-mode immobile"
+                "gModeImmobile": {
+                  "$id": "#/properties/rooms/items/properties/nodes/items/properties/gModeImmobile",
+                  "type": "object",
+                  "required": [ "requires" ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "requires": {
+                      "$id": "#/properties/rooms/items/properties/nodes/items/properties/gModeImmobile/properties/requires",
+                      "$ref": "m3-requirements.schema.json#/definitions/logicalRequirements",
+                      "title": "G-Mode Immobile Requirements",
+                      "description": "Logical requirements in order to allow control to be returned to Samus when coming into this door with G-mode immobile"
+                    },
+                    "note": {
+                      "$ref" : "m3-note.schema.json#/definitions/note",
+                      "$id": "#/properties/rooms/items/properties/nodes/items/properties/locks/items/properties/note"
+                    },
+                    "devNote": {
+                      "$ref" : "m3-note.schema.json#/definitions/devNote",
+                      "$id": "#/properties/rooms/items/properties/nodes/items/properties/locks/items/properties/devNote"
+                    }
+                  }
                 },
                 "spawnAt": {
                   "$id": "#/properties/rooms/items/properties/nodes/items/properties/spawnAt",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -633,7 +633,7 @@
             "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode",
             "type": "object",
             "title": "Come in With G-Mode",
-            "description": "Fulfilled by being able to come into the room via one of a specific set of doors with G-mode (direct or indirect). This implicitly requires the tech canEnterGMode as well as XRayScope and ReserveTank items.",
+            "description": "Fulfilled by being able to come into the room via one of a specific set of doors with G-mode (direct or indirect). This implicitly requires the tech canEnterGMode as well as XRayScope and ReserveTank items and a matching leaveWithDamage (with non-zero reserve energy) or leaveWithGMode property on the neighboring door.",
             "required": [
               "fromNodes",
               "mode",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -638,7 +638,6 @@
               "fromNodes",
               "mode",
               "artificialMorph",
-              "previouslyOverloadedPLMs",
               "immobile"
             ],
             "additionalProperties": false,
@@ -671,12 +670,6 @@
                 "type": "boolean",
                 "title": "Artificial Morph",
                 "description": "Whether we must come in with artificial morph"
-              },
-              "previouslyOverloadedPLMs": {
-                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/previouslyOverloadedPLMs",
-                "type": "boolean",
-                "title": "Previously Overloaded PLMs",
-                "description": "Whether the strat assumes that PLMs have already been overloaded in a previous room. This is only applicable for indirect G-mode. If false, then the strat does not make any assumptions about whether PLMs are already overloaded when entering, which means that either the strat does not need overloaded PLMs, or PLMs can be overloaded in the same room as part of the strat."
               },
               "immobile": {
                 "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/immobile",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -609,7 +609,7 @@
             "$id": "#/definitions/logicalRequirement/items/properties/comeInWithRMode",
             "type": "object",
             "title": "Come in With R-Mode",
-            "description": "Fulfilled by being able to come into the room via one of a specific set of doors to obtain R-mode (not including G-mode). This implicitly requires the tech canEnterRMode.",
+            "description": "Fulfilled by being able to come into the room via one of a specific set of doors to obtain R-mode (not including G-mode). This implicitly requires the tech canEnterRMode as well as XRayScope and ReserveTank items.",
             "required": [
               "fromNodes"
             ],
@@ -633,13 +633,13 @@
             "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode",
             "type": "object",
             "title": "Come in With G-Mode",
-            "description": "Fulfilled by being able to come into the room via one of a specific set of doors with G-mode (direct or indirect). This implicitly requires the tech canEnterGMode.",
+            "description": "Fulfilled by being able to come into the room via one of a specific set of doors with G-mode (direct or indirect). This implicitly requires the tech canEnterGMode as well as XRayScope and ReserveTank items.",
             "required": [
               "fromNodes",
               "mode",
-              "needsArtificialMorph",
-              "needsPreviouslyOverloadedPLMs",
-              "usableImmobile"
+              "artificialMorph",
+              "previouslyOverloadedPLMs",
+              "immobile"
             ],
             "additionalProperties": false,
             "properties": {
@@ -666,17 +666,23 @@
                 "title": "Mode",
                 "description": "Whether we must come in with direct G-mode, indirect G-mode, or either"
               },
-              "needsArtificialMorph": {
-                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/needsArtificialMorph",
+              "artificialMorph": {
+                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/artificialMorph",
                 "type": "boolean",
-                "title": "Needs Artificial Morph",
-                "description": "Whether we must come in with artificial morph (also satisfied by having collected Morph)"
+                "title": "Artificial Morph",
+                "description": "Whether we must come in with artificial morph"
               },
-              "needsPreviouslyOverloadedPLMs": {
-                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/needsPreviouslyOverloadedPLMs",
+              "previouslyOverloadedPLMs": {
+                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/previouslyOverloadedPLMs",
                 "type": "boolean",
-                "title": "Needs Previously Overloaded PLMs",
+                "title": "Previously Overloaded PLMs",
                 "description": "Whether the strat assumes that PLMs have already been overloaded in a previous room. This is only applicable for indirect G-mode. If false, then the strat does not make any assumptions about whether PLMs are already overloaded when entering, which means that either the strat does not need overloaded PLMs, or PLMs can be overloaded in the same room as part of the strat."
+              },
+              "immobile": {
+                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/immobile",
+                "type": "boolean",
+                "title": "Immobile",
+                "description": "Whether the strat assumes that we come in with G-mode immobile. This requires that an enemy be able to hit Samus where she enters the room."
               }
             }
           }

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -609,7 +609,7 @@
             "$id": "#/definitions/logicalRequirement/items/properties/comeInWithRMode",
             "type": "object",
             "title": "Come in With R-Mode",
-            "description": "Fulfilled by being able to come into the room via one of a specific set of doors to obtain R-mode.",
+            "description": "Fulfilled by being able to come into the room via one of a specific set of doors to obtain R-mode. This implicitly requires the tech canEnterRMode.",
             "required": [
               "fromNodes"
             ],
@@ -633,7 +633,7 @@
             "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode",
             "type": "object",
             "title": "Come in With G-Mode",
-            "description": "Fulfilled by being able to come into the room via one of a specific set of doors with G-mode (direct or indirect).",
+            "description": "Fulfilled by being able to come into the room via one of a specific set of doors with G-mode (direct or indirect). This implicitly requires the tech canEnterGMode.",
             "required": [
               "fromNodes",
               "mode",
@@ -676,7 +676,7 @@
                 "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/needsPreviouslyOverloadedPLMs",
                 "type": "boolean",
                 "title": "Needs Previously Overloaded PLMs",
-                "description": "Whether we must come into the room with PLMs already overloaded. This is only applicable for indirect G-mode. If this is false, then either the strat does not need overloaded PLMs, or PLMs can be overloaded in the same room as part of the strat"
+                "description": "Whether the strat assumes that PLMs have already been overloaded in a previous room. This is only applicable for indirect G-mode. If false, then the strat does not make any assumptions about whether PLMs are already overloaded when entering, which means that either the strat does not need overloaded PLMs, or PLMs can be overloaded in the same room as part of the strat."
               }
             }
           }

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -619,12 +619,12 @@
                 "$id": "#/definitions/logicalRequirement/items/properties/comeInWithRMode/properties/fromNodes",
                 "type": "array",
                 "title": "From Nodes",
-                "description": "A list of in-room node IDs, one of which we must come in through while obtaining R-mode",
+                "description": "A list of in-room node IDs, one of which we must obtain R-mode through in order to satisfy this logical element",
                 "items": {
                   "$id": "#/definitions/logicalRequirement/items/properties/comeInWithRMode/properties/fromNode/items",
                   "type": "integer",
                   "title": "From Node",
-                  "description": "The ID of a node which we may come in through while obtaining R-mode"
+                  "description": "The ID of a node which we may obtain R-mode through in order to satisfy this logical element"
                 }
               }
             }
@@ -647,12 +647,12 @@
                 "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/fromNodes",
                 "type": "array",
                 "title": "From Nodes",
-                "description": "A list of in-room node IDs, one of which we must come in through with G-mode",
+                "description": "A list of in-room node IDs, one of which we must come in through with G-mode in order to satisfy this logical element.",
                 "items": {
                   "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/fromNodes/items",
                   "type": "integer",
                   "title": "From Node",
-                  "description": "The ID of a node which we may come in through with G-mode"
+                  "description": "The ID of a node which we may come in through with G-mode in order to satisfy this logical element."
                 }
               },
               "mode": {

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -604,10 +604,84 @@
                 "description": "Indicates that no other node but the entry node may be visited in order to fulfill this logical element. Must not be defined when it is intended to be false, unless there are no nodes or obstacles to avoid."
               }
             }
+          },
+          "comeInWithRMode": {
+            "$id": "#/definitions/logicalRequirement/items/properties/comeInWithRMode",
+            "type": "object",
+            "title": "Come in With R-Mode",
+            "description": "Fulfilled by being able to come into the room via one of a specific set of doors to obtain R-mode.",
+            "required": [
+              "fromNodes"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "fromNodes": {
+                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithRMode/properties/fromNodes",
+                "type": "array",
+                "title": "From Nodes",
+                "description": "A list of in-room node IDs, one of which we must come in through while obtaining R-mode",
+                "items": {
+                  "$id": "#/definitions/logicalRequirement/items/properties/comeInWithRMode/properties/fromNode/items",
+                  "type": "integer",
+                  "title": "From Node",
+                  "description": "The ID of a node which we may come in through while obtaining R-mode"
+                }
+              }
+            }
+          },
+          "comeInWithGMode": {
+            "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode",
+            "type": "object",
+            "title": "Come in With G-Mode",
+            "description": "Fulfilled by being able to come into the room via one of a specific set of doors with G-mode (direct or indirect).",
+            "required": [
+              "fromNodes",
+              "mode",
+              "needsArtificialMorph",
+              "needsPreviouslyOverloadedPLMs",
+              "usableImmobile"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "fromNodes": {
+                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/fromNodes",
+                "type": "array",
+                "title": "From Nodes",
+                "description": "A list of in-room node IDs, one of which we must come in through with G-mode",
+                "items": {
+                  "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/fromNodes/items",
+                  "type": "integer",
+                  "title": "From Node",
+                  "description": "The ID of a node which we may come in through with G-mode"
+                }
+              },
+              "mode": {
+                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/mode",
+                "type": "string",
+                "enum": [
+                  "direct",
+                  "indirect",
+                  "any"
+                ],
+                "title": "Mode",
+                "description": "Whether we must come in with direct G-mode, indirect G-mode, or either"
+              },
+              "needsArtificialMorph": {
+                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/needsArtificialMorph",
+                "type": "boolean",
+                "title": "Needs Artificial Morph",
+                "description": "Whether we must come in with artificial morph (also satisfied by having collected Morph)"
+              },
+              "needsPreviouslyOverloadedPLMs": {
+                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/needsPreviouslyOverloadedPLMs",
+                "type": "boolean",
+                "title": "Needs Previously Overloaded PLMs",
+                "description": "Whether we must come into the room with PLMs already overloaded. This is only applicable for indirect G-mode. If this is false, then either the strat does not need overloaded PLMs, or PLMs can be overloaded in the same room as part of the strat"
+              }
+            }
           }
         }
       }
     }
-
   }
 }

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -637,8 +637,7 @@
             "required": [
               "fromNodes",
               "mode",
-              "artificialMorph",
-              "immobile"
+              "artificialMorph"
             ],
             "additionalProperties": false,
             "properties": {
@@ -670,12 +669,6 @@
                 "type": "boolean",
                 "title": "Artificial Morph",
                 "description": "Whether we must come in with artificial morph"
-              },
-              "immobile": {
-                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/immobile",
-                "type": "boolean",
-                "title": "Immobile",
-                "description": "Whether the strat assumes that we come in with G-mode immobile. This requires that an enemy be able to hit Samus where she enters the room."
               }
             }
           }

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -633,7 +633,7 @@
             "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode",
             "type": "object",
             "title": "Come in With G-Mode",
-            "description": "Fulfilled by being able to come into the room via one of a specific set of doors with G-mode (direct or indirect). This implicitly requires the tech canEnterGMode as well as XRayScope and ReserveTank items and a matching leaveWithDamage (with non-zero reserve energy) or leaveWithGMode property on the neighboring door.",
+            "description": "Fulfilled by being able to come into the room via one of a specific set of doors with G-mode (direct or indirect). This implicitly requires the tech canEnterGMode as well as XRayScope and ReserveTank items and a matching leaveWithGModeSetup (with non-zero reserve energy) or leaveWithGMode property on the neighboring door.",
             "required": [
               "fromNodes",
               "mode",

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -668,7 +668,7 @@
                 "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/artificialMorph",
                 "type": "boolean",
                 "title": "Artificial Morph",
-                "description": "Whether we must come in with artificial morph"
+                "description": "Whether we must come in with artificial morph (also satisfied by having Morph collected)"
               }
             }
           }

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -609,7 +609,7 @@
             "$id": "#/definitions/logicalRequirement/items/properties/comeInWithRMode",
             "type": "object",
             "title": "Come in With R-Mode",
-            "description": "Fulfilled by being able to come into the room via one of a specific set of doors to obtain R-mode. This implicitly requires the tech canEnterRMode.",
+            "description": "Fulfilled by being able to come into the room via one of a specific set of doors to obtain R-mode (not including G-mode). This implicitly requires the tech canEnterRMode.",
             "required": [
               "fromNodes"
             ],
@@ -619,12 +619,12 @@
                 "$id": "#/definitions/logicalRequirement/items/properties/comeInWithRMode/properties/fromNodes",
                 "type": "array",
                 "title": "From Nodes",
-                "description": "A list of in-room node IDs, one of which we must obtain R-mode through in order to satisfy this logical element",
+                "description": "A list of in-room node IDs, through one of which we must obtain R-mode (not including G-mode) in order to satisfy this logical element",
                 "items": {
                   "$id": "#/definitions/logicalRequirement/items/properties/comeInWithRMode/properties/fromNode/items",
                   "type": "integer",
                   "title": "From Node",
-                  "description": "The ID of a node which we may obtain R-mode through in order to satisfy this logical element"
+                  "description": "The ID of a node through which we may obtain R-mode (not including G-mode) in order to satisfy this logical element"
                 }
               }
             }

--- a/tech.json
+++ b/tech.json
@@ -874,16 +874,16 @@
               "name": "canEnterGMode",
               "requires": [ "canEnterRMode" ],
               "note": [
-                "Ability to enter G-mode using a basic setup.",
-                "Have 4 energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-Ray before reserves have finished filling (a 4-frame window)."
+                "Ability to enter G-mode starting with low reserve energy (the usual way of entering G-mode).",
+                "Have 4 or fewer energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-Ray before reserves have finished filling (a 4-frame window when starting with 4 reserve energy)."
               ],
               "extensionTechs": [
                 {
                   "name": "canEnterGModeImmobile",
                   "requires": [ "canEnterGMode" ],
                   "note": [
-                    "Ability to enter G-mode immobile with high energy.",
-                    "Have 5 or more energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-ray immediately before reserves finish filling (normally a 3-frame window).",
+                    "Ability to enter G-mode starting with high reserve energy, resulting in Samus being immobilized.",
+                    "Have 5 or more energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-ray immediately before reserves finish filling (a 3-frame window when starting with 12 or more reserve energy, a much larger frame window if you have between 5 and 11).",
                     "Samus will be unable to move until getting hit by an enemy (or until canceling G-mode by using X-Ray)."
                   ]
                 },
@@ -892,8 +892,8 @@
                   "requires": [ "canEnterGMode" ],
                   "note": [
                     "Ability to obtain artificial morph with G-mode.",
-                    "Turn around after reserves finish filling but before knockback frames expire (a 4-frame window when entering G-mode with 4 reserve energy).",
-                    "For G-mode immobile, instead turn around while taking knockback from the enemy that returns control to Samus (a 5-frame window)",
+                    "For low-energy G-mode setups, turn around after reserves finish filling but before knockback frames expire (a 4-frame window when entering G-mode with 4 reserve energy).",
+                    "For high-energy (immobile) setups, instead turn around while taking knockback from the enemy that returns control to Samus (a 5-frame window)",
                     "This results in Samus entering a morph ball state without needing to have collected or equipped Morph."
                   ]
                 }

--- a/tech.json
+++ b/tech.json
@@ -883,7 +883,7 @@
                   "requires": [ "canEnterGMode" ],
                   "note": [
                     "Ability to enter G-mode immobile with high energy.",
-                    "Have 12 or more energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-ray immediately before reserves finish filling (a 3-frame window).",
+                    "Have 5 or more energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-ray immediately before reserves finish filling (normally a 3-frame window).",
                     "Samus will be unable to move until getting hit by an enemy, or until canceling G-mode by using X-Ray."
                   ]
                 },

--- a/tech.json
+++ b/tech.json
@@ -864,7 +864,7 @@
         },
         {
           "name": "canEnterRMode",
-          "requires": [ "XRayScope", "ReserveTank" ],
+          "requires": [ "XRayScope", "ReserveTank", "canUseEnemies" ],
           "note": [
             "Ability to enter R-mode.",
             "Have some energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-Ray after reserves have finished filling."

--- a/tech.json
+++ b/tech.json
@@ -874,7 +874,7 @@
               "name": "canEnterGMode",
               "requires": [ "canEnterRMode" ],
               "note": [
-                "Ability to enter G-mode starting with low reserve energy (the usual way of entering G-mode).",
+                "Ability to enter G-mode starting with low reserve energy.",
                 "Have 4 or fewer energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-Ray before reserves have finished filling (a 4-frame window when starting with 4 reserve energy)."
               ],
               "extensionTechs": [

--- a/tech.json
+++ b/tech.json
@@ -884,7 +884,7 @@
                   "note": [
                     "Ability to enter G-mode immobile with high energy.",
                     "Have 5 or more energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-ray immediately before reserves finish filling (normally a 3-frame window).",
-                    "Samus will be unable to move until getting hit by an enemy, or until canceling G-mode by using X-Ray."
+                    "Samus will be unable to move until getting hit by an enemy (or until canceling G-mode by using X-Ray)."
                   ]
                 },
                 {

--- a/tech.json
+++ b/tech.json
@@ -878,25 +878,24 @@
                 "Have 4 energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-Ray before reserves have finished filling (a 4-frame window)."
               ],
               "extensionTechs": [
-                  {
-                    "name": "canEnterGModeImmobile",
-                    "requires": [ "canEnterGMode" ],
-                    "note": [
-                      "Ability to enter G-mode immobile with high energy.",
-                      "Have 12 or more energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-ray immediately before reserves finish filling (a 3-frame window).",
-                      "Samus will be unable to move until getting hit by an enemy, or until canceling G-mode by using X-Ray."
-                    ]
-                  },
-                  {
-                    "name": "canArtificialMorph",
-                    "requires": [ "canEnterGMode" ],
-                    "note": [
-                      "Ability to obtain artificial morph with G-mode.",
-                      "Turn around after reserves finish filling but before knockback frames expire (a 4-frame window when entering G-mode with 4 reserve energy).",
-                      "For G-mode immobile, instead turn around while taking knockback from the enemy that returns control to Samus (a 5-frame window)",
-                      "This results in Samus entering a morph ball state without needing to have collected or equipped Morph."
-                    ]
-                  },
+                {
+                  "name": "canEnterGModeImmobile",
+                  "requires": [ "canEnterGMode" ],
+                  "note": [
+                    "Ability to enter G-mode immobile with high energy.",
+                    "Have 12 or more energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-ray immediately before reserves finish filling (a 3-frame window).",
+                    "Samus will be unable to move until getting hit by an enemy, or until canceling G-mode by using X-Ray."
+                  ]
+                },
+                {
+                  "name": "canArtificialMorph",
+                  "requires": [ "canEnterGMode" ],
+                  "note": [
+                    "Ability to obtain artificial morph with G-mode.",
+                    "Turn around after reserves finish filling but before knockback frames expire (a 4-frame window when entering G-mode with 4 reserve energy).",
+                    "For G-mode immobile, instead turn around while taking knockback from the enemy that returns control to Samus (a 5-frame window)",
+                    "This results in Samus entering a morph ball state without needing to have collected or equipped Morph."
+                  ]
                 }
               ]
             }

--- a/tech.json
+++ b/tech.json
@@ -861,6 +861,46 @@
               ]
             }
           ]
+        },
+        {
+          "name": "canEnterRMode",
+          "requires": [ "XRayScope", "ReserveTank" ],
+          "note": [
+            "Ability to enter R-mode.",
+            "Have some energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-Ray after reserves have finished filling."
+          ],
+          "extensionTechs": [
+            {
+              "name": "canEnterGMode",
+              "requires": [ "canEnterRMode" ],
+              "note": [
+                "Ability to enter G-mode using a basic setup.",
+                "Have 4 energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-Ray before reserves have finished filling (a 4-frame window)."
+              ],
+              "extensionTechs": [
+                  {
+                    "name": "canEnterGModeImmobile",
+                    "requires": [ "canEnterGMode" ],
+                    "note": [
+                      "Ability to enter G-mode immobile with high energy.",
+                      "Have 12 or more energy in reserves (set to Auto), take damage while going through a door, use X-Ray while entering the next room, and release X-ray immediately before reserves finish filling (a 3-frame window).",
+                      "Samus will be unable to move until getting hit by an enemy, or until canceling G-mode by using X-Ray."
+                    ]
+                  },
+                  {
+                    "name": "canArtificialMorph",
+                    "requires": [ "canEnterGMode" ],
+                    "note": [
+                      "Ability to obtain artificial morph with G-mode.",
+                      "Turn around after reserves finish filling but before knockback frames expire (a 4-frame window when entering G-mode with 4 reserve energy).",
+                      "For G-mode immobile, instead turn around while taking knockback from the enemy that returns control to Samus (a 5-frame window)",
+                      "This results in Samus entering a morph ball state without needing to have collected or equipped Morph."
+                    ]
+                  },
+                }
+              ]
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
This includes the following:
- New tech:
  - canEnterRMode
  - canEnterGMode
  - canEnterGModeImmobile
  - canArtificialMorph
- New node properties:
  - leaveWithGModeSetup
  - leaveWithGMode
- New logical requirements:
  - comeInWithRMode
  - comeInWithGMode
- New helper:
  - h_canArtificialMorphMovement
- Example strats in Landing Site, Flyway, and Crateria Tube.

The new node properties and logical requirements follow a pattern similar to "canLeaveCharged" and "canComeInCharged" (except without the "can" to avoid confusion with tech: we may later rename "canLeaveCharged" and "canComeInCharged" to "leaveCharged" and "comeInCharged"). 

The node property "leaveWithGModeSetup" is for describing how to leave a door node while taking enemy damage, in a way that can be used to set up R-mode or G-mode in the next room.

The logical requirements "comeInWithRMode" and "comeInWithGMode" are for describing how to use R-Mode or G-Mode once you have it. 

The node property "leaveWithGMode" is for describing how to carry G-mode through another transition.

One characteristic of this design is that "comeInWithGMode" strats can be fairly complex, e.g. involving going across a room to overload PLMs before moving to another point of interest, bypassing junctions that normally would be involved with such movement. 

@kjbranch and I considered an alternative design, where "G-mode" and "PLMs overloaded" would be treated as bits of state that could be tracked similarly to flags/obstacles. That approach could avoid the need for strats that bypass junctions, but at the heavy expense of needing to go through all the strats in the game and add some kind of "nonGMode" requirement to adjust them if they don't work in G-mode, such as if they depend on destroying shot blocks, bombing bomb blocks, etc. It would be more complicated than this because multiple cases would need to be addressed, based on whether PLMs are overloaded or not and whether we are using artificial morph or not. Such a design could also require increasing the amount of nodes in many rooms since some regions assumed to be freely traversable would no longer be (particularly when we consider the case of artificial morph, which can have very restrictive movement options). Overall we think the approach proposed in this PR should be more manageable, but feedback would be welcome. 

We'll need to consider somewhat similar questions later when we want to model carrying spikesuits & blue suits around the game; in that case, making implicit abilities become explicit (canJumpUp, canDash, etc.) may make sense to help determine which strats can be used while preserving the suits. But those cases are a little different because the effects of spikesuits & blue suits on the game's behavior and movement options are not nearly as complex compared to G-mode. The complexity here is a lot of what motivates us to try to keep G-mode contained to dedicated properties and strats, rather than allowing it to spread out and complicate the other strats in the game.