### PR TITLE
Tighten acidFrames in Metroid Room 1

### DIFF
--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -642,6 +642,14 @@
                   "requires": [
                     {"acidFrames": 80}
                   ]
+                },
+                {
+                  "name": "Bounce Ball",
+                  "notable": false,
+                  "requires": [
+                    {"acidFrames": 60},
+                    "canBounceBall"
+                  ]
                 }
               ]
             }

--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -629,7 +629,7 @@
                   "name": "Fearless Dive",
                   "notable": false,
                   "requires": [
-                    {"acidFrames": 30},
+                    {"acidFrames": 20},
                     {"or":[
                       "canWalljump",
                       "Gravity"
@@ -682,7 +682,7 @@
                   "name": "Fearless Dive",
                   "notable": false,
                   "requires": [
-                    {"acidFrames": 30},
+                    {"acidFrames": 20},
                     {"or":[
                       "canWalljump",
                       "Gravity",

--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -640,7 +640,7 @@
                   "name": "Acid Run",
                   "notable": false,
                   "requires": [
-                    {"acidFrames": 100}
+                    {"acidFrames": 80}
                   ]
                 }
               ]
@@ -684,7 +684,7 @@
                   "requires": [
                     {"acidFrames": 20},
                     {"or":[
-                      "canWalljump",
+                      "canPreciseWalljump",
                       "Gravity",
                       "HiJump"
                     ]}
@@ -694,7 +694,7 @@
                   "name": "Acid Run",
                   "notable": false,
                   "requires": [
-                    {"acidFrames": 100}
+                    {"acidFrames": 70}
                   ]
                 }
               ]


### PR DESCRIPTION
The acidFrames for the Fearless Dive here were overly lenient.

This is why, for example, the logic thought SpeedBooster was needed for progression at the start of cheesyboatride's recent seed (https://maprando.com/seed/6m8Q6m2UMFjlzpbTu-57lg/).