### PR TITLE
Add note about buffering the jump in canSpringBallJumpMidAir

### DIFF
--- a/tech.json
+++ b/tech.json
@@ -371,7 +371,9 @@
           ],
           "note": [
             "Reaching a higher than normal height with a jump, by morphing in mid-air and then turning on SpringBall while still climbing upwards.",
-            "This makes it possible to use SpringBall while Samus is still climbing upwards, for an additional jump."
+            "This makes it possible to use SpringBall while Samus is still climbing upwards, for an additional jump.",
+            "This is often done most easily by buffering the SpringBall jump: while unpausing after turning on SpringBall, press and hold jump starting anytime after the pause menu has finished fading out (i.e. while the screen is black)."
+
           ],
           "extensionTechs": [
             {


### PR DESCRIPTION
We have canSpringBallJumpMidAir in "Medium" in Map Rando now, and it's one of the trickier ones in that level. It can be helpful to players to have a little more detail explaining how to buffer the jump, which is generally the easiest way to do it (i.e. assuming a max jump height or other precise positioning isn't needed, which would require some harder tech on top of canSpringBallJumpMidAir).