### PR TITLE
Remove Notable from Basement Speedball

### DIFF
--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -1178,21 +1178,8 @@
                   "requires": ["h_canBombThings"]
                 },
                 {
-                  "name": "Basement Speedball (Phantoon Alive)",
-                  "notable": true,
-                  "requires": [
-                    "canMockball",
-                    {"canShineCharge": {
-                      "usedTiles": 25,
-                      "shinesparkFrames": 0,
-                      "openEnd": 0
-                    }}
-                  ],
-                  "note": "The speedball is more complicated because of the robot standing in the way."
-                },
-                {
                   "name": "Basement Speedball (Phantoon Dead)",
-                  "notable": true,
+                  "notable": false,
                   "requires": [
                     "canMockball",
                     "f_DefeatedPhantoon",
@@ -1203,9 +1190,22 @@
                     }}
                   ],
                   "note": [
-                    "An easier version of the speedball, since you can push the robots all the way left.",
+                    "This speedball is easier with Phantoon dead, since you can push the robots all the way left.",
                     "It's even possible to setup the short hop mockball by bonking the center platform."
                   ]
+                },
+                {
+                  "name": "Basement Speedball (Phantoon Alive)",
+                  "notable": false,
+                  "requires": [
+                    "canMockball",
+                    {"canShineCharge": {
+                      "usedTiles": 25,
+                      "shinesparkFrames": 0,
+                      "openEnd": 0
+                    }}
+                  ],
+                  "note": "This speedball is harder with Phantoon alive and has a shorter runway because of the robot standing in the way."
                 },
                 {
                   "name": "G-mode Morph",
@@ -1505,13 +1505,21 @@
                 {
                   "name": "Missiles",
                   "notable": false,
-                  "requires": ["Missile"],
+                  "requires": [
+                    {"resourceCapacity": [
+                      {"type": "Missile", "count": 1}
+                    ]}
+                  ],
                   "note": "No ammo count because Missiles are farmable here."
                 },
                 {
                   "name": "Nintendo Power Phantoon",
                   "notable": false,
-                  "requires": ["Super"],
+                  "requires": [
+                    {"resourceCapacity": [
+                      {"type": "Super", "count": 1}
+                    ]}
+                  ],
                   "note": "No ammo count because Supers are farmable here.",
                   "devNote": "FIXME add tech/energy/item requirements to survive flames."
                 }


### PR DESCRIPTION
I swapped the order of these strats, as the easier one should be earlier. Otherwise if the player can do a 25 tile short charge, it would say use `Basement Speedball (Phantoon Alive)` regardless of if it was dead or alive.