### PR TITLE
Tighten heatFrames for Space+Screw in Pillar Room

### DIFF
--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -1100,7 +1100,7 @@
                     "h_canNavigateHeatRooms",
                     "ScrewAttack",
                     "SpaceJump",
-                    {"heatFrames": 400}
+                    {"heatFrames": 360}
                   ]
                 },
                 {
@@ -1182,7 +1182,7 @@
                     "h_canNavigateHeatRooms",
                     "ScrewAttack",
                     "SpaceJump",
-                    {"heatFrames": 400}
+                    {"heatFrames": 390}
                   ]
                 },
                 {


### PR DESCRIPTION
This can be done in both directions with no tanks and no adjacent runways. Right-to-left uses more energy because of the shorter in-room runway.