### PR TITLE
CF clip rework

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -490,22 +490,28 @@
       "name": "h_canBombIntoCrystalFlashClip",
       "requires": [
         "canBombIntoCrystalFlashClip",
-        "h_canCrystalFlash"
-      ]
+        "h_canCrystalFlash",
+        {"ammo": {"type": "PowerBomb","count": 5}}
+      ],
+      "devNote": "5 Power bombs leniency."
     },
     {
       "name": "h_canArtificialMorphBombIntoCrystalFlashClip",
       "requires": [
         "canBombIntoCrystalFlashClip",
-        "h_canArtificialMorphCrystalFlash"
-      ]
+        "h_canArtificialMorphCrystalFlash",
+        {"ammo": {"type": "PowerBomb","count": 5}}
+      ],
+      "devNote": "5 Power bombs leniency."
     },
     {
       "name": "h_canJumpIntoCrystalFlashClip",
       "requires": [
         "canJumpIntoCrystalFlashClip",
-        "h_canCrystalFlash"
-      ]
+        "h_canCrystalFlash",
+        {"ammo": {"type": "PowerBomb","count": 10}}
+      ],
+      "devNote": "10 Power bombs leniency."
     },
     {
       "name": "h_canArtificialMorphMovement",

--- a/helpers.json
+++ b/helpers.json
@@ -487,31 +487,24 @@
       ]
     },
     {
-      "name": "h_canCrystalFlashClip",
+      "name": "h_canBombIntoCrystalFlashClip",
       "requires": [
-        "canCrystalFlashClip",
+        "canBombIntoCrystalFlashClip",
         "h_canCrystalFlash"
       ]
     },
     {
-      "name": "h_canArtificialMorphCrystalFlashClip",
+      "name": "h_canArtificialMorphBombIntoCrystalFlashClip",
       "requires": [
-        "canCrystalFlashClip",
+        "canBombIntoCrystalFlashClip",
         "h_canArtificialMorphCrystalFlash"
       ]
     },
     {
-      "name": "h_canCrystalFlashGrappleClip",
+      "name": "h_canJumpIntoCrystalFlashClip",
       "requires": [
-        "canCrystalFlashGrappleClip",
-        "h_canCrystalFlashClip"
-      ]
-    },
-    {
-      "name": "h_canArtificialMorphCrystalFlashGrappleClip",
-      "requires": [
-        "canCrystalFlashGrappleClip",
-        "h_canArtificialMorphCrystalFlashClip"
+        "canJumpIntoCrystalFlashClip",
+        "h_canCrystalFlash"
       ]
     },
     {

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -6239,8 +6239,8 @@
               "id": 4,
               "strats": [
                 {
-                  "name": "Mickey Mouse Crystal Flash Grapple Clip",
-                  "notable": true,
+                  "name": "Crystal Flash Grapple Clip",
+                  "notable": false,
                   "requires": [
                     "h_heatProof",
                     "h_canJumpIntoCrystalFlashClip",
@@ -6258,7 +6258,8 @@
                   ],
                   "note": [
                     "It is considered free to kill the Multiviolas with Power Beam while heatproof, and heatproof is required for the CF clip.",
-                    "All of the bomb blocks will be destroyed while performing the Crystal Flash."
+                    "All of the bomb blocks will be destroyed while performing the Crystal Flash.",
+                    "Menu to Grappling Beam before the crystal flash ends and mash shoot while holding down."
                   ]
                 }
               ]

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -6243,7 +6243,8 @@
                   "notable": true,
                   "requires": [
                     "h_heatProof",
-                    "h_canCrystalFlashGrappleClip"
+                    "h_canJumpIntoCrystalFlashClip",
+                    "Grapple"
                   ],
                   "obstacles": [
                     {

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -354,15 +354,16 @@
                   ]
                 },
                 {
-                  "name": "Reverse Acid Statue CF Grapple Clip",
-                  "notable": true,
+                  "name": "CF Grapple Clip",
+                  "notable": false,
                   "requires": [
                     "h_heatProof",
                     "h_canBombThings",
                     "h_canJumpIntoCrystalFlashClip",
                     "Grapple"
                   ],
-                  "note": "The extra power bomb or morph bombs is to get through the bomb blocks."
+                  "note": "Menu to Grappling Beam before the crystal flash ends and mash shoot while holding down.",
+                  "devNote": "The extra power bomb or morph bombs is to get through the bomb blocks."
                 }
               ]
             }

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -359,7 +359,8 @@
                   "requires": [
                     "h_heatProof",
                     "h_canBombThings",
-                    "h_canCrystalFlashGrappleClip"
+                    "h_canJumpIntoCrystalFlashClip",
+                    "Grapple"
                   ],
                   "note": "The extra power bomb or morph bombs is to get through the bomb blocks."
                 }

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -2160,34 +2160,25 @@
                   "devNote": "1 hit per attempt, 7 for leniency."
                 },
                 {
-                  "name": "East Pants Room CF Clip",
+                  "name": "Crystal Flash Clip with Bombs",
                   "notable": false,
                   "requires": [
                     "h_canBombIntoCrystalFlashClip",
-                    "Gravity",
-                    {"ammo": {
-                      "type": "PowerBomb",
-                      "count": 5
-                    }}
+                    "Gravity"
                   ],
-                  "devNote": "Extra 5 cost is just leniency."
+                  "note": "Clip below the crumble blocks on the left side.  Hold down after clipping to break them."
                 },
                 {
-                  "name": "East Pants Room Suitless Crystal Flash Clip",
-                  "notable": true,
+                  "name": "Suitless Crystal Flash Clip",
+                  "notable": false,
                   "requires": [
                     "h_canJumpIntoCrystalFlashClip",
-                    "canSuitlessMaridia",
-                    {"ammo": {
-                      "type": "PowerBomb",
-                      "count": 10
-                    }}
+                    "canSuitlessMaridia"
                   ],
                   "note": [
-                    "Place a PB up against the crumble blocks, then jump and midair morph into that same position at the end of the explosion while holing CF inputs.",
+                    "Place a PB up against the crumble blocks, then jump and midair morph into that same position at the end of the explosion while holding CF inputs.",
                     "Immediately after the CF, hold down to break the crumble blocks."
-                  ],
-                  "devNote": "Extra 10 cost is just leniency."
+                  ]
                 }
               ]
             },

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -2163,9 +2163,8 @@
                   "name": "East Pants Room CF Clip",
                   "notable": false,
                   "requires": [
-                    "h_canCrystalFlashClip",
+                    "h_canBombIntoCrystalFlashClip",
                     "Gravity",
-                    "Bombs",
                     {"ammo": {
                       "type": "PowerBomb",
                       "count": 5
@@ -2177,7 +2176,7 @@
                   "name": "East Pants Room Suitless Crystal Flash Clip",
                   "notable": true,
                   "requires": [
-                    "h_canCrystalFlashClip",
+                    "h_canJumpIntoCrystalFlashClip",
                     "canSuitlessMaridia",
                     {"ammo": {
                       "type": "PowerBomb",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -1331,14 +1331,6 @@
         {
           "name": "Botwoon Hallway Puyo Ice Clip",
           "note": "Herding the rightmost puyo into the ice clip position. It will become uncooperative after a few tries"
-        },
-        {
-          "name": "Botwoon Hallway Suitless Crystal Flash Clip",
-          "note": [
-            "Find the crumble blocks and crystal flash mid-air, just below them.",
-            "Hold down as the CF ends to break the non-respawning crumble blocks.",
-            "This is for the much harder version, without Gravity and Morph Bombs."
-          ]
         }
       ],
       "links": [
@@ -1375,7 +1367,7 @@
                   "note": "With no jump assists, use a frozen Mochtroid as a platform to get to the ledge above the door."
                 },
                 {
-                  "name": "Botwoon CF Clip (Left to Right)",
+                  "name": "CF Clip with Bombs (Left to Right)",
                   "notable": false,
                   "requires": [
                     "h_canBombIntoCrystalFlashClip",
@@ -1389,13 +1381,12 @@
                   ]
                 },
                 {
-                  "name": "Botwoon Hallway Suitless CF Clip (Left to Right)",
-                  "notable": true,
+                  "name": "Suitless CF Clip (Left to Right)",
+                  "notable": false,
                   "requires": [
                     "h_canJumpIntoCrystalFlashClip",
                     "canSuitlessMaridia"
                   ],
-                  "reusableRoomwideNotable": "Botwoon Hallway Suitless Crystal Flash Clip",
                   "note": [
                     "Find the crumble blocks and crystal flash mid-air, just below them.",
                     "They are on the far right of the ceiling of the bottom right pathway.",
@@ -1449,7 +1440,7 @@
                   "note": "With no jump assists, a precise crouch jump and down grab is required to get to the Mochtroid." 
                 },
                 {
-                  "name": "Botwoon CF Clip (Right to Left)",
+                  "name": "CF Clip with Bombs (Right to Left)",
                   "notable": false,
                   "requires": [
                     "h_canBombIntoCrystalFlashClip",
@@ -1463,13 +1454,12 @@
                   ]
                 },
                 {
-                  "name": "Botwoon Hallway Suitless CF Clip (Right to Left)",
-                  "notable": true,
+                  "name": "Suitless CF Clip (Right to Left)",
+                  "notable": false,
                   "requires": [
                     "h_canJumpIntoCrystalFlashClip",
                     "canSuitlessMaridia"
                   ],
-                  "reusableRoomwideNotable": "Botwoon Hallway Suitless Crystal Flash Clip",
                   "note": [
                     "Find the crumble blocks and crystal flash mid-air, just below them.",
                     "They are on the far left of the ceiling of the middle left pathway.",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -1378,9 +1378,8 @@
                   "name": "Botwoon CF Clip (Left to Right)",
                   "notable": false,
                   "requires": [
-                    "h_canCrystalFlashClip",
-                    "Gravity",
-                    "Bombs"
+                    "h_canBombIntoCrystalFlashClip",
+                    "Gravity"
                   ],
                   "note": [
                     "Find the crumble blocks and crystal flash mid-air, just below them.",
@@ -1393,7 +1392,7 @@
                   "name": "Botwoon Hallway Suitless CF Clip (Left to Right)",
                   "notable": true,
                   "requires": [
-                    "h_canCrystalFlashClip",
+                    "h_canJumpIntoCrystalFlashClip",
                     "canSuitlessMaridia"
                   ],
                   "reusableRoomwideNotable": "Botwoon Hallway Suitless Crystal Flash Clip",
@@ -1453,9 +1452,8 @@
                   "name": "Botwoon CF Clip (Right to Left)",
                   "notable": false,
                   "requires": [
-                    "h_canCrystalFlashClip",
-                    "Gravity",
-                    "Bombs"
+                    "h_canBombIntoCrystalFlashClip",
+                    "Gravity"
                   ],
                   "note": [
                     "Find the crumble blocks and crystal flash mid-air, just below them.",
@@ -1468,7 +1466,7 @@
                   "name": "Botwoon Hallway Suitless CF Clip (Right to Left)",
                   "notable": true,
                   "requires": [
-                    "h_canCrystalFlashClip",
+                    "h_canJumpIntoCrystalFlashClip",
                     "canSuitlessMaridia"
                   ],
                   "reusableRoomwideNotable": "Botwoon Hallway Suitless Crystal Flash Clip",

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -2307,7 +2307,10 @@
                 {
                   "name": "Bowling Reserve Crystal Flash Grapple Clip",
                   "notable": true,
-                  "requires": ["h_canCrystalFlashGrappleClip"]
+                  "requires": [
+                    "h_canJumpIntoCrystalFlashClip",
+                    "Grapple"
+                  ]
                 }
               ]
             },

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -2305,12 +2305,13 @@
               "id": 1,
               "strats": [
                 {
-                  "name": "Bowling Reserve Crystal Flash Grapple Clip",
-                  "notable": true,
+                  "name": "Crystal Flash Grapple Clip",
+                  "notable": false,
                   "requires": [
                     "h_canJumpIntoCrystalFlashClip",
                     "Grapple"
-                  ]
+                  ],
+                  "note": "Menu to Grappling Beam before the crystal flash ends and mash shoot while holding down."
                 }
               ]
             },

--- a/tech.json
+++ b/tech.json
@@ -1114,7 +1114,7 @@
                 "This requires bombing once to place the power bomb against the ceiling, then bombing again to position Samus for the crystal flash.",
                 "This trick has a 2 frame window.",
                 "If below crumble blocks, hold down to break them.  Usually only useful when the crumble blocks do not respawn.",
-                "If below a single solid tile, grapple can be used to place Samus above it."
+                "If below a single solid tile, grapple can be used immediately when the CF finishes to place Samus above it."
               ]
             },
             {

--- a/tech.json
+++ b/tech.json
@@ -1076,39 +1076,6 @@
       "description": "A catch-all for techs that don't fit in anywhere else",
       "techs": [
         {
-          "name": "canCrystalFlash",
-          "requires": [],
-          "note": "Performing a Crystal Flash.",
-          "extensionTechs": [
-            {
-              "name": "canCrystalFlashClip",
-              "requires": [ "canCrystalFlash" ],
-              "note": [
-                "Using a Crystal Flash below a non-respawning crumble block to clip into the block while holding down to break it.",
-                "This tech is not required for simply unmorphing in a morph tunnel."
-              ],
-              "extensionTechs": [
-                {
-                  "name": "canCrystalFlashGrappleClip",
-                  "requires": [
-                    "canCrystalFlashClip",
-                    "Grapple"
-                  ],
-                  "note": [
-                    "Using a Crystal Flash below a one-tile-thick ceiling, then using grapple to force Samus on top of it.",
-                    "To do this, select grapple as your health refills then hold down and mash shoot, the earlier you shoot the better."
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "canMaridiaTubeClip",
-          "requires": [],
-          "note": "The ability to clip into the Maridia tube from above."
-        },
-        {
           "name": "canCeilingClip",
           "requires": [],
           "note": [
@@ -1124,6 +1091,53 @@
             "This is done by, in quick succession: jumping, aiming down, and then pressing forward."
           ],
           "devNote": "Cancelling a spinjump with angle can get the same effect, but has very limited logical uses."
+        },
+        {
+          "name": "canCrystalFlash",
+          "requires": [],
+          "note": [
+            "Performing a Crystal Flash.",
+            "Initiating the Crystal flash requires energy at 50 or lower, empty reserve energy, 1 power bomb to initiate, and holding L+R+Shoot+Down with no other inputs.",
+            "A Crystal Flash will refill 1500 energy at the cost of 10 missiles, 10 super missiles, and 10 power bombs.",
+            "The Crystal Flash will also put Samus in a standing position even if she is in a Morph tunnel."
+          ],
+          "extensionTechs": [
+            {
+              "name": "canBombIntoCrystalFlashClip",
+              "requires": [ 
+                "canCrystalFlash",
+                "canCeilingClip",
+                "Bombs"
+              ],
+              "note": [
+                "Setting up a Crystal Flash in a 3 tile high space with bombs to clip into the above tile.",
+                "This requires bombing once to place the power bomb against the ceiling, then bombing again to position Samus for the crystal flash.",
+                "This trick has a 2 frame window.",
+                "If below crumble blocks, hold down to break them.  Usually only useful when the crumble blocks do not respawn.",
+                "If below a single solid tile, grapple can be used to place Samus above it."
+              ]
+            },
+            {
+              "name": "canJumpIntoCrystalFlashClip",
+              "requires": [
+                "canCrystalFlash",
+                "canCeilingClip",
+                "Morph"
+              ],
+              "note": [
+                "Setting up a Crystal Flash by jumping and morphing.  Once to place the power bomb, then again to activate the Crystal Flash.",
+                "This trick has a 1 frame window.",
+                "If below crumble blocks, hold down to break them.  Usually only useful when the crumble blocks do not respawn.",
+                "If below a single solid tile, grapple can be used to place Samus above it.",
+                "To do this, select grapple as your health refills then hold down and mash shoot, the earlier you shoot the better."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "canMaridiaTubeClip",
+          "requires": [],
+          "note": "The ability to clip into the Maridia tube from above."
         },
         {
           "name": "canTurnaroundAimCancel",


### PR DESCRIPTION
Changed the techs for CF clip so there is 1)on ground 2)bomb jump up to clip and 3) jump morph up to clip.  Breaking crumbles or grapple trick can be used from any of them.

I left the ground CF clips as notable mostly for being easier tech, but its also not a specified CF clip tech.  Removed notables from the rest because the difficult part is now in the tech.  The places you can CF are not too well known, plus the botwoon/shaktool clips are known well enough you would want to toggle them as notables.  But the difficulty is all in the tech and we don't want to make every instance of a tech also notable.  A way to list the uses elsewhere would be nice.

I put the leniency power bombs in the helpers now.  It is the same difficulty everywhere the tricks show up.