### PR TITLE
Update Acid Chozo Statue

### DIFF
--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -268,7 +268,6 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "f_UsedAcidChozoStatue",
                     {"heatFrames": 250}
                   ]
                 }


### PR DESCRIPTION
Coming up from the bottom of acid chozo statue with a CF grapple clip will enable Samus to get to the right door without needing `f_UsedAcidChozoStatue`. It may be possible to go to the statue to save some heat frames, but the CF grapple clip currently requires being `heatproof`