### PR TITLE
Correct Main Hall elevator heat damage

### DIFF
--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -159,7 +159,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 285}
+                    {"heatFrames": 440}
                   ]
                 }
               ],
@@ -178,7 +178,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 310}
+                    {"heatFrames": 440}
                   ]
                 }
               ],


### PR DESCRIPTION
I tested this and found that a suitless trip on Main Hall elevator takes exactly 109 energy in either direction (with no fast elevator patch).