### PR TITLE
Add leaveWithGMode for Crateria elevators

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -5259,7 +5259,25 @@
           "name": "Elevator to Blue Brinstar",
           "nodeType": "door",
           "nodeSubType": "elevator",
-          "nodeAddress": "0x0018b9e"
+          "nodeAddress": "0x0018b9e",
+          "leaveWithGMode": [
+            {
+              "leavesWithArtificialMorph": false,
+              "strats": [
+                {
+                  "name": "Carry G-Mode Down the Elevator",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "artificialMorph": false,
+                      "mode": "any"
+                    }}
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ],
       "enemies": [],

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -5269,7 +5269,7 @@
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [1],
+                      "fromNodes": [1, 2],
                       "artificialMorph": false,
                       "mode": "any"
                     }}

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -459,7 +459,25 @@
           "name": "Elevator to Red Brinstar",
           "nodeType": "door",
           "nodeSubType": "elevator",
-          "nodeAddress": "0x0018b02"
+          "nodeAddress": "0x0018b02",
+          "leaveWithGMode": [
+            {
+              "leavesWithArtificialMorph": false,
+              "strats": [
+                {
+                  "name": "Carry G-Mode Down the Elevator",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "artificialMorph": false,
+                      "mode": "any"
+                    }}
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ],
       "enemies": [],
@@ -2232,7 +2250,25 @@
           "name": "Elevator to Maridia",
           "nodeType": "door",
           "nodeSubType": "elevator",
-          "nodeAddress": "0x0018a5a"
+          "nodeAddress": "0x0018a5a",
+          "leaveWithGMode": [
+            {
+              "leavesWithArtificialMorph": false,
+              "strats": [
+                {
+                  "name": "Carry G-Mode Down the Elevator",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "artificialMorph": false,
+                      "mode": "any"
+                    }}
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ],
       "enemies": [],

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -469,7 +469,7 @@
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [1],
+                      "fromNodes": [1, 2],
                       "artificialMorph": false,
                       "mode": "any"
                     }}
@@ -2260,7 +2260,7 @@
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [1],
+                      "fromNodes": [1, 2],
                       "artificialMorph": false,
                       "mode": "any"
                     }}

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -814,7 +814,25 @@
           "name": "Elevator to Green Brinstar",
           "nodeType": "door",
           "nodeSubType": "elevator",
-          "nodeAddress": "0x0018c0a"
+          "nodeAddress": "0x0018c0a",
+          "leaveWithGMode": [
+            {
+              "leavesWithArtificialMorph": false,
+              "strats": [
+                {
+                  "name": "Carry G-Mode Down the Elevator",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "artificialMorph": false,
+                      "mode": "any"
+                    }}
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ],
       "enemies": [],
@@ -1019,7 +1037,25 @@
           "name": "Elevator to Tourian",
           "nodeType": "door",
           "nodeSubType": "elevator",
-          "nodeAddress": "0x0019222"
+          "nodeAddress": "0x0019222",
+          "leaveWithGMode": [
+            {
+              "leavesWithArtificialMorph": false,
+              "strats": [
+                {
+                  "name": "Carry G-Mode Down the Elevator",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "artificialMorph": false,
+                      "mode": "any"
+                    }}
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
           "id": 3,

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -824,7 +824,7 @@
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [1],
+                      "fromNodes": [1, 2],
                       "artificialMorph": false,
                       "mode": "any"
                     }}
@@ -1047,7 +1047,7 @@
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [1],
+                      "fromNodes": [1, 2],
                       "artificialMorph": false,
                       "mode": "any"
                     }}


### PR DESCRIPTION
Elevators can be used while in G-mode (unlike normal doors which cannot be shot open), so they are a way to bring G-mode into a third room.