### PR TITLE
Add Heat Resistant to preRidley Farm 

### DIFF
--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -4359,6 +4359,7 @@
               "cycleFrames": 240,
               "requires": [
                 "h_canNavigateHeatRooms",
+                "h_heatResistant",
                 {"heatFrames": 240}
               ],
               "note": "Involves tiny hops to get the drops as well"
@@ -4386,6 +4387,7 @@
               "cycleFrames": 240,
               "requires": [
                 "h_canNavigateHeatRooms",
+                "h_heatResistant",
                 {"heatFrames": 240}
               ],
               "note": "Involves tiny hops to get the drops as well"
@@ -4413,6 +4415,7 @@
               "cycleFrames": 240,
               "requires": [
                 "h_canNavigateHeatRooms",
+                "h_heatResistant",
                 {"heatFrames": 240}
               ],
               "note": "Involves tiny hops to get the drops as well"


### PR DESCRIPTION
You can't gain health in preRidley, or plowerhouse, with no equipment.  Plowerhouse was already taken care of and there were no other Norfair farm points where you do not gain health over time.