### PR TITLE
Update low jump strat into Pseudo Plasma Spark Room

### DIFF
--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -517,7 +517,7 @@
                   ]
                 },
                 {
-                  "name": "Cross Room Jump - Insane Low Wall Jump",
+                  "name": "Cross Room Jump - Low Wall Jump Turnaround",
                   "notable": false,
                   "requires": [
                     "canCrossRoomJumpIntoWater",
@@ -527,16 +527,20 @@
                       "minHeight": 2,
                       "maxHeight": 2
                     }},
-                    "canInsaneWalljump"
+                    {"or": [
+                      "canInsaneWalljump",
+                      "canMomentumConservingTurnaround"
+                    ]}
                   ],
                   "note": [
                     "Do a low spin jump and press against the right side of the door frame.",
                     "Wall jump as low as possible, jumping as soon as possible after moving away from the wall.",
-                    "Immediately turn back to the right and try to press against the door frame again before the transition, while maintaining spin."
+                    "Immediately turn back to the right and try to press against the door frame again before the transition, while maintaining spin.",
+                    "After the transition, typically a momentum-conserving turnaround is needed to avoid bonking."
                   ],
                   "devNote": [
                     "This strat is for cases where the door frame below has only a two-tile-high surface available for wall-jumping.",
-                    "If a third tile is available, the jump can be done much more easily."
+                    "If a third tile is available, the jump can be done more easily."
                   ]
                 }
               ]


### PR DESCRIPTION
Updating this low wall jump strat to include canMomentumConservingTurnaround as an alternative to canInsaneWalljump. As insomniaspeed found, it's much easier with the turnaround:
https://discord.com/channels/1053421401354285129/1053434704180805744/1113636325057380382