### PR TITLE
Double Chamber heat frames getting to & from the item

### DIFF
--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -4328,7 +4328,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "Grapple",
-                    {"heatFrames": 200}
+                    {"heatFrames": 180}
                   ]
                 },
                 {
@@ -4337,7 +4337,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "SpaceJump",
-                    {"heatFrames": 200}
+                    {"heatFrames": 160}
                   ]
                 },
                 {
@@ -4529,7 +4529,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "Grapple",
-                    {"heatFrames": 200}
+                    {"heatFrames": 180}
                   ]
                 },
                 {
@@ -4538,7 +4538,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "SpaceJump",
-                    {"heatFrames": 200}
+                    {"heatFrames": 160}
                   ]
                 },
                 {


### PR DESCRIPTION
When coming from the right door, it's possible to get to the item and back using SpaceJump or Grapple without any tanks.

