### PR TITLE
Make Green Hill Zone Wall Jump Notable

### DIFF
--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -3272,8 +3272,8 @@
                   ]
                 },
                 {
-                  "name": "Green Hill Zone Walljump",
-                  "notable": false,
+                  "name": "Green Hill Zone Wall Jump to Top Right Door",
+                  "notable": true,
                   "requires": [ "canPreciseWalljump" ],
                   "note": "Wall jump on the top half of the Geega pipe, then on the overhang."
                 },


### PR DESCRIPTION
I wonder if this should be notable? Because people keep asking about it.

It is a little harder than most precise wall jumps, because of the spawning bugs, and because it feels doable without the pipe.