### PR TITLE
G-Mode Main Street/Everest Morph Tunnel

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -40,6 +40,15 @@
       "devNote": "In the original game Gravity provides full immunity, but some randomizers also require Varia."
     },
     {
+      "name": "h_EverestMorphTunnelExpanded",
+      "requires": [ "never" ],
+      "devNote": [
+        "In order to be able to randomize the connection of the Everest/Main Street morph tunnel, the doorway needs to be expanded to a normal doorway height.",
+        "Without being expanded, Samus will get stuck in the wall upon entry unless she enters morphed at the bottom of the transition.",
+        "This is not done in vanilla, so this is 'never' by default."
+      ]
+    },
+    {
       "name": "h_canNavigateHeatRooms",
       "requires": [
         {"or":[

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -1323,7 +1323,7 @@
                   ]
                 },
                 {
-                  "name": "G-Mode Morph Get Item and Return",
+                  "name": "Direct G-Mode Morph Get Item and Return",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
@@ -1359,7 +1359,7 @@
                   "requires": [
                     {"comeInWithGMode": {
                       "fromNodes": [5],
-                      "mode": "indirect",
+                      "mode": "any",
                       "artificialMorph": true
                     }},
                     {"or":[
@@ -1376,7 +1376,7 @@
                   "note": "The crab will not come through the whole tunnel, so wait for it to pass before going through the vertical portion."
                 },
                 {
-                  "name": "G-Mode Morph",
+                  "name": "Direct G-Mode Morph",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
@@ -1431,7 +1431,19 @@
                 {
                   "name": "G-Mode Morph Return",
                   "notable": false,
-                  "requires": [ {"obstaclesCleared": ["B"]} ]
+                  "requires": [
+                    {"obstaclesCleared": ["B"]},
+                    {"or":[
+                      "SpringBall",
+                      {"and":[
+                        "Gravity",
+                        {"or": [
+                          "Bombs",
+                          {"ammo": { "type": "PowerBomb", "count": 1 }}
+                        ]}
+                      ]}
+                    ]}
+                  ]
                 }
               ]
             }
@@ -3636,6 +3648,13 @@
                     {"or": [
                       "h_canArtificialMorphIBJ",
                       {"and": [
+                        "SpringBall",
+                        {"or": [
+                          "canGravityJump",
+                          "HiJump"
+                        ]},
+                      ]},
+                      {"and": [
                         "h_canArtificialMorphSpringBallBombJump",
                         {"or": [
                           "Bombs",
@@ -4186,6 +4205,13 @@
                     }},
                     "Gravity",
                     {"or": [
+                      {"and": [
+                        "SpringBall",
+                        {"or": [
+                          "canGravityJump",
+                          "HiJump"
+                        ]},
+                      ]},
                       "h_canArtificialMorphIBJ",
                       "h_canArtificialMorphSpringBallBombJump"
                     ]}

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -1359,7 +1359,29 @@
                   "requires": [
                     {"comeInWithGMode": {
                       "fromNodes": [5],
-                      "mode": "any",
+                      "mode": "indirect",
+                      "artificialMorph": true
+                    }},
+                    {"or":[
+                      "SpringBall",
+                      {"and":[
+                        "Gravity",
+                        {"or": [
+                          "Bombs",
+                          {"ammo": { "type": "PowerBomb", "count": 1 }}
+                        ]}
+                      ]}
+                    ]}
+                  ],
+                  "note": "The crab will not come through the whole tunnel, so wait for it to pass before going through the vertical portion."
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [5],
+                      "mode": "direct",
                       "artificialMorph": true
                     }},
                     "h_EverestMorphTunnelExpanded",
@@ -3126,7 +3148,6 @@
                       "artificialMorph": false,
                       "mode": "any"
                     }},
-                    "h_EverestMorphTunnelExpanded",
                     "Morph",
                     {"or": [
                       {"and": [
@@ -3162,7 +3183,6 @@
                       "artificialMorph": false,
                       "mode": "any"
                     }},
-                    "h_EverestMorphTunnelExpanded",
                     "Morph",
                     {"or": [
                       {"and": [
@@ -3198,7 +3218,6 @@
                       "artificialMorph": false,
                       "mode": "any"
                     }},
-                    "h_EverestMorphTunnelExpanded",
                     "Morph",
                     {"or": [
                       {"and": [
@@ -3241,7 +3260,6 @@
                       "artificialMorph": false,
                       "mode": "any"
                     }},
-                    "h_EverestMorphTunnelExpanded",
                     "Morph",
                     {"or": [
                       "canGravityJump",
@@ -3446,7 +3464,6 @@
                       "mode": "any",
                       "artificialMorph": true
                     }},
-                    "h_EverestMorphTunnelExpanded",
                     {"or": [
                       "SpringBall",
                       {"and": [
@@ -3459,7 +3476,8 @@
                       ]},
                       {"enemyDamage": { "enemy": "Sciser", "type": "contact", "hits": 1 }}
                     ]}
-                  ]
+                  ],
+                  "devNote": "This technically requires going through the trransition while in G-Mode, but that shouldn't cause a problem."
                 }
               ]
             },
@@ -3614,7 +3632,6 @@
                       "mode": "any",
                       "artificialMorph": true
                     }},
-                    "h_EverestMorphTunnelExpanded",
                     "Gravity",
                     {"or": [
                       "h_canArtificialMorphIBJ",
@@ -3626,7 +3643,8 @@
                         ]}
                       ]}
                     ]}
-                  ]
+                  ],
+                  "devNote": "This technically requires going through the trransition while in G-Mode, but that shouldn't cause a problem."
                 }
               ]
             },
@@ -4166,13 +4184,13 @@
                       "mode": "any",
                       "artificialMorph": true
                     }},
-                    "h_EverestMorphTunnelExpanded",
                     "Gravity",
                     {"or": [
                       "h_canArtificialMorphIBJ",
                       "h_canArtificialMorphSpringBallBombJump"
                     ]}
-                  ]
+                  ],
+                  "devNote": "This technically requires going through the trransition while in G-Mode, but that shouldn't cause a problem."
                 }
               ]
             },
@@ -4259,7 +4277,6 @@
                       "mode": "any",
                       "artificialMorph": true
                     }},
-                    "h_EverestMorphTunnelExpanded",
                     {"or": [
                       "SpringBall",
                       {"and": [
@@ -4271,7 +4288,8 @@
                         "h_canArtificialMorphBombHorizontally"
                       ]}
                     ]}
-                  ]
+                  ],
+                  "devNote": "This technically requires going through the trransition while in G-Mode, but that shouldn't cause a problem."
                 }
               ]
             },

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -4291,12 +4291,132 @@
           "from": 6,
           "to": [
             {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "G-Mode Morph IBJ",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [6],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "h_canArtificialMorphIBJ",
+                    "Gravity"
+                  ],
+                  "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
+                },
+                {
+                  "name": "G-Mode Morph SpringBall Bomb Jump",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [6],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "Gravity",
+                    "h_canArtificialMorphSpringBallBombJump",
+                    {"or": [
+                      "Bombs",
+                      {"ammo": { "type": "PowerBomb", "count": 2 }}
+                    ]}
+                  ],
+                  "note": [
+                    "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab.",
+                    "This requires three spring ball bomb jumps."
+                  ]
+                }
+              ]
+            },
+            {
               "id": 2,
               "strats": [
                 {
                   "name": "Base",
                   "notable": false,
                   "requires": [ "Morph" ]
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "G-Mode Morph IBJ",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [6],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "h_canArtificialMorphIBJ",
+                    "Gravity"
+                  ],
+                  "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
+                },
+                {
+                  "name": "G-Mode Morph SpringBall Bomb Jump",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [6],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "Gravity",
+                    "h_canArtificialMorphSpringBallBombJump"
+                  ],
+                  "note": [
+                    "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab.",
+                    "This requires one spring ball bomb jump."
+                  ]
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "strats": [
+                {
+                  "name": "G-Mode Morph IBJ",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [6],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "h_canArtificialMorphIBJ",
+                    "Gravity"
+                  ],
+                  "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
+                }
+              ]
+            },
+            {
+              "id": 9,
+              "strats": [
+                {
+                  "name": "G-Mode Morph IBJ",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [6],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "h_canArtificialMorphIBJ",
+                    "Gravity"
+                  ],
+                  "note": "After entering the room, quickly leave the morph tunnel in order to prevent getting hit by the crab."
                 }
               ]
             }

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -3072,7 +3072,170 @@
           "nodeSubType": "passage",
           "nodeAddress": "0x001a45c",
           "doorEnvironments": [{"physics": "water"}],
-          "note": "It's not quite a door, but it is a morph passage transition to another room"
+          "note": "It's not quite a door, but it is a morph passage transition to another room",
+          "leaveWithGMode": [
+            {
+              "leavesWithArtificialMorph": true,
+              "strats": [
+                {
+                  "name": "Carry G-Mode Morph Through Tunnel From Top Left",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "artificialMorph": false,
+                      "mode": "any"
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "Morph",
+                    {"or": [
+                      {"and": [
+                        "Gravity",
+                        {"or": [
+                          "HiJump",
+                          "canWalljump",
+                          "SpeedBooster",
+                          "h_canFly",
+                          "canSpringBallJumpMidAir",
+                          "h_canSpringBallBombJump"
+                        ]}
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "HiJump",
+                        "canSpringBallJumpMidAir"
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "canTrickyUseFrozenEnemies",
+                        "Grapple"
+                      ]}
+                    ]}
+                  ]
+                },
+                {
+                  "name": "Carry G-Mode Morph Through Tunnel From Bottom Left",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "artificialMorph": false,
+                      "mode": "any"
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "Morph",
+                    {"or": [
+                      {"and": [
+                        "Gravity",
+                        {"or": [
+                          "HiJump",
+                          "canWalljump",
+                          "SpeedBooster",
+                          "h_canFly",
+                          "canSpringBallJumpMidAir",
+                          "h_canSpringBallBombJump"
+                        ]}
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "HiJump",
+                        "canSpringBallJumpMidAir"
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "canTrickyUseFrozenEnemies",
+                        "Grapple"
+                      ]}
+                    ]}
+                  ]
+                },
+                {
+                  "name": "Carry G-Mode Morph Through Tunnel From Top Middle",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [5],
+                      "artificialMorph": false,
+                      "mode": "any"
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "Morph",
+                    {"or": [
+                      {"and": [
+                        "canGravityJump",
+                        {"or": [
+                          "HiJump",
+                          "canTrickyJump",
+                          "canLateralMidAirMorph"
+                        ]}
+                      ]},
+                      {"and": [
+                        "Gravity",
+                        "HiJump",
+                        "SpeedBooster"
+                      ]},
+                      {"and": [
+                        "Gravity",
+                        "h_canFly"
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "Grapple",
+                        "HiJump",
+                        "canSpringBallJumpMidAir"
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "canTrickyUseFrozenEnemies",
+                        "Grapple"
+                      ]}
+                    ]}
+                  ]
+                },
+                {
+                  "name": "Carry G-Mode Morph Through Tunnel From Top Right",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [4],
+                      "artificialMorph": false,
+                      "mode": "any"
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "Morph",
+                    {"or": [
+                      "canGravityJump",
+                      {"and": [
+                        "Gravity",
+                        "canInsaneWalljump"
+                      ]},
+                      {"and": [
+                        "Gravity",
+                        "HiJump",
+                        "canTrickyDashJump",
+                        "canWalljump"
+                      ]},
+                      {"and": [
+                        "Gravity",
+                        "h_canFly"
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "Grapple",
+                        "HiJump",
+                        "canSpringBallJumpMidAir"
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "canTrickyUseFrozenEnemies",
+                        "Grapple"
+                      ]}
+                    ]}
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
           "id": 7,
@@ -3383,7 +3546,8 @@
                       "canWalljump",
                       "SpeedBooster",
                       "h_canFly",
-                      "canSpringBallJumpMidAir"
+                      "canSpringBallJumpMidAir",
+                      "h_canSpringBallBombJump"
                     ]}
                   ]
                 },
@@ -4208,11 +4372,7 @@
                     "canSuitlessMaridia",
                     "canCrazyCrabClimb",
                     "HiJump",
-                    "Super",
-                    {"ammo": {
-                      "type": "Super",
-                      "count": 1
-                    }}
+                    {"ammo": { "type": "Super", "count": 1 }}
                   ],
                   "obstacles": [
                     {
@@ -4235,11 +4395,7 @@
                     "canSuitlessMaridia",
                     "canCrazyCrabClimb",
                     "canSpringBallJumpMidAir",
-                    "Super",
-                    {"ammo": {
-                      "type": "Super",
-                      "count": 1
-                    }}
+                    {"ammo": { "type": "Super", "count": 1 }}
                   ],
                   "obstacles": [
                     {
@@ -4263,11 +4419,7 @@
                     "canCrazyCrabClimb",
                     "canTrickyJump",
                     "canBePatient",
-                    "Super",
-                    {"ammo": {
-                      "type": "Super",
-                      "count": 1
-                    }}
+                    {"ammo": { "type": "Super", "count": 1 }}
                   ],
                   "obstacles": [
                     {
@@ -4297,11 +4449,7 @@
                     "canCrazyCrabClimb",
                     "canTrickyJump",
                     "canBePatient",
-                    "Super",
-                    {"ammo": {
-                      "type": "Super",
-                      "count": 1
-                    }}
+                    {"ammo": { "type": "Super", "count": 1 }}
                   ],
                   "obstacles": [
                     {

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -881,6 +881,11 @@
           "id": "A",
           "name": "Speed Blocks",
           "obstacleType": "inanimate"
+        },
+        {
+          "id": "B",
+          "name": "Morph Tunnel Remain in Artificial Morph",
+          "obstacleType": "abstract"
         }
       ],
       "enemies": [
@@ -1292,12 +1297,66 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [ "Morph" ]
+                  "requires": [ "Morph" ],
+                  "note": [
+                    "Turn HiJump and gravity suit off before jumping and morphing into the tunnel.",
+                    "The crab will not come through the whole tunnel. Retreat to the right to avoid taking a hit."
+                  ]
+                },
+                {
+                  "name": "G-Mode Morph Get Item and Return",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [5],
+                      "mode": "direct",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    {"or":[
+                      "SpringBall",
+                      {"and":[
+                        "Gravity",
+                        "Bombs"
+                      ]}
+                    ]}
+                  ],
+                  "obstacles": [
+                    {
+                      "id": "B",
+                      "requires": []
+                    }
+                  ],
+                  "note": [
+                    "There is a camera scroll block inside of the morph tunnel, so it is best to go through the tunnel quickly and not backtrack.",
+                    "The crab will not come through the whole tunnel, so as Samus gets close to the vertical portion, wait for the crab to pass.",
+                    "After touching the item, retreat to the doorway before exiting g-mode."
+                  ],
+                  "devNote": "A PB will overload PLMs."
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [5],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    {"or":[
+                      "SpringBall",
+                      {"and":[
+                        "Gravity",
+                        {"or": [
+                          "Bombs",
+                          {"ammo": { "type": "PowerBomb", "count": 1 }}
+                        ]}
+                      ]}
+                    ]}
+                  ],
+                  "note": "The crab will not come through the whole tunnel, so wait for it to pass before going through the vertical portion."
                 }
-              ],
-              "note": [
-                "Turn HiJump and gravity suit off before jumping and morphing into the tunnel.",
-                "The crab will not come through the whole tunnel. Retreat to the right to avoid taking a hit."
               ]
             }
           ]
@@ -1327,6 +1386,11 @@
                   "name": "Base",
                   "notable": false,
                   "requires": [ "Morph" ]
+                },
+                {
+                  "name": "G-Mode Morph Return",
+                  "notable": false,
+                  "requires": [ {"obstaclesCleared": ["B"]} ]
                 }
               ]
             }

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -4210,7 +4210,7 @@
                         {"or": [
                           "canGravityJump",
                           "HiJump"
-                        ]},
+                        ]}
                       ]},
                       "h_canArtificialMorphIBJ",
                       "h_canArtificialMorphSpringBallBombJump"

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -845,6 +845,25 @@
           "nodeSubType": "passage",
           "nodeAddress": "0x001a3cc",
           "doorEnvironments": [{"physics": "water"}],
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Sciser",
+                  "notable": false,
+                  "requires": [
+                    "h_EverestMorphTunnelExpanded",
+                    "Morph",
+                    {"ammo": { "type": "Super", "count": 1 }}
+                  ],
+                  "note": [
+                    "Get to the item while avoiding the crab, note that it doesn't go all the way through the tunnel.",
+                    "Use a super to knock it off, while it is on the right wall, in order to knock it off so it will go down the morph tunnel."
+                  ]
+                }
+              ]
+            }
+          ],
           "note": "It's not quite a door, but it is a morph passage transition to another room"
         },
         {
@@ -3073,6 +3092,27 @@
           "nodeAddress": "0x001a45c",
           "doorEnvironments": [{"physics": "water"}],
           "note": "It's not quite a door, but it is a morph passage transition to another room",
+          "leaveWithGModeSetup": [
+            {
+              "strats": [
+                {
+                  "name": "Get Hit By Sciser",
+                  "notable": false,
+                  "requires": [ "h_EverestMorphTunnelExpanded" ]
+                }
+              ]
+            }
+          ],
+          "gModeImmobile": {
+            "requires": [
+              "h_EverestMorphTunnelExpanded",
+              {"enemyDamage": {
+                "enemy": "Sciser",
+                "type": "contact",
+                "hits": 1
+              }}
+            ]
+          },
           "leaveWithGMode": [
             {
               "leavesWithArtificialMorph": true,

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -3395,6 +3395,35 @@
               "note": "Shinespark direct link"
             },
             {
+              "id": 6,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    {"or": [
+                      "SpringBall",
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphBombHorizontally"
+                      ]},
+                      {"enemyDamage": { "enemy": "Sciser", "type": "contact", "hits": 1 }}
+                    ]}
+                  ]
+                }
+              ]
+            },
+            {
               "id": 9,
               "strats": [
                 {
@@ -3531,6 +3560,34 @@
                     "In Crocomire's Room, the different platform height affects which vertical speeds are obtainable, and apparently none of them work."
                   ]
                 }                    
+              ]
+            },
+            {
+              "id": 6,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "Gravity",
+                    {"or": [
+                      "h_canArtificialMorphIBJ",
+                      {"and": [
+                        "h_canArtificialMorphSpringBallBombJump",
+                        {"or": [
+                          "Bombs",
+                          {"ammo": { "type": "PowerBomb", "count": 1 }}
+                        ]}
+                      ]}
+                    ]}
+                  ]
+                }
               ]
             },
             {
@@ -4058,6 +4115,28 @@
               "note": "This link is for shinespark and cross room jumps. All other strats should take other routes."
             },
             {
+              "id": 6,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [4],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    "Gravity",
+                    {"or": [
+                      "h_canArtificialMorphIBJ",
+                      "h_canArtificialMorphSpringBallBombJump"
+                    ]}
+                  ]
+                }
+              ]
+            },
+            {
               "id": 9,
               "strats": [
                 {
@@ -4128,6 +4207,34 @@
         {
           "from": 5,
           "to": [
+            {
+              "id": 6,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [5],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_EverestMorphTunnelExpanded",
+                    {"or": [
+                      "SpringBall",
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphBombHorizontally"
+                      ]}
+                    ]}
+                  ]
+                }
+              ]
+            },
             {
               "id": 9,
               "strats": [

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -3652,7 +3652,7 @@
                         {"or": [
                           "canGravityJump",
                           "HiJump"
-                        ]},
+                        ]}
                       ]},
                       {"and": [
                         "h_canArtificialMorphSpringBallBombJump",


### PR DESCRIPTION
In order to put in `leaveWithGMode`, you need to include strats to go to the door node that sets up the gmode and return. This ended up being a pain for Everest.