### PR TITLE
Ceiling and Ice Clip Rework

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -437,6 +437,19 @@
             "canXMode",
             "Morph"
           ]
+        },
+        {
+          "name": "h_canNonTrivialCeilingClip",
+          "requires": [
+            "canCeilingClip",
+            {"or":[
+              "canPreciseCeilingClip",
+              {"and":[
+                "Morph",
+                "canXRayStandUp"
+              ]}
+            ]}
+          ]
         }
       ]
     },

--- a/helpers.json
+++ b/helpers.json
@@ -439,15 +439,19 @@
           ]
         },
         {
+          "name": "h_canXRayCeilingClip",
+          "requires": [
+            "canXRayCeilingClip",
+            "Morph",
+            "canXRayStandUp"
+          ]
+        },
+        {
           "name": "h_canNonTrivialCeilingClip",
           "requires": [
-            "canCeilingClip",
             {"or":[
               "canPreciseCeilingClip",
-              {"and":[
-                "Morph",
-                "canXRayStandUp"
-              ]}
+              "h_canXRayCeilingClip"
             ]}
           ]
         }

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -787,8 +787,15 @@
                 },
                 {
                   "name": "Green Brinstar Main Shaft Ice Clip",
-                  "notable": false,
-                  "requires": ["canWallCrawlerIceClip"]
+                  "notable": true,
+                  "requires": [
+                    "h_canNonTrivialCeilingClip",
+                    "canTrickyUseFrozenEnemies"
+                  ],
+                  "note": [
+                    "Freeze the wall crawler at a precise location in order to jump through the Power Bomb Blocks.",
+                    "The pixel window is larger and higher with Morph and an X-Ray Stand Up."
+                  ]
                 }
               ]
             }
@@ -2569,9 +2576,10 @@
               "strats": [
                 {
                   "name": "Etecoon E-Tank Beetom Clip",
-                  "notable": false,
+                  "notable": true,
                   "requires": [
-                    "canBeetomIceClip",
+                    "h_canNonTrivialCeilingClip",
+                    "canTrickyUseFrozenEnemies",
                     "Morph",
                     {"enemyDamage": {
                       "enemy": "Beetom",
@@ -2579,7 +2587,11 @@
                       "hits": 2
                     }}
                   ],
-                  "note": "Two Beetom hits are assumed, but with failed attempts it could take more, possibly requiring leaving the Beetom and going back to the right to farm.",
+                  "note": [
+                    "Jump and freeze the Beetom at a precise location in order to jump through the crumble blocks.",
+                    "The pixel window is larger and higher with Morph and an X-Ray Stand Up.",
+                    "Two Beetom hits are assumed, but with failed attempts it could take more, possibly requiring leaving the Beetom and going back to the right to farm."
+                  ],
                   "devNote": "Morph is required to lure a Beetom. Morphless tunnel crawl should not be required."
                 },
                 {

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -2591,8 +2591,6 @@
                       "canWalljump",
                       "HiJump",
                       "SpaceJump",
-                      "h_canJumpIntoIBJ",
-                      "canSpringBallJumpMidAir",
                       {"enemyDamage": {
                         "enemy": "Beetom",
                         "type": "contact",

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -787,7 +787,7 @@
                 },
                 {
                   "name": "Green Brinstar Main Shaft Ice Clip",
-                  "notable": true,
+                  "notable": false,
                   "requires": [
                     "h_canNonTrivialCeilingClip",
                     "canTrickyUseFrozenEnemies"

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -2585,7 +2585,20 @@
                       "enemy": "Beetom",
                       "type": "contact",
                       "hits": 2
-                    }}
+                    }},
+                    {"or": [
+                      "canPreciseCeilingClip",
+                      "canWalljump",
+                      "HiJump",
+                      "SpaceJump",
+                      "h_canJumpIntoIBJ",
+                      "canSpringBallJumpMidAir",
+                      {"enemyDamage": {
+                        "enemy": "Beetom",
+                        "type": "contact",
+                        "hits": 2
+                      }}
+                    ]}
                   ],
                   "note": [
                     "Jump and freeze the Beetom at a precise location in order to jump through the crumble blocks.",

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -286,7 +286,7 @@
                       "type": "contact",
                       "hits": 1
                     }},
-                    "canTrickyUseFrozenEnemies",
+                    "canWallIceClip",
                     "canXRayClimb"
                   ],
                   "reusableRoomwideNotable": "Red Tower R-Mode Frozen Beetom X-Ray Climb",
@@ -600,7 +600,6 @@
                       "h_canFly",
                       "canSpringBallJumpMidAir"
                     ]},
-                    "canTrickyUseFrozenEnemies",
                     {"enemyDamage": {
                       "enemy": "Beetom",
                       "type": "contact",
@@ -611,6 +610,7 @@
                       "type": "contact",
                       "hits": 1
                     }},
+                    "canWallIceClip",
                     "canXRayClimb"
                   ],
                   "reusableRoomwideNotable": "Red Tower R-Mode Frozen Beetom X-Ray Climb",

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2142,10 +2142,11 @@
                 },
                 {
                   "name": "Ceiling Clip Alcatraz Escape",
-                  "notable": false,
+                  "notable": true,
                   "requires": [
                     "canBePatient",
-                    "canWallCrawlerIceClip",
+                    "canPreciseCeilingClip",
+                    "canTrickyUseFrozenEnemies",
                     "Morph",
                     "canXRayStandUp"
                   ],

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2142,7 +2142,7 @@
                 },
                 {
                   "name": "Ceiling Clip Alcatraz Escape",
-                  "notable": true,
+                  "notable": false,
                   "requires": [
                     "canBePatient",
                     "canPreciseCeilingClip",

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -1577,17 +1577,14 @@
                   "name": "West Ocean Bug Ice Clip",
                   "notable": true,
                   "requires": [
-                    "canPreciseCeilingClip",
+                    "h_canNonTrivialCeilingClip",
                     "canTrickyUseFrozenEnemies"
                   ],
                   "note": [
-                    "Freeze a bug a three tiles to the right of the morph tunnel entrance, directly under the tile where ceiling is higher.",
+                    "Freeze a bug three tiles to the right of the morph tunnel entrance, directly under the tile where ceiling is higher.",
                     "Jump onto the bug, crouch, and jump up.",
-                    "With HiJump it is more lenient, otherwise the bug must be at an exact pixel height (unless you have XRay and Morph).",
+                    "The bug must be at a very precise pixel height unless using  XRay and Morph.",
                     "Note that although the ceiling here is 3 tiles thick, only the bottom tile is solid; the other two are slopes pushing Samus up, allowing the trick to be done."
-                  ],
-                  "devNote": [
-                    "FIXME: add a more lenient alternative using HiJump"
                   ]
                 },
                 {

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -1577,7 +1577,8 @@
                   "name": "West Ocean Bug Ice Clip",
                   "notable": true,
                   "requires": [
-                    "canNonTrivialIceClip"
+                    "canPreciseCeilingClip",
+                    "canTrickyUseFrozenEnemies"
                   ],
                   "note": [
                     "Freeze a bug a three tiles to the right of the morph tunnel entrance, directly under the tile where ceiling is higher.",

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -642,8 +642,7 @@
                   "requires": [
                     "canXRayClimb",
                     "Morph",
-                    "canPreciseCeilingClip",
-                    "canTrickyUseFrozenEnemies",
+                    "canWallIceClip",
                     "canBePatient",
                     {"enemyDamage": { "enemy": "Beetom", "hits": 25, "type": "contact"}},
                     {"or": [

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -642,8 +642,8 @@
                   "requires": [
                     "canXRayClimb",
                     "Morph",
-                    "canPixelPerfectIceClip",
-                    "canBeetomIceClip",
+                    "canPreciseCeilingClip",
+                    "canTrickyUseFrozenEnemies",
                     "canBePatient",
                     {"enemyDamage": { "enemy": "Beetom", "hits": 25, "type": "contact"}},
                     {"or": [

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -7983,7 +7983,8 @@
                   "notable": true,
                   "requires": [
                     "h_heatProof",
-                    "canPixelPerfectIceClip",
+                    "canPreciseCeilingClip",
+                    "canTrickyUseFrozenEnemies",
                     "canPartialFloorClip",
                     "canTrickyJump",
                     "canCrumbleJump",
@@ -8014,7 +8015,9 @@
                   "requires": [
                     "h_heatProof",
                     "canXRayStandUp",
-                    "canNonTrivialIceClip",
+                    "Morph",
+                    "canCeilingClip",
+                    "canTrickyUseFrozenEnemies",
                     {"or": [
                       "h_canCrouchJumpDownGrab",
                       "canWalljump",
@@ -8040,7 +8043,8 @@
                   "notable": true,
                   "requires": [
                     "h_heatProof",
-                    "canPixelPerfectIceClip",
+                    "canPreciseCeilingClip",
+                    "canTrickyUseFrozenEnemies",
                     {"enemyDamage": {
                       "enemy": "Multiviola",
                       "type": "contact",
@@ -8065,7 +8069,8 @@
                   "notable": true,
                   "requires": [
                     "canXRayStandUp",
-                    "canNonTrivialIceClip",
+                    "canCeilingClip",
+                    "canTrickyUseFrozenEnemies",
                     "Morph"
                   ],
                   "reusableRoomwideNotable": "Mickey Mouse Viola Ice Clip",

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -8089,7 +8089,8 @@
                   "notable": true,
                   "requires": [
                     "h_heatProof",
-                    "canPixelPerfectIceClip",
+                    "canPreciseCeilingClip",
+                    "canTrickyUseFrozenEnemies",
                     {"enemyDamage": {
                       "enemy": "Multiviola",
                       "type": "contact",
@@ -8117,7 +8118,8 @@
                   "notable": true,
                   "requires": [
                     "h_heatProof",
-                    "canPixelPerfectIceClip",
+                    "canPreciseCeilingClip",
+                    "canTrickyUseFrozenEnemies",
                     {"enemyDamage": {
                       "enemy": "Multiviola",
                       "type": "contact",

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -8014,9 +8014,7 @@
                   "notable": true,
                   "requires": [
                     "h_heatProof",
-                    "canXRayStandUp",
-                    "Morph",
-                    "canCeilingClip",
+                    "h_canXRayCeilingClip",
                     "canTrickyUseFrozenEnemies",
                     {"or": [
                       "h_canCrouchJumpDownGrab",
@@ -8068,10 +8066,8 @@
                   "name": "Mickey Mouse Viola Clip (XRay Standup and Morph)",
                   "notable": true,
                   "requires": [
-                    "canXRayStandUp",
-                    "canCeilingClip",
-                    "canTrickyUseFrozenEnemies",
-                    "Morph"
+                    "h_canXRayCeilingClip",
+                    "canTrickyUseFrozenEnemies"
                   ],
                   "reusableRoomwideNotable": "Mickey Mouse Viola Ice Clip",
                   "note": [

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -3107,7 +3107,8 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    "canPuyoIceClip"
+                    "h_canNonTrivialCeilingClip",
+                    "canTrickyUseFrozenEnemies"
                   ],
                   "note": "Freeze the puyo at the start of its jump animation, on the right frame."
                 },
@@ -3116,7 +3117,8 @@
                   "notable": true,
                   "requires": [
                     "canSuitlessMaridia",
-                    "canPuyoIceClip",
+                    "h_canNonTrivialCeilingClip",
+                    "canTrickyUseFrozenEnemies",
                     {"enemyDamage": {
                       "enemy": "Puyo",
                       "type": "contact",

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -3104,7 +3104,7 @@
               "strats": [
                 {
                   "name": "East Pants Room Puyo Clip",
-                  "notable": false,
+                  "notable": true,
                   "requires": [
                     "Gravity",
                     "h_canNonTrivialCeilingClip",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -3675,7 +3675,8 @@
                   "notable": true,
                   "requires": [
                     "canGrappleClip",
-                    "h_canNonTrivialCeilingClip"
+                    "h_canNonTrivialCeilingClip",
+                    "canTrickyUseFrozenEnemies"
                   ],
                   "reusableRoomwideNotable": "Colosseum Green Door Grapple Clip",
                   "note": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -686,6 +686,14 @@
         {
           "name": "Aqueduct Bootless Suitless Snail Climb",
           "note": "Snail Climb without movement items by better coordinating the movements of both the snail and Samus."
+        },
+        {
+          "name": "Aqueduct Snail Clip",
+          "note": [
+            "Jump on the Snail when it is at a precise location, and then crouch jump through the ceiling and jump again, without moving between jumps.",
+            "The Snail's positioning is very precise, but it is more lenient with Morph and an X-Ray Turn Around. X-Ray can also be useful for helping position the Snail.",
+            "This clip can be used to get to the middle left door and the items in the top right of the room."
+          ]
         }
       ],
       "links": [
@@ -766,8 +774,17 @@
                 },
                 {
                   "name": "Snail Clip",
-                  "notable": false,
-                  "requires": ["canSnailClip"]
+                  "notable": true,
+                  "requires": [
+                    "h_canNonTrivialCeilingClip",
+                    "Gravity",
+                    "canUseEnemies"
+                  ],
+                  "reusableRoomwideNotable": "Aqueduct Snail Clip",
+                  "note": [
+                    "Jump on the Snail when it is at a precise location, and then crouch jump through the ceiling and jump again, without moving between jumps.",
+                    "The Snail's positioning is very precise, but it is more lenient with Morph and an X-Ray Turn Around. X-Ray can also be useful for helping position the Snail."
+                  ]
                 },
                 {
                   "name": "Aqueduct Left-Side X-Ray Climb (Lower)",
@@ -1225,10 +1242,16 @@
               "strats": [
                 {
                   "name": "Snail Clip",
-                  "notable": false,
+                  "notable": true,
                   "requires": [
+                    "h_canNonTrivialCeilingClip",
                     "Gravity",
-                    "canSnailClip"
+                    "canUseEnemies"
+                  ],
+                  "reusableRoomwideNotable": "Aqueduct Snail Clip",
+                  "note": [
+                    "Jump on the Snail when it is at a precise location, and then crouch jump through the ceiling and jump again, without moving between jumps.",
+                    "The Snail's positioning is very precise, but it is more lenient with Morph and an X-Ray Turn Around. X-Ray can also be useful for helping position the Snail."
                   ]
                 },
                 {

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -1588,7 +1588,7 @@
                   "requires": [
                     "h_canNavigateUnderwater",
                     "canCeilingClip",
-                    "canUseEnemies"
+                    "canUseFrozenEnemies"
                   ],
                   "note": [
                     "Crouch under the crumble blocks while aiming upward, using both angle buttons then freeze the Mochtroid while it is on Samus.",
@@ -1648,7 +1648,7 @@
                   "requires": [
                     "h_canNavigateUnderwater",
                     "canCeilingClip",
-                    "canUseEnemies",
+                    "canUseFrozenEnemies",
                     {"or": [
                       {"and": [
                         "h_canCrouchJumpDownGrab",
@@ -3659,7 +3659,7 @@
                     "Gravity",
                     "canGrappleClip",
                     "canCeilingClip",
-                    "canUseEnemies"
+                    "canUseFrozenEnemies"
                   ],
                   "reusableRoomwideNotable": "Colosseum Green Door Grapple Clip",
                   "note": [
@@ -3675,7 +3675,7 @@
                   "notable": true,
                   "requires": [
                     "canGrappleClip",
-                    "h_canNonTrivialIceClip"
+                    "h_canNonTrivialCeilingClip"
                   ],
                   "reusableRoomwideNotable": "Colosseum Green Door Grapple Clip",
                   "note": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -773,7 +773,7 @@
                   ]
                 },
                 {
-                  "name": "Snail Clip",
+                  "name": "Snail Clip to the Left Middle Door",
                   "notable": true,
                   "requires": [
                     "h_canNonTrivialCeilingClip",
@@ -1241,7 +1241,7 @@
               "id": 7,
               "strats": [
                 {
-                  "name": "Snail Clip",
+                  "name": "Snail Clip to the Items",
                   "notable": true,
                   "requires": [
                     "h_canNonTrivialCeilingClip",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -1587,9 +1587,14 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateUnderwater",
-                    "canMochtroidIceClip"
+                    "canCeilingClip",
+                    "canUseEnemies"
                   ],
-                  "note": "With no jump assists, use a frozen Mochtroid as a platform to get to the ledge above the door."
+                  "note": [
+                    "Crouch under the crumble blocks while aiming upward, using both angle buttons then freeze the Mochtroid while it is on Samus.",
+                    "Jump onto the Mochtroid by quickly pressing down after jumping, when on it, press up to stand then jump through the ceiling.",
+                    "With no jump assists, use a frozen Mochtroid as a platform to get to the ledge above the door."
+                  ]
                 },
                 {
                   "name": "CF Clip with Bombs (Left to Right)",
@@ -1642,7 +1647,8 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateUnderwater",
-                    "canMochtroidIceClip",
+                    "canCeilingClip",
+                    "canUseEnemies",
                     {"or": [
                       {"and": [
                         "h_canCrouchJumpDownGrab",
@@ -1653,7 +1659,11 @@
                       "canSpringBallJumpMidAir"
                     ]}
                   ],
-                  "note": "With no jump assists, a precise crouch jump and down grab is required to get to the Mochtroid."
+                  "note": [
+                    "Crouch under the crumble blocks while aiming upward, using both angle buttons then freeze the Mochtroid while it is on Samus.",
+                    "Jump onto the Mochtroid by quickly pressing down after jumping, when on it, press up to stand then jump through the ceiling.",
+                    "With no jump assists, use a frozen Mochtroid as a platform to get to the ledge above the door."
+                  ]
                 },
                 {
                   "name": "CF Clip with Bombs (Right to Left)",
@@ -3648,7 +3658,8 @@
                   "requires": [
                     "Gravity",
                     "canGrappleClip",
-                    "canMochtroidIceClip"
+                    "canCeilingClip",
+                    "canUseEnemies"
                   ],
                   "reusableRoomwideNotable": "Colosseum Green Door Grapple Clip",
                   "note": [
@@ -3664,7 +3675,7 @@
                   "notable": true,
                   "requires": [
                     "canGrappleClip",
-                    "canNonTrivialIceClip"
+                    "h_canNonTrivialIceClip"
                   ],
                   "reusableRoomwideNotable": "Colosseum Green Door Grapple Clip",
                   "note": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -777,8 +777,7 @@
                   "notable": true,
                   "requires": [
                     "h_canNonTrivialCeilingClip",
-                    "Gravity",
-                    "canUseEnemies"
+                    "Gravity"
                   ],
                   "reusableRoomwideNotable": "Aqueduct Snail Clip",
                   "note": [
@@ -1245,8 +1244,7 @@
                   "notable": true,
                   "requires": [
                     "h_canNonTrivialCeilingClip",
-                    "Gravity",
-                    "canUseEnemies"
+                    "Gravity"
                   ],
                   "reusableRoomwideNotable": "Aqueduct Snail Clip",
                   "note": [
@@ -1590,6 +1588,15 @@
           "betweenNodes": [1,2]
         }
       ],
+      "reusableRoomwideNotable": [
+        {
+          "name": "Botwoon Hallway Mochtroid Ice Clip",
+          "note": [
+            "Crouch under the crumble blocks while aiming upward, using both angle buttons then freeze the Mochtroid while it is on Samus.",
+            "Jump onto the Mochtroid by quickly pressing down after jumping, when on it, press up to stand then jump through the ceiling."
+          ]
+        }
+      ],
       "links": [
         {
           "from": 1,
@@ -1606,13 +1613,14 @@
                   ]
                 },
                 {
-                  "name": "Botwoon Mochtroid Clip (Left to Right)",
+                  "name": "Botwoon Hallway Mochtroid Clip (Left to Right)",
                   "notable": false,
                   "requires": [
                     "h_canNavigateUnderwater",
                     "canCeilingClip",
                     "canUseFrozenEnemies"
                   ],
+                  "reusableRoomwideNotable": "Botwoon Hallway Mochtroid Ice Clip",
                   "note": [
                     "Crouch under the crumble blocks while aiming upward, using both angle buttons then freeze the Mochtroid while it is on Samus.",
                     "Jump onto the Mochtroid by quickly pressing down after jumping, when on it, press up to stand then jump through the ceiling.",
@@ -1666,8 +1674,8 @@
                   ]
                 },
                 {
-                  "name": "Botwoon Mochtroid Clip (Right to Left)",
-                  "notable": false,
+                  "name": "Botwoon Hallway Mochtroid Clip (Right to Left)",
+                  "notable": true,
                   "requires": [
                     "h_canNavigateUnderwater",
                     "canCeilingClip",
@@ -1682,6 +1690,7 @@
                       "canSpringBallJumpMidAir"
                     ]}
                   ],
+                  "reusableRoomwideNotable": "Botwoon Hallway Mochtroid Ice Clip",
                   "note": [
                     "Crouch under the crumble blocks while aiming upward, using both angle buttons then freeze the Mochtroid while it is on Samus.",
                     "Jump onto the Mochtroid by quickly pressing down after jumping, when on it, press up to stand then jump through the ceiling.",

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -2542,6 +2542,7 @@
                   "requires": [
                     "h_canNavigateUnderwater",
                     "canWallIceClip",
+                    "Wave",
                     {"enemyDamage": {
                       "enemy": "Zoa",
                       "type": "contact",

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -1818,10 +1818,11 @@
                 },
                 {
                   "name": "Indy Jones Mella Ice Clip",
-                  "notable": false,
+                  "notable": true,
                   "requires": [
                     "Morph",
-                    "canMellaIceClip",
+                    "h_canNonTrivialCeilingClip",
+                    "canTrickyUseFrozenEnemies",
                     {"or":[
                       "canConsecutiveWalljump",
                       {"and":[
@@ -1831,7 +1832,8 @@
                     ]}
                   ],
                   "note": [
-                    "Position the frozen Mella such that you can ice clip through the crumble block, then wall jump up the long channel and mid air morph to get out."
+                    "Freeze the Mella at a precise location in order to jump through the crumble block, then wall jump up the long channel and mid air morph to get out.",
+                    "The Mella pixel positioning window is larger and higher with Morph and an X-Ray Stand Up."
                   ]
                 }
               ]

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -2489,8 +2489,15 @@
                 },
                 {
                   "name": "Bubble Mountain Ice Clip",
-                  "notable": false,
-                  "requires": ["canWallCrawlerIceClip"]
+                  "notable": true,
+                  "requires": [
+                    "h_canNonTrivialCeilingClip",
+                    "canTrickyUseFrozenEnemies"
+                  ],
+                  "note": [
+                    "Freeze the wall crawler at a precise location in order to jump through the Power Bomb Blocks.",
+                    "The pixel window is larger and higher with Morph and an X-Ray Stand Up."
+                  ]
                 }
               ]
             }

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -2489,7 +2489,7 @@
                 },
                 {
                   "name": "Bubble Mountain Ice Clip",
-                  "notable": true,
+                  "notable": false,
                   "requires": [
                     "h_canNonTrivialCeilingClip",
                     "canTrickyUseFrozenEnemies"

--- a/tech.json
+++ b/tech.json
@@ -726,16 +726,6 @@
               ]
             },
             {
-              "name": "canSnailClip",
-              "requires": [
-                "canUseEnemies",
-                "canCeilingClip",
-                "Gravity"
-              ],
-              "note": "Manipulating a snail's position to setup and clip through a one-tile-thick ceiling.",
-              "devNote": "FIXME Currently requires Gravity because all known applications are underwater, but maybe there should be a helper for that instead?"
-            },
-            {
               "name": "canManipulateMellas",
               "requires": [ "canUseEnemies" ],
               "note": [
@@ -767,14 +757,6 @@
               ],
               "note": "Can use Ice Beam to freeze enemies to use as platforms or as wall jump supports, to reach higher areas",
               "extensionTechs": [
-                {
-                  "name": "canMochtroidIceClip",
-                  "requires": [
-                    "canCeilingClip",
-                    "canUseFrozenEnemies"
-                  ],
-                  "note": "Using a frozen Mochtroid to clip through a one-tile-thick ceiling."
-                },
                 {
                   "name": "canMochtroidIceClimb",
                   "requires": [ "canUseFrozenEnemies" ],
@@ -810,57 +792,6 @@
                     "If supers are available, they can be used to knock wall crawlers off walls and freeze them mid air."
                   ],
                   "extensionTechs": [
-                    {
-                      "name": "canNonTrivialIceClip",
-                      "requires": [
-                        "canCeilingClip",
-                        "canTrickyUseFrozenEnemies",
-                        {"or":[
-                          "canPixelPerfectIceClip",
-                          {"and":[
-                            "Morph",
-                            "canXRayStandUp"
-                          ]}
-                        ]}
-                      ],
-                      "note": [
-                        "Clipping through a one-tile-thick ceiling by using a frozen enemy. This requires either pixel perfect enemy positioning or the ability to force a standup with X-Ray.",
-                        "This is not required for Mochtroid ice clips, as they line up perfectly and are much easier to execute."
-                      ],
-                      "extensionTechs": [
-                        {
-                          "name": "canWallCrawlerIceClip",
-                          "requires": [ "canNonTrivialIceClip" ],
-                          "note": "Using a frozen wall crawling enemy (such as a Zeela or Geemer) to clip through a one-tile-thick ceiling."
-                        },
-                        {
-                          "name": "canPuyoIceClip",
-                          "requires": [ "canNonTrivialIceClip" ],
-                          "note": "Using a frozen Puyo to clip through a one-tile-thick ceiling."
-                        },
-                        {
-                          "name": "canBeetomIceClip",
-                          "requires": [ "canNonTrivialIceClip" ],
-                          "note": [
-                            "Using an attached Beetom to precisely freeze it in place to be used for a clip through a one-tile-thick ceiling.",
-                            "Freezing an attached Beetom works best when facing right and vertical speed is low."
-                          ]
-                        },
-                        {
-                          "name": "canMellaIceClip",
-                          "requires": [ "canNonTrivialIceClip" ],
-                          "note": "Using a frozen Mella to clip through a one-tile-thick ceiling."
-                        }
-                      ]
-                    },
-                    {
-                      "name": "canPixelPerfectIceClip",
-                      "requires": [
-                        "canCeilingClip",
-                        "canTrickyUseFrozenEnemies"
-                      ],
-                      "note": "Setting up an ice clip at exactly the right pixel, so the clip can work without the leniency allowed by an X-Ray standup"
-                    },
                     {
                       "name": "canWallIceClip",
                       "requires": [
@@ -1313,8 +1244,21 @@
         {
           "name": "canCeilingClip",
           "requires": [],
-          "note": "Basic variant of jumping into a two block high space and performing the actions needed to clip up through a one-tile-thick ceiling.",
-          "devNote": "This often uses enemies, so is required for enemy clip enemies that are extensions of canUseEnemies."
+          "note": [
+            "Basic variant of jumping into a two block high space and performing the actions needed to clip up through a one-tile-thick ceiling.",
+            "Common examples include positioning snails or frozen enemies close enough to the ceiling in order to morph on the enemy, X-Ray Stand Up, and jump through."
+          ],
+          "devNote": "This often uses enemies, so is required for enemy clip enemies that are extensions of canUseEnemies.",
+          "extensionTechs": [
+            {
+              "name": "canPreciseCeilingClip",
+              "requires": [
+                "canCeilingClip",
+                "canUseEnemies"
+              ],
+              "note": "Setting up a an enemy positioning to perform a very precise ceiling clip. The enemy positioning will require a 2-3 pixel range, so the clip can work without the leniency allowed by an X-Ray standup."
+            }
+          ]
         },
         {
           "name": "canPartialFloorClip",

--- a/tech.json
+++ b/tech.json
@@ -794,13 +794,11 @@
                   "extensionTechs": [
                     {
                       "name": "canWallIceClip",
-                      "requires": [
-                        "canTrickyUseFrozenEnemies",
-                        "Wave"
-                      ],
+                      "requires": [ "canTrickyUseFrozenEnemies" ],
                       "note": [
                         "Collision will prioritize frozen enemies before walls which allows Samus to clip 1 pixel into a wall if an enemy is there.",
-                        "Enemies that fly through walls may be repeatedly frozen to advance 1 pixel at a time to eventually allow Samus to pass through a wall or touch a door transition."
+                        "This can be used to get Samus into position to X-Ray Climb.",
+                        "Additionally, enemies that fly through walls may be repeatedly frozen to advance 1 pixel at a time to eventually push Samus through a wall or touch a door transition."
                       ]
                     },
                     {

--- a/tech.json
+++ b/tech.json
@@ -1244,19 +1244,26 @@
         {
           "name": "canCeilingClip",
           "requires": [],
-          "note": [
-            "Basic variant of jumping into a two block high space and performing the actions needed to clip up through a one-tile-thick ceiling.",
-            "Common examples include positioning snails or frozen enemies close enough to the ceiling in order to morph on the enemy, X-Ray Stand Up, and jump through."
-          ],
-          "devNote": "This often uses enemies, so is required for enemy clip enemies that are extensions of canUseEnemies.",
+          "note": "Basic variant of jumping into a two block high space and performing the actions needed to clip up through a one-tile-thick ceiling.",
           "extensionTechs": [
             {
-              "name": "canPreciseCeilingClip",
+              "name": "canXRayCeilingClip",
               "requires": [
                 "canCeilingClip",
                 "canUseEnemies"
               ],
-              "note": "Setting up a an enemy positioning to perform a very precise ceiling clip. The enemy positioning will require a 2-3 pixel range, so the clip can work without the leniency allowed by an X-Ray standup."
+              "note": [
+                "Setting up an enemy positioning to perform a ceiling clip. Jump and Morph onto the enemy, perform an X-Ray standup, and then jump through.",
+                "The enemy positioning will require approximately 1.5 to 2 tiles between the enemy and the ceiling. Just enough to unmorph while on top of it."
+              ],
+              "devNote": "This tech cannot require Morph and canXRayStandUp, because it's extension removes those requirements.",
+              "extensionTechs": [
+                {
+                  "name": "canPreciseCeilingClip",
+                  "requires": [ "canXRayCeilingClip" ],
+                  "note": "Setting up an enemy positioning to perform a very precise ceiling clip. The enemy positioning will require a 2-3 pixel precision range, several pixels lower than what is possible with an X-Ray standup."
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
This addresses #817 

What are your thoughts on this? 

There are currently only two different ceiling clip tech, one for low level strats (`canMochtroidIceClip`) and then it can be paired with other tech to increase its difficulty (`canPartialFloorClip`). Then actual tricky strats are all notable, so they could be increased in difficulty. Then the `canPreciseCeilingClip` is for the very precise stuff, which would be able to be used on all of the lower difficulty notables without Morph+XRayTurnAround. 

Alternatively, we could make a mid level clip for standard wall crawlers and snails, and make those no longer notable.