### PR TITLE
Add a leniency shot for gate glitches

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -164,8 +164,10 @@
       "name": "h_canGreenGateGlitch",
       "requires": [
         "canGateGlitch",
+        {"ammo": { "type": "Super", "count": 1 }},
         {"ammo": { "type": "Super", "count": 1 }}
-      ]
+      ],
+      "devNote": "Ammo for a second shot for leniency."
     },
     {
       "name": "h_canBlueGateGlitch",
@@ -174,24 +176,33 @@
         {"or": [
           {"ammo": { "type": "Missile", "count": 1 }},
           {"ammo": { "type": "Super", "count": 1 }}
+        ]},
+        {"or": [
+          {"ammo": { "type": "Missile", "count": 1 }},
+          {"ammo": { "type": "Super", "count": 1 }}
         ]}
-      ]
+      ],
+      "devNote": "Ammo for a second shot for leniency."
     },
     {
       "name": "h_canHeatedBlueGateGlitch",
       "requires": [ 
         "h_canNavigateHeatRooms",
         {"heatFrames": 60},
-        "h_canBlueGateGlitch"
-      ]
+        "h_canBlueGateGlitch",
+        {"heatFrames": 60}
+      ],
+      "devNote": "Ammo and heat frames for a second shot for leniency."
     },
     {
       "name": "h_canHeatedGreenGateGlitch",
       "requires": [ 
         "h_canNavigateHeatRooms",
         {"heatFrames": 60},
-        "h_canGreenGateGlitch"
-      ]
+        "h_canGreenGateGlitch",
+        {"heatFrames": 60}
+      ],
+      "devNote": "Ammo and heat frames for a second shot for leniency."
     },
     {
       "name": "h_canCrouchJumpDownGrab",


### PR DESCRIPTION
A second shot is not much, but it could be a problem to increase this much more, as the player could easily go out of logic if the leniency is too large.

I kept the original and secondary shots separate, so it is more clear what is going on, and which number to increase if the leniency was increased or removed.

Note that in Map Rando, these will still be multiplied by the user's resource multiplier.