### PR TITLE
Add low level tech

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -254,6 +254,10 @@
       "name": "h_canJumpIntoIBJ",
       "requires": [
         "canJumpIntoIBJ",
+        {"or": [
+          "SpringBall",
+          "canMidAirMorph"
+        ]},
         "h_canUseMorphBombs"
       ]
     },
@@ -437,6 +441,10 @@
       "name": "h_canJumpIntoCrystalFlashClip",
       "requires": [
         "canJumpIntoCrystalFlashClip",
+        {"or": [
+          "SpringBall",
+          "canMidAirMorph"
+        ]},
         "h_canCrystalFlash",
         {"ammo": {"type": "PowerBomb","count": 10}}
       ],

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -733,7 +733,10 @@
                     "canSandfallBounce",
                     {"or":[
                       "canSandIBJ",
-                      "HiJump"
+                      {"and": [
+                        "HiJump",
+                        "canMidAirMorph"
+                      ]}
                     ]}
                   ],
                   "note": [

--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -4228,15 +4228,17 @@
                       {"and": [
                         "SpaceJump",
                         "HiJump",
-                        "ScrewAttack"
+                        {"or": [
+                          "ScrewAttack",
+                          "canPseudoScrew"
+                        ]}
                       ]}
                     ]}
                   ],
                   "note": [
                     "Use Screw Attack or a Pseudo Screw to avoid Space Pirate attacks while climbing the central shaft.",
                     "The Screw Attack effect is not active when Samus is preparing to Walljump."
-                  ],
-                  "devNote": "FIXME: Add spacejump with pseudoscrew."
+                  ]
                 },
                 {
                   "name": "Reverse Tourian Escape Room 4 Dodge While Climbing",

--- a/tech.json
+++ b/tech.json
@@ -834,12 +834,9 @@
               "note": "The ability to run from, jump over, or duck under attacks that do not require precise avoidance movements while shooting the enemy."
             },
             {
-              "name": "canEscapeDraygonGrab",
+              "name": "canEscapeEnemyGrab",
               "requires": [],
-              "note": [
-                "The ability to become gooped and grabbed by Draygon and then escape by pressing 60 directional inputs.",
-                "Failure to escape usually results in death."
-              ]
+              "note": "The ability to become grabbed by Draygon or a Beetom and then escape by pressing 60+ inputs."
             }
           ]
         }

--- a/tech.json
+++ b/tech.json
@@ -541,7 +541,6 @@
             {
               "name": "canJumpIntoIBJ",
               "requires": [ 
-                "canMidAirMorph",
                 "canIBJ" 
               ],
               "note": "The ability to start an IBJ from a jump or spring ball jump. Can be required in strats that need Samus to IBJ up faster or to avoid something near the ground."
@@ -599,12 +598,12 @@
           "name": "canBombJumpOnSand",
           "requires": [ 
             "canPlayInSand", 
-            "h_canBombThings",
-            "canMidAirMorph"
+            "h_canBombThings"
           ],
           "note": [
             "The ability to bomb jump while dealing with the sinking effect of sand physics.",
-            "This is done by placing the bomb on or above the top of the sand line and then jumping again to land on the bomb explosion."
+            "This is done by placing the bomb on or above the top of the sand line and then jumping again to land on the bomb explosion.",
+            "Or by rising out of the sand using Bombs inside of a sandfall to then land on the bomb that is at the sand line."
           ]
         }
       ]
@@ -1271,8 +1270,7 @@
               "name": "canJumpIntoCrystalFlashClip",
               "requires": [
                 "canCrystalFlash",
-                "canCeilingClip",
-                "canMidAirMorph"
+                "canCeilingClip"
               ],
               "note": [
                 "Setting up a Crystal Flash by jumping and morphing.  Once to place the power bomb, then again to activate the Crystal Flash.",

--- a/tech.json
+++ b/tech.json
@@ -433,17 +433,6 @@
               ]
             }
           ]
-        },
-        {
-          "name": "canWalljumpWithCharge",
-          "requires": [
-            "Charge",
-            "canWalljump"
-          ],
-          "note": [
-            "The ability to store charge beam and continue walljumping.",
-            "This is done by releasing the shoot button when trying to walljump. Otherwise Samus will stop spinning."
-          ]
         }
       ]
     },
@@ -792,6 +781,46 @@
           "note": [
             "The ability to pass through some enemies undamaged by shooting.",
             "May involve running through the enemy after making its hitbox inactive (e.g. Metal Pirates) or while the enemy has iframes (e.g. using Plasma)."
+          ]
+        },
+        {
+          "name": "canPseudoScrew",
+          "requires": ["Charge"],
+          "note": [
+            "The ability to spinjump with Charge beam stored.",
+            "Pseudo screw gives Samus some protection from projecitles and enemies.",
+            "It will damage enemies who are vulnerable to this attack and Samus will only take damage if the enemy takes damage and is not killed."
+          ],
+          "extensionTechs": [
+            {
+              "name": "canWalljumpWithCharge",
+              "requires": [
+                "canPseudoScrew",
+                "canWalljump"
+              ],
+              "note": [
+                "The ability to store charge beam and continue walljumping.",
+                "This is done by releasing the shoot button when trying to walljump. Otherwise Samus will stop spinning."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "canSpecialBeamAttack",
+          "requires": [
+            "Charge",
+            "PowerBomb",
+            {"or": [
+              "Ice",
+              "Wave",
+              "Spazer",
+              "Plasma"
+            ]}
+          ],
+          "note": [
+            "The knowledge of how to use a Special Beam Attack (SBA) for any beam type.",
+            "A SBA is activated by equipping exactly Charge and one other Beam and selecting Power Bombs.",
+            "After charging the beam, a power bomb will be consumed, and a beam specific attack will occur."
           ]
         },
         {

--- a/tech.json
+++ b/tech.json
@@ -256,9 +256,44 @@
           ]
         },
         {
-          "name": "canPreciseGrapple",
-          "requires": [ "Grapple" ],
-          "note": "The ability to precisely aim at grapple points while moving quickly, and precise control of Samus' speed and trajectory when releasing from a grapplable object."
+          "name": "canUseGrapple",
+          "requires": ["Grapple"],
+          "note": [
+            "The ability to fling Samus moderate distances by grappling onto attach points to build up momentum.",
+            "Knowing how to use Grapple also means knowing that the Grapple Beam can be used as a weapon to instantly kill certain enemies."
+          ],
+          "extensionTechs": [
+            {
+              "name": "canPreciseGrapple",
+              "requires": [ "canUseGrapple" ],
+              "note": "The ability to precisely aim at grapple points while moving quickly, and precise control of Samus' speed and trajectory when releasing from a grapplable object."
+            },
+            {
+              "name": "canGrappleJump",
+              "requires": [
+                "canUseGrapple",
+                "canMidAirMorph",
+                {"or": [
+                  "HiJump",
+                  "can3HighMidAirMorph"
+                ]}
+              ],
+              "note": [
+                "Using grapple to propel yourself upwards, then continuously morphing/unmorphing/jumping in midair to climb upwards",
+                "Much more lenient with HiJump."
+              ],
+              "extensionTechs": [
+                {
+                  "name": "canDraygonTurretGrappleJump",
+                  "requires": [
+                    "canGrappleJump",
+                    {"draygonElectricityFrames": 60}
+                  ],
+                  "note": "Using grapple jump off a Draygon turret.  Usually done by bouncing off the wall for momentum."
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -351,31 +386,6 @@
           "note": [
             "The ability to reliably jump while landing on a crumble block.",
             "A straight jump may employ the small amount of jump buffering the game offers, but a spinjump can only use the time before the crumble block breaks."
-          ]
-        },
-        {
-          "name": "canGrappleJump",
-          "requires": [
-            "Grapple",
-            "Morph",
-            {"or": [
-              "HiJump",
-              "can3HighMidAirMorph"
-            ]}
-          ],
-          "note": [
-            "Using grapple to propel yourself upwards, then continuously morphing/unmorphing/jumping in midair to climb upwards",
-            "Much more lenient with HiJump."
-          ],
-          "extensionTechs": [
-            {
-              "name": "canDraygonTurretGrappleJump",
-              "requires": [
-                "canGrappleJump",
-                {"draygonElectricityFrames": 60}
-              ],
-              "note": "Using grapple jump off a Draygon turret.  Usually done by bouncing off the wall for momentum."
-            }
           ]
         },
         {

--- a/tech.json
+++ b/tech.json
@@ -118,6 +118,14 @@
           "note": "Holding the direction buttons down and then also backwards in order to move forwards, while in the correct falling state."
         },
         {
+          "name": "canStopOnADime",
+          "requires": [],
+          "note": [
+            "Holding the angle up or angle down buttons when no directional inputs are held will completely stop Samus in place.",
+            "This is used to enter elevators instantly, but can also be used to avoid being carried into some rooms by momentum."
+          ]
+        },
+        {
           "name": "canMoonwalk",
           "requires": [],
           "note": "This is an option that can be turned on in the special setting mode after selecting a save file. It is required for some tech.",

--- a/tech.json
+++ b/tech.json
@@ -799,6 +799,14 @@
               "name": "canDodgeWhileShooting",
               "requires": [],
               "note": "The ability to run from, jump over, or duck under attacks that do not require precise avoidance movements while shooting the enemy."
+            },
+            {
+              "name": "canEscapeDraygonGrab",
+              "requires": [],
+              "note": [
+                "The ability to become gooped and grabbed by Draygon and then escape by pressing 60 directional inputs.",
+                "Failure to escape usually results in death."
+              ]
             }
           ]
         }

--- a/tech.json
+++ b/tech.json
@@ -70,6 +70,17 @@
           ]
         },
         {
+          "name": "canDisableEquipment",
+          "requires": [],
+          "note": [
+            "Collecting equipment can make movement more difficult in certain situations.",
+            "Speedbooster will reduce Samus' jump height and turning Speedbooster off will return the jump height to normal.",
+            "Disabling HiJump will give more time to perform a mid-air morph",
+            "Disabling Gravity will allow Samus to float farther in water, or jump slower for a mid-air morph",
+            "Beams may need to be disabled to control how enemies are killed (i.e. Remove plasma for canUseFrozenEnemies, or remove ice to effeciently use heat room farm points)."
+          ]
+        },
+        {
           "name": "canPlayInSand",
           "requires": [],
           "note": [
@@ -329,7 +340,10 @@
         },
         {
           "name": "canGravityJump",
-          "requires": [ "Gravity" ],
+          "requires": [ 
+            "canDisableEquipment",
+            "Gravity"
+          ],
           "note": [
             "Turning off Gravity Suit right after the start of an underwater jump to achieve higher height.",
             "Can be performed in water, lava, or acid."
@@ -351,6 +365,7 @@
         {
           "name": "canSpringBallJumpMidAir",
           "requires": [
+            "canDisableEquipment",
             "canMidAirMorph",
             "SpringBall"
           ],

--- a/tech.json
+++ b/tech.json
@@ -264,6 +264,27 @@
           "note":"The ability to crouch before jumping to reach higher ledges. Commonly paired with a Down Grab."
         },
         {
+          "name": "canTurnaroundSpinJump",
+          "requires": [],
+          "note": [
+            "The ability to buffer a jump by using the turnaround animation frames.",
+            "This allows for an easier Spin Jump timing and works as a way to move underwater quickly."
+          ],
+          "extensionTechs": [
+            {
+              "name": "canFlatleyJump",
+              "requires": [ 
+                "canTurnaroundSpinJump",
+                "canTrickyJump"
+              ],
+              "note": [
+                "Positioning Samus at the very edge of a platform, facing away, then turning around and jumping to initiate the jump from a position that is off the platform (and slightly below it)",
+                "Sometimes referred to as a corner jump."
+              ]
+            }
+          ]
+        },
+        {
           "name": "canGravityJump",
           "requires": [ "Gravity" ],
           "note": [
@@ -378,14 +399,6 @@
                     "The more speed Samus has, the smaller the frame window for the CWJ.",
                     "A slow CWJ uses a wall or ledge near the initial jump point.",
                     "A fast CWJ will wall jump using the opposite side of a distant object."
-                  ]
-                },
-                {
-                  "name": "canFlatleyJump",
-                  "requires": [ "canTrickyJump" ],
-                  "note": [
-                    "Positioning Samus at the very edge of a platform, facing away, then turning around and jumping to initiate the jump from a position that is off the platform (and slightly below it)",
-                    "Sometimes referred to as a corner jump."
                   ]
                 }
               ]

--- a/tech.json
+++ b/tech.json
@@ -136,25 +136,55 @@
           "devNote": "Taking enemy damage can get the same effect but more situations where this is used would need to be found first."
         },
         {
-          "name": "canLateralMidAirMorph",
-          "requires": [ "Morph" ],
-          "note": "Performing the same input as a mockball, but in midair, in order to maintain forward momentum while morphing in midair",
+          "name": "canMidAirMorph",
+          "requires": ["Morph"],
+          "note": [
+            "The ability to enter Morph Ball while in the air.",
+            "There can be an expectation to Morph quickly as well, usually following a jump from the ground.",
+            "Out of water physics this means jumping and morphing in a 4 tile high space.",
+            "In water physics this means jumping and morphing in a 3 tile high space (Samus takes up 3 tiles when standing)."
+          ],
           "extensionTechs": [
             {
-              "name": "canSpringBallBounce",
-              "requires": [
-                "canLateralMidAirMorph",
-                "SpringBall"
-              ],
-              "note": "Using a lateral mid-air morph to bounce off a surface with SpringBall while retaining previous momentum."
+              "name": "can3HighMidAirMorph",
+              "requires": [ "canMidAirMorph" ],
+              "note" : "A mid-air morph that has to be done within an elevation difference of 3 tiles (with a ceiling removing any extra room). It's a lot more precise than with more room."
             },
             {
-              "name": "canStationaryLateralMidAirMorph",
-              "requires": [ "canLateralMidAirMorph" ],
+              "name": "canRJump",
+              "requires": [ "canMidAirMorph" ],
               "note": [
-                "While performing a stationary vertical jump, it's possible to mid-air morph in a manner similar to a lateral mid-air morph.",
-                "Doing this immediately gives lateral momentum equivalent to maximum walk speed.",
-                "This is meaningless under normal physics, but has underwater applications."
+                "A technique for mid-air morphing over a two tile wall in air physics, or a one tile wall in water physics.",
+                "The key point is that pausing can be used to morph much faster than double pressing down.",
+                "\"R\" means holding angle aim before the first down press so Samus has a smaller hitbox for slightly more space to work with.",
+                "1) Hold angle aim(up or down) and down while in a crouching position.",
+                "2) Pause and jump as late as possible.",
+                "3) Release all inputs during the pause screen.",
+                "4) Hold jump and down and forward after the pause screen clears but before game control resumes."
+              ]
+            },
+            {
+              "name": "canLateralMidAirMorph",
+              "requires": [ "canMidAirMorph" ],
+              "note": "Performing the same input as a mockball, but in midair, in order to maintain forward momentum while morphing in midair",
+              "extensionTechs": [
+                {
+                  "name": "canSpringBallBounce",
+                  "requires": [
+                    "canLateralMidAirMorph",
+                    "SpringBall"
+                  ],
+                  "note": "Using a lateral mid-air morph to bounce off a surface with SpringBall while retaining previous momentum."
+                },
+                {
+                  "name": "canStationaryLateralMidAirMorph",
+                  "requires": [ "canLateralMidAirMorph" ],
+                  "note": [
+                    "While performing a stationary vertical jump, it's possible to mid-air morph in a manner similar to a lateral mid-air morph.",
+                    "Doing this immediately gives lateral momentum equivalent to maximum walk speed.",
+                    "This is meaningless under normal physics, but has underwater applications."
+                  ]
+                }
               ]
             }
           ]
@@ -199,24 +229,6 @@
           "name": "canQuickCrumbleEscape",
           "requires": [],
           "note":"The combination of a crumble quick drop, and landing on a lower surface and jumping back over the crumble block before it re-forms."
-        },
-        {
-          "name": "can3HighMidAirMorph",
-          "requires": [ "Morph" ],
-          "note" : "A mid-air morph that has to be done within an elevation difference of 3 tiles (with a ceiling removing any extra room). It's a lot more precise than with more room."
-        },
-        {
-          "name": "canRJump",
-          "requires": ["Morph"],
-          "note": [
-            "A technique for mid-air morphing over a two tile wall in air physics, or a one tile wall in water physics.",
-            "The key point is that pausing can be used to morph much faster than double pressing down.",
-            "\"R\" means holding angle aim before the first down press so Samus has a smaller hitbox for slightly more space to work with.",
-            "1) Hold angle aim(up or down) and down while in a crouching position.",
-            "2) Pause and jump as late as possible.",
-            "3) Release all inputs during the pause screen.",
-            "4) Hold jump and down and forward after the pause screen clears but before game control resumes."
-          ]
         },
         {
           "name": "canMidairWiggle",
@@ -275,7 +287,7 @@
         {
           "name": "canSpringBallJumpMidAir",
           "requires": [
-            "Morph",
+            "canMidAirMorph",
             "SpringBall"
           ],
           "note": [
@@ -296,10 +308,7 @@
             },
             {
               "name": "canDoubleSpringBallJumpMidAir",
-              "requires": [
-                "Morph",
-                "SpringBall"
-              ],
+              "requires": [ "canSpringBallJumpMidAir" ],
               "note": [
                 "Using the SpringBallJumpMidAir twice during a single jump to gain even more height. This typically only works underwater with HiJump.",
                 "This consists of a tight variant of SpringBallJumpMidAir, then turning off spring ball, then a second SpringBallJumpMidAir all while still climbing upwards."
@@ -409,7 +418,7 @@
                   "name": "can2HighWallMidAirMorph",
                   "requires": [
                     "canPreciseWalljump",
-                    "Morph"
+                    "canMidAirMorph"
                   ],
                   "note" : "Getting up a 2-tile-high jump in a morph passage by mid-air morphing off the opposite wall.  Morphing after a wall jump only requires one down press."
                 }
@@ -449,6 +458,7 @@
           "name": "canWallJumpBombBoost",
           "requires": [
             "canWalljump",
+            "canMidAirMorph",
             "h_canBombThings"
           ],
           "note": [
@@ -484,7 +494,10 @@
           "extensionTechs": [
             {
               "name": "canJumpIntoIBJ",
-              "requires": [ "canIBJ" ],
+              "requires": [ 
+                "canMidAirMorph",
+                "canIBJ" 
+              ],
               "note": "The ability to start an IBJ from a jump or spring ball jump. Can be required in strats that need Samus to IBJ up faster or to avoid something near the ground."
             },
             {
@@ -529,13 +542,20 @@
         },
         {
           "name": "canBombJumpWaterEscape",
-          "requires": [ "h_canBombThings" ],
+          "requires": [ 
+            "canMidAirMorph",
+            "h_canBombThings" 
+          ],
           "note": "From a submerged platform, setting up a single bomb jump above the water line to propel Samus up and out of the water.",
           "devNote": "It's recommended to apply a number of tries as leniency here for the PBs version."
         },
         {
           "name": "canBombJumpOnSand",
-          "requires": [ "canPlayInSand", "h_canBombThings" ],
+          "requires": [ 
+            "canPlayInSand", 
+            "h_canBombThings",
+            "canMidAirMorph"
+          ],
           "note": [
             "The ability to bomb jump while dealing with the sinking effect of sand physics.",
             "This is done by placing the bomb on or above the top of the sand line and then jumping again to land on the bomb explosion."
@@ -1201,7 +1221,7 @@
               "requires": [
                 "canCrystalFlash",
                 "canCeilingClip",
-                "Morph"
+                "canMidAirMorph"
               ],
               "note": [
                 "Setting up a Crystal Flash by jumping and morphing.  Once to place the power bomb, then again to activate the Crystal Flash.",

--- a/tech.json
+++ b/tech.json
@@ -1258,6 +1258,16 @@
             "Uses the uninteruptable frames of turning around in order to continue moving after hitting a solid object.",
             "Can be used to make it through an opening door, or barely just past a ledge."
           ]
+        },
+        {
+          "name": "canCameraManip",
+          "requires": [],
+          "note": [
+            "The ability to scroll the camera to bring enemies or projectiles on or off camera.",
+            "Most enemes become inactive while off camera, and most projectiles cease to exist.",
+            "This can be done by jumping in place; changing Samus' hitbox with aim down will scroll the camera lower.",
+            "By running back and forth the camera will scroll horizontally; Moonwalk can be used to camera scroll without travelling as far."
+          ]
         }
       ]
     }

--- a/tech.json
+++ b/tech.json
@@ -322,7 +322,7 @@
           "requires": [],
           "note": [
             "The ability to buffer a jump by using the turnaround animation frames.",
-            "This allows for an easier Spin Jump timing and works as a way to move underwater quickly."
+            "This allows for an easier Spin Jump timing and works as a way jump far underwater without building up run speed."
           ],
           "extensionTechs": [
             {

--- a/weapons/main.json
+++ b/weapons/main.json
@@ -382,7 +382,7 @@
       "name": "Grapple",
       "damage": 200,
       "cooldownFrames": 15,
-      "useRequires": ["Grapple"],
+      "useRequires": [ "canUseGrapple", "Grapple" ],
       "categories": ["All"],
       "situational": false,
       "hitsGroup": false,

--- a/weapons/main.json
+++ b/weapons/main.json
@@ -338,7 +338,7 @@
       "name": "PseudoScrew",
       "damage": 200,
       "cooldownFrames": 60,
-      "useRequires": ["Charge", "PowerBeam"],
+      "useRequires": ["canPseudoScrew", "Charge", "PowerBeam"],
       "categories": ["All"],
       "situational": true,
       "hitsGroup": false,
@@ -393,7 +393,7 @@
       "name": "Wave Shield",
       "damage": 1200,
       "cooldownFrames": 400,
-      "useRequires": ["Wave", "PowerBomb", "Charge"],
+      "useRequires": ["canSpecialBeamAttack", "Wave", "PowerBomb", "Charge"],
       "shotRequires": [
         {"ammo": {
           "type": "PowerBomb",
@@ -410,7 +410,7 @@
       "name": "Ice Shield",
       "damage": 360,
       "cooldownFrames": 200,
-      "useRequires": ["Ice", "PowerBomb", "Charge"],
+      "useRequires": ["canSpecialBeamAttack", "Ice", "PowerBomb", "Charge"],
       "shotRequires": [
         {"ammo": {
           "type": "PowerBomb",
@@ -426,7 +426,7 @@
       "name": "Spazer Shield",
       "damage": 600,
       "cooldownFrames": 230,
-      "useRequires": ["Spazer", "PowerBomb", "Charge"],
+      "useRequires": ["canSpecialBeamAttack", "Spazer", "PowerBomb", "Charge"],
       "shotRequires": [
         {"ammo": {
           "type": "PowerBomb",
@@ -442,7 +442,7 @@
       "name": "Plasma Shield",
       "damage": 600,
       "cooldownFrames": 400,
-      "useRequires": ["Plasma", "PowerBomb", "Charge"],
+      "useRequires": ["canSpecialBeamAttack", "Plasma", "PowerBomb", "Charge"],
       "shotRequires": [
         {"ammo": {
           "type": "PowerBomb",


### PR DESCRIPTION
These are the assumed techs we've been using.  Most are very widespread or don't make sense to add to specific strats. Pseudo screw and SBA were easy enough to add where used.  canUseGrapple and canCameraManip could be added to strats still.  canDraygonEscape wouldn't be put in logic.

The very low level techs of #745 would be added for a different purpose so I'm not worrying about them now.