### PR TITLE
Acid Chozo Statue Partial Update

### DIFF
--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -87,7 +87,7 @@
                     "h_canNavigateHeatRooms",
                     "SpaceJump",
                     "h_canUsePowerBombs",
-                    {"heatFrames": 800}
+                    {"heatFrames": 1000}
                   ]
                 }
               ]
@@ -163,6 +163,28 @@
                       "shinesparkFrames": 36
                     }},
                     {"heatFrames": 125}
+                  ]
+                },
+                {
+                  "name": "Acid Dive",
+                  "notable": false,
+                  "requires": [
+                    "canSuitlessLavaDive",
+                    {"or": [
+                      "HiJump",
+                      "canWalljump"
+                    ]},
+                    {"acidFrames": 80},
+                    {"heatFrames": 230}
+                  ],
+                  "devNote": "FIXME This is also possible with a sPring ball jump or flatley jump."
+                },
+                {
+                  "name": "Ceiling Bomb Jump",
+                  "notable": false,
+                  "requires": [
+                    "h_heatProof",
+                    "h_canCeilingBombJump"
                   ]
                 }
               ]


### PR DESCRIPTION
In vanilla, the only way to activate the statue is with Space Jump, so strats from 1->3 required space jump or the statue to have already been activated. 

A randomizer may wish to remove this space jump requirement (located on the statue lock), so common non-space jump strats from 1->3 are added.