### PR TITLE
Make 'X-Ray Climb' in Fast Pillars Setup Room not notable

### DIFF
--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -739,7 +739,7 @@
                 },
                 {
                   "name": "X-Ray Climb",
-                  "notable": true,
+                  "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "canRightFacingDoorXRayClimb",


### PR DESCRIPTION
This is the strat that is used in the top part of the room to just reach the platform. The name does not include the room name as it should if it were notable, and it doesn't seem important enough to be notable (it's only useful for avoiding wall jumps).