### PR TITLE
Sand Pits update

### DIFF
--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -6303,6 +6303,22 @@
                     ]}
                   ],
                   "note": "It's possible to get out of the sand suitless and without hjb after falling from the chute, by hugging the left side and moving quickly."
+                },
+                {
+                  "name": "Shinespark",
+                  "notable": false,
+                  "requires": [
+                    "canPlayInSand",
+                    "canSunkenTileWideWallClimb",
+                    "canMidairShinespark",
+                    "canShinechargeMovement",
+                    {"canComeInCharged": {
+                      "framesRemaining": 105,
+                      "fromNode": 1,
+                      "shinesparkFrames": 11
+                    }}
+                  ],
+                  "note": "Jump out of the sand before Shinesparking."
                 }
               ]
             },
@@ -6381,6 +6397,36 @@
                     "This requires a very precise spinjump into the sandfall which also exits the sandfall, after being pushed down, with more height than a regular jump.",
                     "It is very easy to fall into the sand and be unable to escape."
                   ]
+                },
+                {
+                  "name": "Shinespark",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateUnderwater",
+                    "Morph",
+                    "canPlayInSand",
+                    "canMidairShinespark",
+                    "canShinechargeMovement",
+                    {"or": [
+                      {"and": [
+                        "canPrepareForNextRoom",
+                        {"canComeInCharged": {
+                          "framesRemaining": 70,
+                          "fromNode": 1,
+                          "shinesparkFrames": 18
+                        }}
+                      ]},
+                      {"and": [
+                        "canTrickyJump",
+                        {"canComeInCharged": {
+                          "framesRemaining": 140,
+                          "fromNode": 1,
+                          "shinesparkFrames": 20
+                        }}
+                      ]}
+                    ]}
+                  ],
+                  "note": "The shinespark must be performed near the upper ledge, and not inside the sandfall."
                 }
               ]
             }
@@ -6591,6 +6637,7 @@
                   "requires": [
                     "h_canNavigateUnderwater",
                     "canPlayInSand",
+                    "canShinechargeMovement",
                     {"or": [
                       {"and": [
                         {"or": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -6789,32 +6789,27 @@
                   "devNote": "FIXME: Jumping onto a single bomb should be a tech.  Its like canJumpIntoIBJ except not an IBJ and works with powerbombs."
                 },
                 {
-                  "name": "West Sand Hole MidAir Morph (Bootless Suitless)",
-                  "notable": true,
-                  "requires": [
-                    "canSuitlessMaridia",
-                    "canPreciseWalljump",
-                    "Morph",
-                    "canSpaceJumpWaterBounce"
-                  ],
-                  "note": "Use space jump to break free of the water then walljump and morph to get up to the morph tunnel."
-                },
-                {
-                  "name": "Suitless HiJump",
+                  "name": "Suitless Mid Air Morph",
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
                     "Morph",
-                    "HiJump",
                     {"or": [
-                      "canPreciseWalljump",
                       {"and": [
-                        "canSpaceJumpWaterBounce",
-                        "canWalljump"
+                        "HiJump",
+                        "canPreciseWalljump"
                       ]},
-                      "canSpaceJumpWaterEscape"
+                      {"and": [
+                        "HiJump",
+                        "canSpaceJumpWaterEscape"
+                      ]},
+                      {"and": [
+                        "canPreciseWalljump",
+                        "canSpaceJumpWaterBounce"
+                      ]}
                     ]}
-                  ]
+                  ],
+                  "note": "Escape the water with either HiJump or SpaceJump, then carefully jump and morph into the tunnel."
                 },
                 {
                   "name": "Spring Ball Jump",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -6781,12 +6781,15 @@
                     "Gravity",
                     "h_canUseSpringBall",
                     {"or": [
-                      "h_canBombThings",
+                      {"and": [
+                        "canJumpIntoIBJ",
+                        "h_canBombThings"
+                      ]},
                       "HiJump"
                     ]}
                   ],
                   "note": "Springball bounce on top of the crumble blocks.  Use either a bomb or HiJump to gain a little bit of extra height.",
-                  "devNote": "FIXME: Jumping onto a single bomb should be a tech.  Its like canJumpIntoIBJ except not an IBJ and works with powerbombs."
+                  "devNote": "The tech requirement is `catching yourself on an aerial bomb` which is what canJumpIntoIBJ adds to canIBJ.  Only one bomb or powerbomb is needed."
                 },
                 {
                   "name": "Suitless Mid Air Morph",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -6310,8 +6310,11 @@
                   "requires": [
                     "canPlayInSand",
                     "canSunkenTileWideWallClimb",
-                    "canMidairShinespark",
                     "canShinechargeMovement",
+                    {"or": [
+                      "canMidairShinespark",
+                      "canCarefulJump"
+                    ]},
                     {"canComeInCharged": {
                       "framesRemaining": 105,
                       "fromNode": 1,
@@ -6652,6 +6655,17 @@
                           "fromNode": 1,
                           "shinesparkFrames": 24,
                           "excessShinesparkFrames": 5
+                        }}
+                      ]},
+                      {"and": [
+                        "canHeroShot",
+                        "canTrickyJump",
+                        "canShinechargeMovementComplex",
+                        {"canComeInCharged": {
+                          "framesRemaining": 160,
+                          "fromNode": 1,
+                          "shinesparkFrames": 25,
+                          "excessShinesparkFrames": 4
                         }}
                       ]},
                       {"and": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -6584,6 +6584,45 @@
                     "Bouncing on the sand as springball can reach the above maze by altering Samus' fall height, like by bouncing under the solid ledge before trying to jump up."
                   ],
                   "devNote": "Jumping through the sandfall is failable enough to require canPlayInSand"
+                },
+                {
+                  "name": "Shinespark",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateUnderwater",
+                    "canPlayInSand",
+                    {"or": [
+                      {"and": [
+                        {"or": [
+                          "canResetFallSpeed",
+                          {"and": [
+                            "canPrepareForNextRoom",
+                            "h_canUsePowerBombs"
+                          ]}
+                        ]},
+                        {"canComeInCharged": {
+                          "framesRemaining": 150,
+                          "fromNode": 1,
+                          "shinesparkFrames": 24,
+                          "excessShinesparkFrames": 5
+                        }}
+                      ]},
+                      {"and": [
+                        "Wave",
+                        {"canComeInCharged": {
+                          "framesRemaining": 85,
+                          "fromNode": 1,
+                          "shinesparkFrames": 24,
+                          "excessShinesparkFrames": 5
+                        }}
+                      ]}
+                    ]}
+                  ],
+                  "note": [
+                    "Break the shot block before reaching the sand and then shinespark up.",
+                    "Samus cannot shinespark after unmorphing until she touches the sand and this can be used to shoot upwards without sparking.",
+                    "A diagonal ShineSpark will most likely not have any horizontal movement when performed from the sand."
+                  ]
                 }
               ]
             }
@@ -6783,6 +6822,10 @@
                     {"or": [
                       {"and": [
                         "canJumpIntoIBJ",
+                        "h_canBombThings"
+                      ]},
+                      {"and": [
+                        "canSpringBallBombJump",
                         "h_canBombThings"
                       ]},
                       "HiJump"


### PR DESCRIPTION
Shinesparks can do a lot towards reaching the items.  
Removed the bootsless suitless notable, and merged it into the HiJump strat.