### PR TITLE
Add West Cac Alley strat with HiJump + SpaceJump

### DIFF
--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -4168,12 +4168,21 @@
                   "requires": ["Gravity"]
                 },
                 {
-                  "name": "Suitless Dual Jump Assist",
+                  "name": "Suitless HiJump SpringBall",
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
                     "HiJump",
                     "canSpringBallJumpMidAir"
+                  ]
+                },
+                {
+                  "name": "Suitless HiJump SpaceJump",
+                  "notable": false,
+                  "requires": [
+                    "canSuitlessMaridia",
+                    "HiJump",
+                    "SpaceJump"
                   ]
                 },
                 {
@@ -4195,7 +4204,7 @@
                   ]
                 },
                 {
-                  "name": "West Cactus Alley X-Ray Climb",
+                  "name": "X-Ray Climb",
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",


### PR DESCRIPTION
Also use a more specific name for the existing HiJump + SpringBall strat, and remove the room name from the X-Ray Climb strat since it is no longer notable.

Video by insomniaspeed: https://youtu.be/6X60X7-b_Wg