### PR TITLE
Add 'mobility' property to comeInWithGMode requirement

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -401,7 +401,8 @@ A `comeInWithGMode` object represents the need to either have or obtain G-mode w
 * _fromNodes:_ Indicates from what doors this logical requirement expects Samus to enter the room.
 * _mode:_ Takes one of three possible values, "direct", "indirect", or "any", indicating whether this logical requirement expects Samus to enter in direct G-mode, indirect G-mode, or either. Direct G-mode is the state obtained when G-mode is first entered (i.e., the next room after the G-mode setup is performed), while indirect G-mode is the state after passing a door transition with G-mode (usually back into the room where the G-mode setup was performed).
 * _artificialMorph:_ A boolean indicating whether the logical requirement expects Samus to either obtain or already have an artificially morphed state when coming into the room, or to have collected the Morph item.
-
+* _mobility_: Takes one of three possible values, "mobile", "immobile", or "any", indicating whether or not Samus is
+required to be mobile (or immobile) after entering the room. The default value is "any". When entering with indirect G-mode, Samus is always mobile. With direct G-mode, Samus can be mobile if she takes knockback through the door transition and the reserve energy is low enough that knockback frames do not expire until after reserves finish filling.
 __Example:__
 ```json
 {"comeInWithGMode": {

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -724,6 +724,18 @@
                 "type": "boolean",
                 "title": "Artificial Morph",
                 "description": "Whether we must come in with artificial morph (also satisfied by having Morph collected)"
+              },
+              "mobility": {
+                "$id": "#/definitions/logicalRequirement/items/properties/comeInWithGMode/properties/mobility",
+                "type": "string",
+                "enum": [
+                  "mobile",
+                  "immobile",
+                  "any"
+                ],
+                "default": "any",
+                "title": "Mobility",
+                "description": "Whether Samus must come in mobile, immobile, or either."
               }
             }
           },


### PR DESCRIPTION
@kjbranch mentioned that some G-mode strats may not work when entering immobile, as the delay to get hit can result in enemies no longer being in the position needed to execute the strat. To support being able to properly express requirements in cases like this, we add a "mobility" property which can be set to "mobile" if it is required that Samus enter mobile. 

For completeness, we also support an "immobile" requirement though it is not clear yet if this will have any applications. Entering with immobile can allow Samus to stand suspended in the air, which conceivably could have some use. Regardless of the amount of reserve energy, for direct G-mode I think it should always be possible to enter immobile by doing an early turnaround, earlier than what would result in artificial morph.