### PR TITLE
Gmode helpers - Split tech to no longer require morph

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -75,7 +75,7 @@
       "name": "h_canFly",
       "requires": [
         {"or": [
-          "canIBJ",
+          "h_canIBJ",
           "SpaceJump"
         ]}
       ]

--- a/helpers.json
+++ b/helpers.json
@@ -324,6 +324,196 @@
       ]
     },
     {
+      "name": "h_canJumpIntoIBJ",
+      "requires": [
+        "canJumpIntoIBJ",
+        "h_canUseMorphBombs"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphJumpIntoIBJ",
+      "requires": [
+        "canJumpIntoIBJ",
+        "Bombs",
+        "SpringBall"
+      ]
+    },
+    {
+      "name": "h_canBombAboveIBJ",
+      "requires": [
+        "canBombAboveIBJ",
+        "h_canUseMorphBombs"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphBombAboveIBJ",
+      "requires": [
+        "canBombAboveIBJ",
+        "Bombs"
+      ]
+    },
+    {
+      "name": "h_canCeilingBombJump",
+      "requires": [
+        "canCeilingBombJump",
+        "h_canUseMorphBombs"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphCeilingBombJump",
+      "requires": [
+        "canCeilingBombJump",
+        "Bombs"
+      ]
+    },
+    {
+      "name": "h_canDiagonalBombJump",
+      "requires": [
+        "canDiagonalBombJump",
+        "h_canUseMorphBombs"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphDiagonalBombJump",
+      "requires": [
+        "canDiagonalBombJump",
+        "Bombs"
+      ]
+    },
+    {
+      "name": "h_canSandIBJ",
+      "requires": [
+        "canSandIBJ",
+        "h_canJumpIntoIBJ"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphSandIBJ",
+      "requires": [
+        "canSandIBJ",
+        "h_canArtificialMorphJumpIntoIBJ"
+      ]
+    },
+    {
+      "name": "h_canDoubleBombJump",
+      "requires": [
+        "canDoubleBombJump",
+        "h_canUseMorphBombs"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphDoubleBombJump",
+      "requires": [
+        "canDoubleBombJump",
+        "Bombs"
+      ]
+    },
+    {
+      "name": "h_canStaggeredIBJ",
+      "requires": [
+        "canStaggeredIBJ",
+        "h_canUseMorphBombs"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphStaggeredIBJ",
+      "requires": [
+        "canStaggeredIBJ",
+        "Bombs"
+      ]
+    },
+    {
+      "name": "h_canBombHorizontally",
+      "requires": [
+        "canBombHorizontally",
+        "h_canBombThings"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphBombHorizontally",
+      "requires": [
+        "canBombHorizontally",
+        {"or": [
+          "Bombs",
+          {"ammo": { "type": "PowerBomb", "count": 1 }}
+        ]}
+      ]
+    },
+    {
+      "name": "h_canHBJ",
+      "requires": [
+        "canHBJ",
+        "h_canUseMorphBombs"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphHBJ",
+      "requires": [
+        "canHBJ",
+        "Bombs"
+      ]
+    },
+    {
+      "name": "h_canResetFallSpeed",
+      "requires": [
+        "canResetFallSpeed",
+        "Morph"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphResetFallSpeed",
+      "requires": [ "canResetFallSpeed" ]
+    },
+    {
+      "name": "h_canCrystalFlash",
+      "requires": [
+        "canCrystalFlash",
+        "Morph",
+        {"ammo": { "type": "PowerBomb", "count": 1 }},
+        {"ammo": { "type": "Missile", "count": 10 }},
+        {"ammo": { "type": "Super", "count": 10 }},
+        {"ammo": { "type": "PowerBomb", "count": 10 }}
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphCrystalFlash",
+      "requires": [
+        "canCrystalFlash",
+        {"ammo": { "type": "PowerBomb", "count": 1 }},
+        {"ammo": { "type": "Missile", "count": 10 }},
+        {"ammo": { "type": "Super", "count": 10 }},
+        {"ammo": { "type": "PowerBomb", "count": 10 }}
+      ]
+    },
+    {
+      "name": "h_canCrystalFlashClip",
+      "requires": [
+        "canCrystalFlashClip",
+        "h_canCrystalFlash"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphCrystalFlashClip",
+      "requires": [
+        "canCrystalFlashClip",
+        "h_canArtificialMorphCrystalFlash"
+      ]
+    },
+    {
+      "name": "h_canCrystalFlashGrappleClip",
+      "requires": [
+        "canCrystalFlashGrappleClip",
+        "h_canCrystalFlashClip"
+      ]
+    },
+    {
+      "name": "h_canArtificialMorphCrystalFlashGrappleClip",
+      "requires": [
+        "canCrystalFlashGrappleClip",
+        "h_canArtificialMorphCrystalFlashClip"
+      ]
+    },
+    {
       "name": "h_canArtificialMorphMovement",
       "requires": [
         {"or": [

--- a/helpers.json
+++ b/helpers.json
@@ -381,20 +381,6 @@
       ]
     },
     {
-      "name": "h_canSandIBJ",
-      "requires": [
-        "canSandIBJ",
-        "h_canJumpIntoIBJ"
-      ]
-    },
-    {
-      "name": "h_canArtificialMorphSandIBJ",
-      "requires": [
-        "canSandIBJ",
-        "h_canArtificialMorphJumpIntoIBJ"
-      ]
-    },
-    {
       "name": "h_canDoubleBombJump",
       "requires": [
         "canDoubleBombJump",

--- a/helpers.json
+++ b/helpers.json
@@ -310,11 +310,18 @@
       ]
     },
     {
+      "name": "h_canIBJ",
+      "requires": [
+        "canIBJ",
+        "h_canUseMorphBombs"
+      ]
+    },
+    {
       "name": "h_canArtificialMorphIBJ",
       "requires": [
+        "canIBJ",
         "Bombs"
-      ],
-      "devNote": "FIXME: Add a canIBJ tech requirement after Morph is removed as a requirement."
+      ]
     },
     {
       "name": "h_canArtificialMorphMovement",

--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -1059,15 +1059,15 @@
                 {
                   "name": "Ceiling E-Tank IBJ",
                   "notable": false,
-                  "requires": ["canBombAboveIBJ"],
+                  "requires": ["h_canBombAboveIBJ"],
                   "devNote": "Would've been notable due to breaking the shot block while maintaining ibj, but there's a tech for that."
                 },
                 {
                   "name": "Ceiling E-Tank Jump Into IBJ",
                   "notable": false,
                   "requires": [
-                    "canJumpIntoIBJ",
-                    "canDoubleBombJump"
+                    "h_canJumpIntoIBJ",
+                    "h_canDoubleBombJump"
                   ],
                   "note": "An alternate strat to canBombAboveIBJ. Shoot the block, jump into an IBJ, then do a quick double bomb jump to make it in time."
                 },

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -610,7 +610,7 @@
                 {
                   "name": "IBJ",
                   "notable": false,
-                  "requires": ["canIBJ"]
+                  "requires": ["h_canIBJ"]
                 },
                 {
                   "name": "Space Jump",
@@ -809,7 +809,7 @@
                 {
                   "name": "Full Etecoon IBJ",
                   "notable": false,
-                  "requires": ["canIBJ"],
+                  "requires": ["h_canIBJ"],
                   "note": "This is the full climb, since you have to drop down to 10 and start there."
                 },
                 {

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -1976,7 +1976,7 @@
                   "name": "IBJ",
                   "notable": false,
                   "requires": [
-                    "h_h_canIBJ",
+                    "h_canIBJ",
                     {"obstaclesCleared": ["A"]}
                   ],
                   "obstacles": [

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -1976,7 +1976,7 @@
                   "name": "IBJ",
                   "notable": false,
                   "requires": [
-                    "canIBJ",
+                    "h_h_canIBJ",
                     {"obstaclesCleared": ["A"]}
                   ],
                   "obstacles": [

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -1222,7 +1222,7 @@
                       "id": "F",
                       "requires": [
                         "h_canBombThings",
-                        "canCrystalFlash",
+                        "h_canCrystalFlash",
                         {"ammo": {
                           "type": "Super",
                           "count": 1
@@ -1619,7 +1619,7 @@
                   "name": "Pink Brinstar Power Bombs Crystal Flash Clip",
                   "notable": true,
                   "requires": [
-                    "canCrystalFlash",
+                    "h_canCrystalFlash",
                     "canCeilingClip"
                   ],
                   "note": [

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -471,8 +471,8 @@
                   "name": "Red Tower IBJ Between the Bottom Rippers",
                   "notable": true,
                   "requires": [
-                    "canDoubleBombJump",
-                    "canStaggeredIBJ"
+                    "h_canDoubleBombJump",
+                    "h_canStaggeredIBJ"
                   ],
                   "note": "Requires switching between single and double IBJs. While Doubles are not techincally necessary, they make the strat more bearable."
                 },
@@ -489,7 +489,7 @@
                   "notable": true,
                   "requires": [
                     "canWallJumpBombBoost",
-                    "canHBJ"
+                    "h_canHBJ"
                   ],
                   "note": [
                     "Starting on the right ledge at the bottom of Red Tower, wall jump just below the middle plant, just above the top ripper.",
@@ -502,7 +502,7 @@
                   "notable": false,
                   "requires": [
                     "canWalljump",
-                    "canDiagonalBombJump"
+                    "h_canDiagonalBombJump"
                   ]
                 }
               ]
@@ -638,7 +638,7 @@
                 {
                   "name": "Red Tower IBJ",
                   "notable": false,
-                  "requires": [ "canBombAboveIBJ" ],
+                  "requires": [ "h_canBombAboveIBJ" ],
                   "obstacles": [
                     {
                       "id": "A",
@@ -955,7 +955,7 @@
                   "name": "X-Ray Access IBJ",
                   "notable": false,
                   "requires": [
-                    "canJumpIntoIBJ",
+                    "h_canJumpIntoIBJ",
                     {"spikeHits": 5},
                     {"or": [
                       "canIframeSpikeJump",

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -449,7 +449,7 @@
                       "HiJump",
                       "canWalljump",
                       "canSpringBallJumpMidAir",
-                      "canIBJ"
+                      "h_canIBJ"
                     ]}
                   ]
                 },
@@ -457,7 +457,7 @@
                   "name": "IBJ",
                   "notable": false,
                   "requires": [
-                    "canIBJ",
+                    "h_canIBJ",
                     {
                       "enemyKill": {
                         "enemies": [

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -3601,7 +3601,7 @@
                 {
                   "name": "IBJ",
                   "notable": false,
-                  "requires": ["canIBJ"]
+                  "requires": ["h_canIBJ"]
                 }
               ]
             }

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -171,7 +171,7 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    "canIBJ"
+                    "h_canIBJ"
                   ]
                 },
                 {
@@ -1024,7 +1024,7 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    "canIBJ"
+                    "h_canIBJ"
                   ]
                 },
                 {
@@ -1295,7 +1295,7 @@
                     {"or":[
                       "canWalljump",
                       "HiJump",
-                      "canIBJ"
+                      "h_canIBJ"
                     ]}
                   ],
                   "devNote": "A speedy jump would be obsoleted by another strat for being tricky."
@@ -1895,7 +1895,7 @@
                       "canWalljump",
                       "HiJump",
                       "SpaceJump",
-                      "canIBJ"
+                      "h_canIBJ"
                     ]}
                   ]
                 },

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -226,7 +226,7 @@
                 {
                   "name": "Moat Horizontal Bomb Jump",
                   "notable": false,
-                  "requires": ["canHBJ"]
+                  "requires": ["h_canHBJ"]
                 },
                 {
                   "name": "Double Spring Ball Jump",
@@ -239,7 +239,7 @@
                 {
                   "name": "Moat Ceiling Bomb Jump",
                   "notable": false,
-                  "requires": ["canCeilingBombJump"]
+                  "requires": ["h_canCeilingBombJump"]
                 }
               ],
               "note": "Because Moving from 1 to 3 is free, all strats are represented here even if they start at 1."
@@ -693,7 +693,7 @@
                   "name": "Bowling Skip",
                   "notable": true,
                   "requires": [
-                    "canCrystalFlash",
+                    "h_canCrystalFlash",
                     "canXRayClimb",
                     "canGrappleClip",
                     "canUseEnemies"

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -2032,7 +2032,7 @@
                           "canTrickyJump",
                           {"and":[
                             "canCarefulJump",
-                            "canBombHorizontally",
+                            "h_canBombHorizontally",
                             {"acidFrames": 35}
                           ]},
                           {"acidFrames": 100}

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -4967,7 +4967,7 @@
                   "name": "Mickey Mouse Crumble IBJ",
                   "notable": true,
                   "requires": [
-                    "canJumpIntoIBJ",
+                    "h_canJumpIntoIBJ",
                     "canCrumbleJump",
                     {"heatFrames": 500}
                   ],
@@ -4990,7 +4990,7 @@
                   "name": "Mickey Mouse Spring Ball IBJ",
                   "notable": false,
                   "requires": [
-                    "canJumpIntoIBJ",
+                    "h_canJumpIntoIBJ",
                     "h_canUseSpringBall",
                     {"heatFrames": 550}
                   ],
@@ -5219,7 +5219,7 @@
                   "notable": true,
                   "requires": [
                     "h_heatProof",
-                    "canCrystalFlashGrappleClip"
+                    "h_canCrystalFlashGrappleClip"
                   ],
                   "obstacles": [
                     {
@@ -6805,7 +6805,7 @@
                   "notable": true,
                   "requires": [
                     {"heatFrames": 350},
-                    "canCrystalFlash",
+                    "h_canCrystalFlash",
                     "canCeilingClip",
                     {"heatFrames": 450}
                   ],

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -1318,7 +1318,7 @@
                   "name": "Writg IBJ",
                   "notable": false,
                   "requires": [
-                    "canIBJ",
+                    "h_canIBJ",
                     "h_heatProof"
                   ],
                   "obstacles": [
@@ -4268,7 +4268,7 @@
                   "notable": false,
                   "requires": [
                     "h_heatProof",
-                    "canIBJ"
+                    "h_canIBJ"
                   ]
                 }
               ]
@@ -6482,7 +6482,7 @@
                 {
                   "name": "Lower Norfair Fireflea IBJ",
                   "notable": false,
-                  "requires": ["canIBJ"],
+                  "requires": ["h_canIBJ"],
                   "note" : "IBJ on the right side of the platform."
                 },
                 {
@@ -6593,7 +6593,7 @@
                 {
                   "name": "IBJ",
                   "notable": false,
-                  "requires": ["canIBJ"]
+                  "requires": ["h_canIBJ"]
                 },
                 {
                   "name": "Speedjump",

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -360,7 +360,7 @@
                   "requires": [
                     "h_heatProof",
                     "h_canBombThings",
-                    "canCrystalFlashGrappleClip"
+                    "h_canCrystalFlashGrappleClip"
                   ],
                   "note": "The extra power bomb or morph bombs is to get through the bomb blocks."
                 }
@@ -778,7 +778,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canBombHorizontally",
+                    "h_canBombHorizontally",
                     {"heatFrames": 200}
                   ],
                   "note": "Uses a single bomb blast to just barely get propelled past the crumble pit."
@@ -884,7 +884,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canBombHorizontally",
+                    "h_canBombHorizontally",
                     {"heatFrames": 200}
                   ],
                   "note": "Uses a single bomb blast to just barely get propelled past the crumble pit."

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -1066,7 +1066,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "f_DefeatedGoldenTorizo",
-                    "canIBJ",
+                    "h_canIBJ",
                     {"heatFrames": 3000}
                   ],
                   "note": "Expects two IBJs; one to break a block, then another one to get back up.",
@@ -1660,7 +1660,7 @@
                     {
                       "id": "A",
                       "requires": [
-                        "canIBJ",
+                        "h_canIBJ",
                         {"heatFrames": 1200}
                       ]
                     }
@@ -2043,7 +2043,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canIBJ",
+                    "h_canIBJ",
                     {"heatFrames": 1300}
                   ]
                 },

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -639,7 +639,7 @@
                   "requires": [
                     "canSuitlessMaridia",
                     "HiJump",
-                    "h_canSandIBJ"
+                    "canSandIBJ"
                   ],
                   "note": [
                     "Time a bomb to hit Samus when she is morphed, 1 pixel into the sand, inside a sandfall, and moving horizontally.",
@@ -1356,7 +1356,7 @@
                   "requires": [
                     "Gravity",
                     "Grapple",
-                    "h_canSandIBJ"
+                    "canSandIBJ"
                   ]
                 },
                 {

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -639,7 +639,7 @@
                   "requires": [
                     "canSuitlessMaridia",
                     "HiJump",
-                    "canSandIBJ"
+                    "h_canSandIBJ"
                   ],
                   "note": [
                     "Time a bomb to hit Samus when she is morphed, 1 pixel into the sand, inside a sandfall, and moving horizontally.",
@@ -1356,7 +1356,7 @@
                   "requires": [
                     "Gravity",
                     "Grapple",
-                    "canSandIBJ"
+                    "h_canSandIBJ"
                   ]
                 },
                 {
@@ -1677,7 +1677,7 @@
                   "name": "East Pants Room CF Clip",
                   "notable": false,
                   "requires": [
-                    "canCrystalFlashClip",
+                    "h_canCrystalFlashClip",
                     "Gravity",
                     "Bombs"
                   ]
@@ -1686,7 +1686,7 @@
                   "name": "East Pants Room Suitless Crystal Flash Clip",
                   "notable": true,
                   "requires": [
-                    "canCrystalFlashClip",
+                    "h_canCrystalFlashClip",
                     "canSuitlessMaridia"
                   ],
                   "note": [

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -1366,7 +1366,7 @@
                     "Gravity",
                     "Grapple",
                     "SpringBall",
-                    "canIBJ"
+                    "h_canIBJ"
                   ],
                   "note": "Starting the IBJ with SpringBall is a lot less obnoxious."
                 },

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -2928,7 +2928,7 @@
                   "name": "Cross Room Jump with IBJ",
                   "notable": false,
                   "requires": [
-                    "canIBJ",
+                    "h_canIBJ",
                     "canCrossRoomJumpIntoWater",
                     "canMomentumConservingTurnaround",
                     {"adjacentRunway": {
@@ -4377,7 +4377,7 @@
                       "physics": ["air"]
                     }},
                     {"or":[
-                      "canIBJ",
+                      "h_canIBJ",
                       {"and":[
                         "h_canBombThings",
                         "canUnmorphBombBoost"
@@ -5347,7 +5347,7 @@
                 {
                   "name": "IBJ",
                   "notable": false,
-                  "requires": ["canIBJ"]
+                  "requires": ["h_canIBJ"]
                 },
                 {
                   "name": "West Sand Hole MidAir Morph",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -1199,7 +1199,7 @@
                   "name": "Botwoon CF Clip (Left to Right)",
                   "notable": false,
                   "requires": [
-                    "canCrystalFlashClip",
+                    "h_canCrystalFlashClip",
                     "Gravity",
                     "Bombs"
                   ],
@@ -1214,7 +1214,7 @@
                   "name": "Botwoon Hallway Suitless CF Clip (Left to Right)",
                   "notable": true,
                   "requires": [
-                    "canCrystalFlashClip",
+                    "h_canCrystalFlashClip",
                     "canSuitlessMaridia"
                   ],
                   "reusableRoomwideNotable": "Botwoon Hallway Suitless Crystal Flash Clip",
@@ -1264,7 +1264,7 @@
                   "name": "Botwoon CF Clip (Right to Left)",
                   "notable": false,
                   "requires": [
-                    "canCrystalFlashClip",
+                    "h_canCrystalFlashClip",
                     "Gravity",
                     "Bombs"
                   ],
@@ -1279,7 +1279,7 @@
                   "name": "Botwoon Hallway Suitless CF Clip (Right to Left)",
                   "notable": true,
                   "requires": [
-                    "canCrystalFlashClip",
+                    "h_canCrystalFlashClip",
                     "canSuitlessMaridia"
                   ],
                   "reusableRoomwideNotable": "Botwoon Hallway Suitless Crystal Flash Clip",
@@ -2349,9 +2349,9 @@
                   "name": "Cross Room Jump with IBJ",
                   "notable": false,
                   "requires": [
-                    "canJumpIntoIBJ",
+                    "h_canJumpIntoIBJ",
                     {"or":[
-                      "canDoubleBombJump",
+                      "h_canDoubleBombJump",
                       {"enemyDamage": {
                         "enemy": "Mochtroid",
                         "type": "contact",
@@ -2535,9 +2535,9 @@
                   "notable": false,
                   "requires": [
                     "canSpringBallJumpMidAir",
-                    "canJumpIntoIBJ",
+                    "h_canJumpIntoIBJ",
                     {"or":[
-                      "canDoubleBombJump",
+                      "h_canDoubleBombJump",
                       {"enemyDamage": {
                         "enemy": "Mochtroid",
                         "type": "contact",
@@ -4289,7 +4289,7 @@
                       "SpaceJump",
                       "canWalljump",
                       {"and":[
-                        "canJumpIntoIBJ",
+                        "h_canJumpIntoIBJ",
                         "canIframeSpikeJump",
                         {"spikeHits": 1}
                       ]}
@@ -4331,9 +4331,9 @@
                   "name": "East Cac Alley Cross Room Jump with IBJ",
                   "notable": true,
                   "requires": [
-                    "canJumpIntoIBJ",
-                    "canBombHorizontally",
-                    "canResetFallSpeed",
+                    "h_canJumpIntoIBJ",
+                    "h_canBombHorizontally",
+                    "h_canResetFallSpeed",
                     "canCrossRoomJumpIntoWater",
                     {"adjacentRunway": {
                       "fromNode": 2,
@@ -4367,7 +4367,7 @@
                   "name": "East Cac Alley Cross Room Jump with Spring Ball, Bomb Boost",
                   "notable": true,
                   "requires": [
-                    "canBombHorizontally",
+                    "h_canBombHorizontally",
                     "canSpringBallJumpMidAir",
                     "canCrossRoomJumpIntoWater",
                     {"adjacentRunway": {
@@ -4474,7 +4474,7 @@
                       "canWalljump",
                       "canSpringBallJumpMidAir",
                       {"and":[
-                        "canJumpIntoIBJ",
+                        "h_canJumpIntoIBJ",
                         "canIframeSpikeJump",
                         {"spikeHits": 1}
                       ]}

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -1528,7 +1528,7 @@
                   "name": "Cross Room Jump with Bomb Boost",
                   "notable": false,
                   "requires": [
-                    "canBombHorizontally",
+                    "h_canBombHorizontally",
                     "canCrossRoomJumpIntoWater",
                     {"adjacentRunway": {
                       "fromNode": 1,
@@ -1628,7 +1628,7 @@
                   "name": "Cross Room Jump with Bomb Boost",
                   "notable": false,
                   "requires": [
-                    "canBombHorizontally",
+                    "h_canBombHorizontally",
                     "canCrossRoomJumpIntoWater",
                     {"adjacentRunway": {
                       "fromNode": 2,
@@ -2522,7 +2522,7 @@
                 {
                   "name": "Jump into IBJ",
                   "notable": false,
-                  "requires": ["canJumpIntoIBJ"],
+                  "requires": ["h_canJumpIntoIBJ"],
                   "failures": [
                     {
                       "name": "Fail Bomb Jump",

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -2487,7 +2487,7 @@
                   "name": "Kill one then IBJ",
                   "notable": false,
                   "requires": [
-                    "canIBJ",
+                    "h_canIBJ",
                     {"or": [
                       {"and": [
                         "canShinechargeMovement",

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -1782,7 +1782,7 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    "canIBJ"
+                    "h_canIBJ"
                   ],
                   "note": "Once high enough, it may be necessary to kill the fish and open the door."
                 },

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -940,7 +940,7 @@
                   "name": "Cross Room Jump with Bomb Boost and Spring Ball",
                   "notable": false,
                   "requires": [
-                    "canBombHorizontally",
+                    "h_canBombHorizontally",
                     "canSpringBallJumpMidAir",
                     "canCrossRoomJumpIntoWater",
                     {"adjacentRunway": {
@@ -2082,7 +2082,7 @@
                   "notable": true,
                   "requires": [
                     "canSuitlessMaridia",
-                    "canResetFallSpeed",
+                    "h_canResetFallSpeed",
                     "canPrepareForNextRoom",
                     {"resetRoom": {
                       "nodes": [ 4 ],
@@ -4484,7 +4484,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateUnderwater",
-                    "canJumpIntoIBJ"
+                    "h_canJumpIntoIBJ"
                   ],
                   "note": [
                     "Ride Mama Turtle. To avoid getting hit, shoot one of her babies to wake her up, then quickly get on her back.",
@@ -4617,7 +4617,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateUnderwater",
-                    "canJumpIntoIBJ"
+                    "h_canJumpIntoIBJ"
                   ],
                   "obstacles": [
                     {

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -741,7 +741,7 @@
                 {
                   "name": "Jump Into IBJ",
                   "notable": false,
-                  "requires": [ "canJumpIntoIBJ" ],
+                  "requires": [ "h_canJumpIntoIBJ" ],
                   "note": [
                     "Jump into an IBJ from the moving platform (Kamer).",
                     "Although it is possible to do it without jumping, by starting next to the Gamet farm, it is harder and more obscure."
@@ -1572,7 +1572,7 @@
                 {
                   "name": "PCJR Door IBJ",
                   "notable": false,
-                  "requires": ["canJumpIntoIBJ"]
+                  "requires": ["h_canJumpIntoIBJ"]
                 },
                 {
                   "name": "Speedjump",

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -553,7 +553,7 @@
                   "requires": [
                     {"or": [
                       {"and": [
-                        "canIBJ",
+                        "h_canIBJ",
                         {"heatFrames": 1020}
                       ]},
                       {"and": [
@@ -1470,7 +1470,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canIBJ",
+                    "h_canIBJ",
                     {"heatFrames": 850}
                   ],
                   "note": "Kill a Gamet and don't pick up its drops, so that they won't spawn while performing the IBJ."
@@ -3711,7 +3711,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canIBJ",
+                    "h_canIBJ",
                     {"heatFrames": 1200}
                   ]
                 },
@@ -3767,7 +3767,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canIBJ",
+                    "h_canIBJ",
                     {"heatFrames": 1950}
                   ],
                   "note": "Jump the Alcoon and kill the Multiviola, then IBJ."
@@ -3827,7 +3827,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canIBJ",
+                    "h_canIBJ",
                     {"heatFrames": 750}
                   ],
                   "note": "Kill the enemies, then IBJ."
@@ -3909,7 +3909,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canIBJ",
+                    "h_canIBJ",
                     {"heatFrames": 1500}
                   ],
                   "note": "Kill the enemies, then IBJ."
@@ -4253,7 +4253,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canIBJ",
+                    "h_canIBJ",
                     {"heatFrames": 1450}
                   ]
                 },
@@ -4347,7 +4347,7 @@
                     "h_canNavigateHeatRooms",
                     "canIframeSpikeJump",
                     {"spikeHits": 1},
-                    "canIBJ",
+                    "h_canIBJ",
                     {"heatFrames": 1200}
                   ]
                 },

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -557,7 +557,7 @@
                         {"heatFrames": 1020}
                       ]},
                       {"and": [
-                         "canDoubleBombJump",
+                         "h_canDoubleBombJump",
                          {"heatFrames": 510}
                        ]}
                      ]}
@@ -570,11 +570,11 @@
                   "requires": [
                     {"or": [
                       {"and": [
-                        "canJumpIntoIBJ",
+                        "h_canJumpIntoIBJ",
                         {"heatFrames": 450}
                       ]},
                       {"and": [
-                        "canDoubleBombJump",
+                        "h_canDoubleBombJump",
                         {"heatFrames": 300}
                       ]}
                     ]}
@@ -4548,7 +4548,7 @@
                     "h_canNavigateHeatRooms",
                     "canIframeSpikeJump",
                     {"spikeHits": 1},
-                    "canJumpIntoIBJ",
+                    "h_canJumpIntoIBJ",
                     {"heatFrames": 1200}
                   ]
                 },
@@ -5619,10 +5619,10 @@
                   "requires": [
                     "h_heatProof",
                     "Gravity",
-                    "canJumpIntoIBJ",
-                    "canDoubleBombJump",
-                    "canDiagonalBombJump",
-                    "canStaggeredIBJ",
+                    "h_canJumpIntoIBJ",
+                    "h_canDoubleBombJump",
+                    "h_canDiagonalBombJump",
+                    "h_canStaggeredIBJ",
                     {"heatFrames": 2800},
                     {"lavaFrames": 2600}
                   ],
@@ -5654,8 +5654,8 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "Gravity",
-                    "canJumpIntoIBJ",
-                    "canDoubleBombJump",
+                    "h_canJumpIntoIBJ",
+                    "h_canDoubleBombJump",
                     "Plasma",
                     "Ice",
                     {"heatFrames": 1530},

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -2333,7 +2333,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "h_canIBJ",
-                    "canStaggeredIBJ",
+                    "h_canStaggeredIBJ",
                     {"heatFrames": 4000}
                   ],
                   "note": [
@@ -2432,7 +2432,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "h_canIBJ",
-                    "canStaggeredIBJ",
+                    "h_canStaggeredIBJ",
                     {"heatFrames": 4000}
                   ],
                   "note": "IBJ against the left-most wall. Changing the IBJ speed may be necessary to get past the Sova."
@@ -3090,7 +3090,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canJumpIntoIBJ",
+                    "h_canJumpIntoIBJ",
                     {"heatFrames": 1650}
                   ]
                 },

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -2332,7 +2332,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canIBJ",
+                    "h_canIBJ",
                     "canStaggeredIBJ",
                     {"heatFrames": 4000}
                   ],
@@ -2347,7 +2347,7 @@
                   "notable": false,
                   "requires": [
                     "h_heatProof",
-                    "canIBJ"
+                    "h_canIBJ"
                   ],
                   "note": [
                     "Kill the Sova on the bottom-right platform, then IBJ right next to the left of the platform.",
@@ -2431,7 +2431,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canIBJ",
+                    "h_canIBJ",
                     "canStaggeredIBJ",
                     {"heatFrames": 4000}
                   ],
@@ -2442,7 +2442,7 @@
                   "notable": false,
                   "requires": [
                     "h_heatProof",
-                    "canIBJ"
+                    "h_canIBJ"
                   ],
                   "note": "IBJ against the left-most wall. Place bombs to kill the Sova. Drop to the bottom and restart if necessary."
                 },
@@ -3100,7 +3100,7 @@
                   "requires": [
                     "h_heatProof",
                     "Gravity",
-                    "canIBJ"
+                    "h_canIBJ"
                   ],
                   "note": "Kill the Dragon with bombs, then start the IBJ in the lava. It's an option without canJumpIntoIBJ."
                 },

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -1733,7 +1733,7 @@
                 {
                   "name": "Bowling Reserve Crystal Flash Grapple Clip",
                   "notable": true,
-                  "requires": ["canCrystalFlashGrappleClip"]
+                  "requires": ["h_canCrystalFlashGrappleClip"]
                 }
               ]
             },
@@ -2055,7 +2055,7 @@
                   "name": "WS East Supers Crystal Flash Clip (Right to Left)",
                   "notable": true,
                   "requires": [
-                    "canCrystalFlash",
+                    "h_canCrystalFlash",
                     "canCeilingClip"
                   ],
                   "note": [

--- a/tech.json
+++ b/tech.json
@@ -79,7 +79,7 @@
         },
         {
           "name": "canResetFallSpeed",
-          "requires": [ "Morph" ],
+          "requires": [],
           "note": "Using unmorph as a way to reset fall speed.",
           "devNote": "Taking enemy damage can get the same effect but more situations where this is used would need to be found first."
         },
@@ -406,32 +406,29 @@
         },
         {
           "name": "canBombHorizontally",
-          "requires": [ "h_canBombThings" ],
+          "requires": [],
           "note": "A horizontal bomb jump using a single bomb. Since it uses one bomb, it works with PBs as well.",
           "extensionTechs": [
             {
               "name": "canHBJ",
-              "requires": [
-                "h_canUseMorphBombs",
-                "canBombHorizontally"
-              ],
+              "requires": [ "canBombHorizontally" ],
               "note": "A horizontal bomb jump using two bombs. Longer range than single HBJ, much harder to execute, doesn't work with PBs."
             }
           ]
         },
         {
           "name": "canIBJ",
-          "requires": [ "h_canUseMorphBombs" ],
+          "requires": [],
           "note": "Infinite Bomb Jump. Using consecutive bomb jumps to gain height indefinitely.",
           "extensionTechs": [
             {
               "name": "canJumpIntoIBJ",
-              "requires": [ "h_canIBJ" ],
-              "note": "The ability to start an IBJ from a jump. Can be required in strats that need Samus to IBJ up faster or to avoid something near the ground."
+              "requires": [ "canIBJ" ],
+              "note": "The ability to start an IBJ from a jump or spring ball jump. Can be required in strats that need Samus to IBJ up faster or to avoid something near the ground."
             },
             {
               "name": "canBombAboveIBJ",
-              "requires": [ "h_canIBJ" ],
+              "requires": [ "canIBJ" ],
               "note": "The ability to break blocks above Samus while maintaining an ongoing IBJ."
             },
             {
@@ -441,7 +438,7 @@
             },
             {
               "name": "canDiagonalBombJump",
-              "requires": [ "h_canIBJ" ],
+              "requires": [ "canIBJ" ],
               "note": "The ability to IBJ with backspin which results in diagonal movement."
             },
             {
@@ -451,12 +448,12 @@
             },
             {
               "name": "canDoubleBombJump",
-              "requires": [ "h_canIBJ" ],
+              "requires": [ "canIBJ" ],
               "note": "The ability to place a second bomb above the first during an infinite bomb jump in order to ascend faster."
             },
             {
               "name": "canStaggeredIBJ",
-              "requires": [ "h_canIBJ" ],
+              "requires": [ "canIBJ" ],
               "note": "The ability to change the bomb placement timing in order control the speed with which you gain height."
             }
           ]
@@ -924,24 +921,7 @@
       "techs": [
         {
           "name": "canCrystalFlash",
-          "requires": [
-            {"ammo": {
-              "type": "Missile",
-              "count": 10
-            }},
-            {"ammo": {
-              "type": "Super",
-              "count": 10
-            }},
-            {"ammo": {
-              "type": "PowerBomb",
-              "count": 11
-            }},
-            "Morph",
-            "Missile",
-            "Super",
-            "PowerBomb"
-          ],
+          "requires": [],
           "note": "Performing a Crystal Flash.",
           "extensionTechs": [
             {

--- a/tech.json
+++ b/tech.json
@@ -443,7 +443,7 @@
             },
             {
               "name": "canSandIBJ",
-              "requires": [ "canJumpIntoIBJ" ],
+              "requires": [ "h_canJumpIntoIBJ" ],
               "note": "The ability to start an IBJ off a jump on sand. Pretty obnoxious."
             },
             {

--- a/tech.json
+++ b/tech.json
@@ -426,12 +426,12 @@
           "extensionTechs": [
             {
               "name": "canJumpIntoIBJ",
-              "requires": [ "canIBJ" ],
+              "requires": [ "h_canIBJ" ],
               "note": "The ability to start an IBJ from a jump. Can be required in strats that need Samus to IBJ up faster or to avoid something near the ground."
             },
             {
               "name": "canBombAboveIBJ",
-              "requires": [ "canIBJ" ],
+              "requires": [ "h_canIBJ" ],
               "note": "The ability to break blocks above Samus while maintaining an ongoing IBJ."
             },
             {
@@ -441,7 +441,7 @@
             },
             {
               "name": "canDiagonalBombJump",
-              "requires": [ "canIBJ" ],
+              "requires": [ "h_canIBJ" ],
               "note": "The ability to IBJ with backspin which results in diagonal movement."
             },
             {
@@ -451,12 +451,12 @@
             },
             {
               "name": "canDoubleBombJump",
-              "requires": [ "canIBJ" ],
+              "requires": [ "h_canIBJ" ],
               "note": "The ability to place a second bomb above the first during an infinite bomb jump in order to ascend faster."
             },
             {
               "name": "canStaggeredIBJ",
-              "requires": [ "canIBJ" ],
+              "requires": [ "h_canIBJ" ],
               "note": "The ability to change the bomb placement timing in order control the speed with which you gain height."
             }
           ]


### PR DESCRIPTION
This will require double checking currently open PRs to not be using tech assuming they include morph