### PR TITLE
More X-ray climbs (including deep stucks)

### DIFF
--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -2482,6 +2482,24 @@
           "from": 2,
           "to": [
             {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    "canRightFacingDoorXRayClimb",
+                    {"adjacentRunway": {
+                      "fromNode": 2,
+                      "usedTiles": 0.5,
+                      "overrideRunwayRequirements": true,
+                      "useFrames": 200
+                    }}
+                  ]
+                }
+              ]
+            },
+            {
               "id": 3,
               "strats": [
                 {

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -2495,7 +2495,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "Climb up 8 screens."
                 }
               ]
             },

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -686,7 +686,8 @@
                     "canTrickyDashJump",
                     "HiJump",
                     "canSpringBallJumpMidAir"
-                  ]
+                  ],
+                  "note": "Climb up 3 screens."
                 },
                 {
                   "name": "G-Mode Deep Stuck X-Ray Climb",
@@ -698,7 +699,8 @@
                       "artificialMorph": false
                     }},
                     "canXRayClimb"
-                  ]
+                  ],
+                  "note": "Climb up 3 screens."
                 },
                 {
                   "name": "Shinespark Deep Stuck X-Ray Climb",

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -708,7 +708,8 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 4,
-                      "shinesparkFrames": 0,
+                      "shinesparkFrames": 1,
+                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
                     }},
                     "canShinesparkDeepStuck",

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -687,6 +687,31 @@
                     "HiJump",
                     "canSpringBallJumpMidAir"
                   ]
+                },
+                {
+                  "name": "G-Mode Deep Stuck X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [4],
+                      "mode": "direct",
+                      "artificialMorph": false
+                    }},
+                    "canXRayClimb"
+                  ]
+                },
+                {
+                  "name": "Shinespark Deep Stuck X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    {"canComeInCharged": {
+                      "fromNode": 4,
+                      "shinesparkFrames": 0,
+                      "framesRemaining": 1
+                    }},
+                    "canShinesparkDeepStuck",
+                    "canXRayClimb"
+                  ]
                 }
               ]
             },

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -1192,7 +1192,8 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 4,
-                      "shinesparkFrames": 0,
+                      "shinesparkFrames": 1,
+                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
                     }},
                     "canShinesparkDeepStuck",
@@ -1300,7 +1301,8 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 5,
-                      "shinesparkFrames": 0,
+                      "shinesparkFrames": 1,
+                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
                     }},
                     "canShinesparkDeepStuck",
@@ -1617,7 +1619,8 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 6,
-                      "shinesparkFrames": 0,
+                      "shinesparkFrames": 1,
+                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
                     }},
                     "canShinesparkDeepStuck",

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -859,7 +859,8 @@
                     }},
                     "canXRayClimb",
                     {"heatFrames": 1650}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 },
                 {
                   "name": "Shinespark Deep Stuck X-Ray Climb",
@@ -873,7 +874,8 @@
                     "canShinesparkDeepStuck",
                     "canXRayClimb",
                     {"heatFrames": 1650}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 }
               ]
             },

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -868,7 +868,8 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 3,
-                      "shinesparkFrames": 0,
+                      "shinesparkFrames": 1,
+                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
                     }},
                     "canShinesparkDeepStuck",

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -756,7 +756,6 @@
                       "fromNode": 1,
                       "usedTiles": 0.5,
                       "overrideRunwayRequirements": true,
-                      "physics": ["normal"],
                       "useFrames": 200
                     }},
                     {"heatFrames": 1260}
@@ -797,6 +796,38 @@
           "from": 2,
           "to": [
             {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "G-Mode Deep Stuck X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "direct",
+                      "artificialMorph": false
+                    }},
+                    "canXRayClimb",
+                    {"heatFrames": 1600}
+                  ]
+                },
+                {
+                  "name": "Shinespark Deep Stuck X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    {"canComeInCharged": {
+                      "fromNode": 2,
+                      "shinesparkFrames": 0,
+                      "framesRemaining": 1
+                    }},
+                    "canShinesparkDeepStuck",
+                    "canXRayClimb",
+                    {"heatFrames": 1600}
+                  ]
+                }
+              ]
+            },
+            {
               "id": 5,
               "strats": [
                 {
@@ -814,6 +845,38 @@
         {
           "from": 3,
           "to": [
+            {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "G-Mode Deep Stuck X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [3],
+                      "mode": "direct",
+                      "artificialMorph": false
+                    }},
+                    "canXRayClimb",
+                    {"heatFrames": 1650}
+                  ]
+                },
+                {
+                  "name": "Shinespark Deep Stuck X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    {"canComeInCharged": {
+                      "fromNode": 3,
+                      "shinesparkFrames": 0,
+                      "framesRemaining": 1
+                    }},
+                    "canShinesparkDeepStuck",
+                    "canXRayClimb",
+                    {"heatFrames": 1650}
+                  ]
+                }
+              ]
+            },
             {
               "id": 5,
               "strats": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -3734,6 +3734,35 @@
                     }}
                   ],
                   "note": "Only requires a runway of approximately one tile in the adjacent room."
+                },
+                {
+                  "name": "X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    "canLeftFacingDoorXRayClimb",
+                    {"adjacentRunway": {
+                      "fromNode": 2,
+                      "usedTiles": 0.5,
+                      "overrideRunwayRequirements": true,
+                      "physics": ["normal"],
+                      "useFrames": 200
+                    }},
+                    {"or": [
+                      "Ice",
+                      "Wave",
+                      "Spazer",
+                      "Plasma",
+                      "Grapple",
+                      {"enemyDamage": {
+                        "enemy": "Mochtroid",
+                        "type": "contact",
+                        "hits": 1
+                      }}
+                    ]}
+                  ],
+                  "note": [
+                    "Immediately when entering the room, turn around to the left while using X-ray and kill the Mochtroid, to prevent or minimize damage."
+                  ]
                 }
               ]
             }
@@ -5346,6 +5375,27 @@
                   "note": [
                     "Requires a runway of approximately 7.5 tiles in the adjacent room, to hit a peak of the speed vs height graph.",
                     "Spring ball can be used with the speed to get all the way to 3, but it's tricky"
+                  ]
+                },
+                {
+                  "name": "X-Ray Climb Space Jump",
+                  "notable": false,
+                  "requires": [
+                    "canLeftFacingDoorXRayClimb",
+                    {"adjacentRunway": {
+                      "fromNode": 2,
+                      "usedTiles": 0.5,
+                      "overrideRunwayRequirements": true,
+                      "physics": ["normal"],
+                      "useFrames": 200
+                    }},
+                    "SpaceJump"
+                  ],
+                  "note": [
+                    "X-ray climb until Samus is above the water surface.",
+                    "To avoid falling out, be careful not to turn left except while holding X-ray.",
+                    "From a standing position facing left, hold left and immediately jump, then use Space Jump to reach the ledge.",
+                    "Alternatively, from a standing position facing right, do a turn-around spin jump; in this case the spin-jump will immediately bonk, so quickly press jump a second time to get a continuous wall jump while holding left."
                   ]
                 }
               ]

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -3763,7 +3763,8 @@
                     ]}
                   ],
                   "note": [
-                    "Immediately when entering the room, turn around to the left while using X-ray and kill the Mochtroid, to prevent or minimize damage."
+                    "Immediately when entering the room, turn around to the left while using X-ray and kill the Mochtroid, to prevent or minimize damage.",
+                    "Climb up 1 screen."
                   ]
                 }
               ]

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -3753,6 +3753,8 @@
                       "Spazer",
                       "Plasma",
                       "Grapple",
+                      {"ammo": { "type": "Missile", "count": 1}},
+                      {"ammo": { "type": "Super", "count": 1}},
                       {"enemyDamage": {
                         "enemy": "Mochtroid",
                         "type": "contact",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -5398,7 +5398,8 @@
                     "X-ray climb until Samus is above the water surface.",
                     "To avoid falling out, be careful not to turn left except while holding X-ray.",
                     "From a standing position facing left, hold left and immediately jump, then use Space Jump to reach the ledge.",
-                    "Alternatively, from a standing position facing right, do a turn-around spin jump; in this case the spin-jump will immediately bonk, so quickly press jump a second time to get a continuous wall jump while holding left."
+                    "Alternatively, from a standing position facing right, do a turn-around spin jump, waiting to jump until part way through the turn-around animation (otherwise Samus will bonk inside the wall)",
+                    "It is also possible to climb lower, with Samus' feet still in the water; in this case, the turn-around animation is slower, providing a larger window to jump, though in this case either a wall jump or a Space Jump water escape may be needed."
                   ]
                 }
               ]

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -1073,7 +1073,8 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "shinesparkFrames": 0,
+                      "shinesparkFrames": 1,
+                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
                     }},
                     "canShinesparkDeepStuck",

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -1053,7 +1053,36 @@
                     "2. Freeze it about a half-tile from the right wall and very quickly stationary spin jump and quickly walljump mash to get up before it thaws.",
                     "This may be easier by jumping away from the wall, towards the fish, to gain height faster."
                   ]
+                },
+                {
+                  "name": "G-Mode Deep Stuck X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "direct",
+                      "artificialMorph": false
+                    }},
+                    "canXRayClimb"
+                  ]
+                },
+                {
+                  "name": "Shinespark Deep Stuck X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    {"canComeInCharged": {
+                      "fromNode": 2,
+                      "shinesparkFrames": 0,
+                      "framesRemaining": 1
+                    }},
+                    "canShinesparkDeepStuck",
+                    "canXRayClimb"
+                  ]
                 }
+              ],
+              "devNote": [
+                "It is possible to X-ray climb higher, into a normally inaccessible area behind the door to Kassiuz Room.",
+                "This doesn't appear to be useful: the door transition there, which appears to lead back to the normal part of Plasma Spark Room, instead transitions to the same room as the bottom right door (to Butterfly Room)."
               ]
             },
             {

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -1064,7 +1064,8 @@
                       "artificialMorph": false
                     }},
                     "canXRayClimb"
-                  ]
+                  ],
+                  "note": "Climb up 2 screens."
                 },
                 {
                   "name": "Shinespark Deep Stuck X-Ray Climb",
@@ -1077,7 +1078,8 @@
                     }},
                     "canShinesparkDeepStuck",
                     "canXRayClimb"
-                  ]
+                  ],
+                  "note": "Climb up 2 screens."
                 }
               ],
               "devNote": [

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -995,9 +995,23 @@
                     "To avoid hitting the Skultera, place the bomb a few pixels from the doorway.",
                     "One way to setup the positioning of the bomb is to place it, unmorph, rotate, and remorph"
                   ]
+                },
+                {
+                  "name": "X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    "canLeftFacingDoorXRayClimb",
+                    {"adjacentRunway": {
+                      "fromNode": 2,
+                      "usedTiles": 0.5,
+                      "overrideRunwayRequirements": true,
+                      "physics": ["normal"],
+                      "useFrames": 200
+                    }}
+                  ]
                 }
               ],
-              "note": "This link is only for the cross room jump. Other strats should go 2 -> 8 -> 3."
+              "note": "This link is only for the cross room jump and X-ray climb. Other strats should go 2 -> 8 -> 3."
             },
             {
               "id": 8,

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -329,7 +329,8 @@
                       "artificialMorph": false
                     }},
                     "canXRayClimb"
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 },
                 {
                   "name": "Shinespark Deep Stuck X-Ray Climb",
@@ -342,7 +343,8 @@
                     }},
                     "canShinesparkDeepStuck",
                     "canXRayClimb"
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 }
               ]
             },

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -317,6 +317,36 @@
           "from": 2,
           "to": [
             {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "G-Mode Deep Stuck X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "direct",
+                      "artificialMorph": false
+                    }},
+                    "canXRayClimb"
+                  ]
+                },
+                {
+                  "name": "Shinespark Deep Stuck X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    {"canComeInCharged": {
+                      "fromNode": 2,
+                      "shinesparkFrames": 0,
+                      "framesRemaining": 1
+                    }},
+                    "canShinesparkDeepStuck",
+                    "canXRayClimb"
+                  ]
+                }
+              ]
+            },
+            {
               "id": 4,
               "strats": [
                 {

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -338,7 +338,8 @@
                   "requires": [
                     {"canComeInCharged": {
                       "fromNode": 2,
-                      "shinesparkFrames": 0,
+                      "shinesparkFrames": 1,
+                      "excessShinesparkFrames": 1,
                       "framesRemaining": 1
                     }},
                     "canShinesparkDeepStuck",

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -2252,6 +2252,26 @@
           "from": 3,
           "to": [
             {
+              "id": 2,
+              "strats": [
+                {
+                  "name": "X-Ray Climb",
+                  "notable": false,
+                  "requires": [
+                    "canRightFacingDoorXRayClimb",
+                    {"adjacentRunway": {
+                      "fromNode": 3,
+                      "usedTiles": 0.5,
+                      "overrideRunwayRequirements": true,
+                      "useFrames": 200
+                    }},
+                    {"spikeHits": 3}
+                  ],
+                  "devNote": "FIXME: See if refreshing I-frames using XRay can reduce the required number of hits."
+                }
+              ]
+            },
+            {
               "id": 4,
               "strats": [
                 {

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -2265,7 +2265,13 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }},
-                    {"spikeHits": 3}
+                    {"or": [
+                      {"spikeHits": 3},
+                      {"and": [
+                        {"not": "f_DefeatedPhantoon"},
+                        "canRiskPermanentLossOfAccess"
+                      ]}
+                    ]}
                   ],
                   "devNote": "FIXME: See if refreshing I-frames using XRay can reduce the required number of hits."
                 }

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -2273,7 +2273,11 @@
                       ]}
                     ]}
                   ],
-                  "devNote": "FIXME: See if refreshing I-frames using XRay can reduce the required number of hits."
+                  "note": [
+                    "Climb up 1 screen.",
+                    "Climb quickly once you reach the spikes to minimize damage (if Phantoon is dead).",
+                    "I-frames will run out while using X-Ray, so you don't want to hold X-Ray for long."
+                  ]
                 }
               ]
             },


### PR DESCRIPTION
Add a bunch more X-ray climbs:
- Landing Site, right side (deep stuck)
- Spore Spawn Supers
- Glass Tunnel, to get from bottom right door to inside tube (deep stuck)
- Colosseum, right side
- Bowling Alley, from Gravity Suit door up through spikes
- East Cactus Alley, to get above water surface
- Plasma Spark Room, bottom right door to middle right door (deep stuck)
- Fast Pillars Setup Room, either bottom door to top left door (deep stuck)
- Main Street, bottom right door to middle right door