### PR TITLE
Add devNote for Halfie Climb water stutter short charge

### DIFF
--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -2997,7 +2997,7 @@
                   ],
                   "devNote": [
                     "For the water stutter version, normally you want to kill the Mochtroid as you enter to prevent taking damage.",
-                    "This can be done with a Missile or Super or any beam other than Charge.",
+                    "This can be done with a Missile, Super, or Grapple or any beam other than Charge.",
                     "Without any beams or ammo, it is possible to kill the Mochtroid using blue speed without taking damage, but it is tricky:",
                     "get the specific stutter where Samus slows down as late in the water room as possible,",
                     "then angle up and shoot the Mochtroid twice when entering the room (which for some reason causes the Mochtroid to swing further left and not damage Samus).",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -2985,7 +2985,21 @@
                           "physics": ["normal"],
                           "overrideRunwayRequirements": true,
                           "useFrames": 80
-                        }}
+                        }},
+                        {"or": [
+                          "Ice",
+                          "Wave",
+                          "Spazer",
+                          "Plasma",
+                          "Grapple",
+                          {"ammo": { "type": "Missile", "count": 1}},
+                          {"ammo": { "type": "Super", "count": 1}},
+                          {"enemyDamage": {
+                            "enemy": "Mochtroid",
+                            "type": "contact",
+                            "hits": 1
+                          }}  
+                        ]}
                       ]}
                     ]},
                     {"canShineCharge": {

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -2985,21 +2985,7 @@
                           "physics": ["normal"],
                           "overrideRunwayRequirements": true,
                           "useFrames": 80
-                        }},
-                        {"or": [
-                          "Ice",
-                          "Wave",
-                          "Spazer",
-                          "Plasma",
-                          "Grapple",
-                          {"ammo": { "type": "Missile", "count": 1}},
-                          {"ammo": { "type": "Super", "count": 1}},
-                          {"enemyDamage": {
-                            "enemy": "Mochtroid",
-                            "type": "contact",
-                            "hits": 1
-                          }}  
-                        ]}
+                        }}
                       ]}
                     ]},
                     {"canShineCharge": {
@@ -3008,6 +2994,14 @@
                       "excessShinesparkFrames": 3,
                       "openEnd": 2
                     }}
+                  ],
+                  "devNote": [
+                    "For the water stutter version, normally you want to kill the Mochtroid as you enter to prevent taking damage.",
+                    "This can be done with a Missile or Super or any beam other than Charge.",
+                    "Without any beams or ammo, it is possible to kill the Mochtroid using blue speed without taking damage, but it is tricky:",
+                    "get the specific stutter where Samus slows down as late in the water room as possible,",
+                    "then angle up and shoot the Mochtroid twice when entering the room (which for some reason causes the Mochtroid to swing further left and not damage Samus).",
+                    "FIXME: Add some tech requirement for this tricky version that kills the Mochtroid with blue speed."
                   ]
                 }
               ]


### PR DESCRIPTION
Dealing with the Mochtroid here can be a little tricky. We add a devNote to explain and include a FIXME to probably add some tech requirement (or separate notable strat) later for this.