### PR TITLE
Delete Botwoon Hallway Puyo Ice Clip

### DIFF
--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -1567,12 +1567,6 @@
           "betweenNodes": [1,2]
         }
       ],
-      "reusableRoomwideNotable": [
-        {
-          "name": "Botwoon Hallway Puyo Ice Clip",
-          "note": "Herding the rightmost puyo into the ice clip position. It will become uncooperative after a few tries"
-        }
-      ],
       "links": [
         {
           "from": 1,
@@ -1587,15 +1581,6 @@
                     "Gravity",
                     "SpeedBooster"
                   ]
-                },
-                {
-                  "name": "Botwoon Hallway Puyo Ice Clip (Left to Right)",
-                  "notable": true,
-                  "requires": [
-                    "h_canNavigateUnderwater",
-                    "canPuyoIceClip"
-                  ],
-                  "reusableRoomwideNotable": "Botwoon Hallway Puyo Ice Clip"
                 },
                 {
                   "name": "Botwoon Mochtroid Clip (Left to Right)",
@@ -1651,26 +1636,6 @@
                     "Gravity",
                     "SpeedBooster"
                   ]
-                },
-                {
-                  "name": "Botwoon Hallway Puyo Ice Clip (Right to Left)",
-                  "notable": true,
-                  "requires": [
-                    "h_canNavigateUnderwater",
-                    "canPuyoIceClip",
-                    {"or": [
-                      {"and": [
-                        "h_canCrouchJumpDownGrab",
-                        "canCarefulJump"
-                      ]},
-                      "HiJump",
-                      "Gravity",
-                      "canSpringBallJumpMidAir",
-                      "Wave"
-                    ]}
-                  ],
-                  "note": "With no jump assists or wave beam, a precise crouch jump and down grab is required to get to free the Puyo.",
-                  "reusableRoomwideNotable": "Botwoon Hallway Puyo Ice Clip"
                 },
                 {
                   "name": "Botwoon Mochtroid Clip (Right to Left)",


### PR DESCRIPTION
This seems relatively useless, since the Motchroid clip is easier in every way