### PR TITLE
G-Mode Aqueduct, Crab Shaft

### DIFF
--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -1526,13 +1526,13 @@
                           "Gravity",
                           "HiJump",
                           "canUseEnemies"
-                        ]},
-                        {"and": [
-                          "Bombs",
-                          "HiJump",
-                          "SpringBall",
-                          "canSnailClimb"
                         ]}
+                      ]},
+                      {"and": [
+                        "Bombs",
+                        "HiJump",
+                        "SpringBall",
+                        "canSnailClimb"
                       ]}
                     ]}
                   ]

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -661,13 +661,6 @@
           "name": "Aqueduct Junction (Below Top Door)",
           "nodeType": "junction",
           "nodeSubType": "junction"
-        },
-        {
-          "id": 10,
-          "name": "G-Mode Overloaded PLMs Junction (Right Door)",
-          "nodeType": "junction",
-          "nodeSubType": "junction",
-          "note": "Represents being at the right door in G-Mode with PLMs overloaded."
         }
       ],
       "obstacles": [
@@ -912,13 +905,7 @@
                     }},
                     "Grapple",
                     "h_canNavigateUnderwater",
-                    {"or":[
-                      "canSnailClimb",
-                      {"and":[
-                        "Gravity",
-                        "SpaceJump"
-                      ]}
-                    ]}
+                    "canSnailClimb"
                   ]
                 },
                 {
@@ -926,7 +913,7 @@
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [2,6],
+                      "fromNodes": [2,5,6],
                       "mode": "any",
                       "artificialMorph": true
                     }},
@@ -945,13 +932,7 @@
                     }},
                     "h_canUseMorphBombs",
                     "h_canNavigateUnderwater",
-                    {"or":[
-                      "canSnailClimb",
-                      {"and":[
-                        "Gravity",
-                        "SpaceJump"
-                      ]}
-                    ]}
+                    "canSnailClimb"
                   ]
                 },
                 {
@@ -963,19 +944,15 @@
                       "mode": "direct",
                       "artificialMorph": false
                     }},
-                    {"itemNotCollectedAtNode": 7},
-                    {"itemNotCollectedAtNode": 8},
+                    {"or":[
+                      {"itemNotCollectedAtNode": 7},
+                      {"itemNotCollectedAtNode": 8}
+                    ]},
                     "canRiskPermanentLossOfAccess",
                     "Morph",
                     {"ammo": { "type": "PowerBomb", "count": 2 }},
                     "h_canNavigateUnderwater",
-                    {"or":[
-                      "canSnailClimb",
-                      {"and":[
-                        "Gravity",
-                        "SpaceJump"
-                      ]}
-                    ]}
+                    "canSnailClimb"
                   ],
                   "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
                   "note": [
@@ -993,8 +970,10 @@
                       "mode": "direct",
                       "artificialMorph": true
                     }},
-                    {"itemNotCollectedAtNode": 7},
-                    {"itemNotCollectedAtNode": 8},
+                    {"or":[
+                      {"itemNotCollectedAtNode": 7},
+                      {"itemNotCollectedAtNode": 8}
+                    ]},
                     "canRiskPermanentLossOfAccess",
                     "SpringBall",
                     {"ammo": { "type": "PowerBomb", "count": 2 }},
@@ -1235,138 +1214,6 @@
                   ]
                 }
               ]
-            },
-            {
-              "id": 10,
-              "strats": [
-                {
-                  "name": "G-Mode Overload PLMs with Grapple or Bombs",
-                  "notable": false,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [2,6],
-                      "mode": "any",
-                      "artificialMorph": false
-                    }},
-                    {"or": [
-                      "Grapple",
-                      "h_canUseMorphBombs"
-                    ]},
-                    {"or":[
-                      {"and": [
-                        "canSnailClimb",
-                        "canSuitlessMaridia"
-                      ]},
-                      {"and":[
-                        "Gravity",
-                        {"or":[
-                          "canWalljump",
-                          "h_canFly",
-                          "SpeedBooster",
-                          {"and": [
-                            "HiJump",
-                            "canSpringBallJumpMidAir"
-                          ]},
-                          {"and": [
-                            "HiJump",
-                            "canUseEnemies"
-                          ]}
-                        ]}
-                      ]}
-                    ]}
-                  ]
-                },
-                {
-                  "name": "G-Mode Morph Overload PLMs - Bomb the Speed Blocks",
-                  "notable": false,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [2,5,6],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }},
-                    "Gravity",
-                    "h_canArtificialMorphIBJ"
-                  ]
-                },
-                {
-                  "name": "G-Mode Overload PLMs - PB the Items",
-                  "notable": true,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [2,5,6],
-                      "mode": "direct",
-                      "artificialMorph": false
-                    }},
-                    {"or":[
-                      {"and": [
-                        "canSnailClimb",
-                        "canSuitlessMaridia"
-                      ]},
-                      {"and":[
-                        "Gravity",
-                        {"or":[
-                          "canWalljump",
-                          "SpaceJump",
-                          "SpeedBooster",
-                          {"and": [
-                            "HiJump",
-                            "canSpringBallJumpMidAir"
-                          ]},
-                          {"and": [
-                            "HiJump",
-                            "canUseEnemies"
-                          ]}
-                        ]}
-                      ]}
-                    ]},
-                    {"or": [
-                      {"itemNotCollectedAtNode": 7},
-                      {"itemNotCollectedAtNode": 8}
-                    ]},
-                    "canRiskPermanentLossOfAccess",
-                    "Morph",
-                    {"ammo": { "type": "PowerBomb", "count": 2 }}
-                  ],
-                  "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
-                  "note": [
-                    "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
-                    "There is a row of tiles that works, just above and to the left of the right door.",
-                    "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
-                  ]
-                },
-                {
-                  "name": "G-Mode Morph Overload PLMs - PB the Items (To the Left Door)",
-                  "notable": true,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [2,5,6],
-                      "mode": "direct",
-                      "artificialMorph": true
-                    }},
-                    {"or": [
-                      {"itemNotCollectedAtNode": 7},
-                      {"itemNotCollectedAtNode": 8}
-                    ]},
-                    "canRiskPermanentLossOfAccess",
-                    "SpringBall",
-                    {"ammo": { "type": "PowerBomb", "count": 2 }},
-                    "h_canNavigateUnderwater",
-                    "canSnailClimb",
-                    {"or":[
-                      "Gravity",
-                      "HiJump"
-                    ]}
-                  ],
-                  "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
-                  "note": [
-                    "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
-                    "There is a row of tiles that works, just above and to the left of the right door.",
-                    "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
-                  ],
-                  "devNote": "canSnailClimb could be avoided from the right door with Gravity and Space Jump, but that is ignored here."
-                }
-              ]
             }
           ]
         },
@@ -1498,35 +1345,6 @@
         {
           "from": 5,
           "to": [
-            {
-              "id": 1,
-              "strats": [
-                {
-                  "name": "G-Mode Morph Overload PLMs - Bomb the Speed Blocks",
-                  "notable": false,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [5],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }},
-                    {"or":[
-                      "h_canArtificialMorphIBJ",
-                      "SpringBall"
-                    ]},
-                    "Bombs",
-                    "h_canNavigateUnderwater",
-                    {"or":[
-                      "canSnailClimb",
-                      {"and":[
-                        "Gravity",
-                        "SpaceJump"
-                      ]}
-                    ]}
-                  ]
-                }
-              ]
-            },
             {
               "id": 2,
               "strats": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -734,14 +734,9 @@
                       "requires":[ "h_canUsePowerBombs" ]
                     }
                   ]
-                }
-              ]
-            },
-            {
-              "id": 7,
-              "strats": [
+                },
                 {
-                  "name": "G-Mode Morph Overload PLMs - Bomb the Crumble Blocks",
+                  "name": "G-Mode Morph PB",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
@@ -749,15 +744,48 @@
                       "mode": "any",
                       "artificialMorph": true
                     }},
-                    "Gravity",
-                    "h_canArtificialMorphIBJ",
+                    {"ammo": { "type": "PowerBomb", "count": 1 }},
+                    "clearsObstacles": ["A"]
+                  ],
+                  "note": "Place a PB then exit G-Mode."
+                }
+              ]
+            },
+            {
+              "id": 7,
+              "strats": [
+                ,
+                {
+                  "name": "G-Mode Morph Overload PLMs - Bomb the PB Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Bombs",
                     {"or": [
-                      "h_canArtificialMorphCeilingBombJump",
-                      "Morph",
-                      "SpringBall"
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "HiJump",
+                        "canSpringBallJumpMidAir",
+                        "canSnailClimb"
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "HiJump",
+                        "canConsecutiveWalljump",
+                        "canPreciseWalljump",
+                        "canSnailClimb"
+                      ]}
                     ]}
                   ],
-                  "note": "Bomb the crumble blocks above to overload PLMs, then IBJ to escape. IBJ through the Speed Blocks to get to the items."
+                  "note": "Bomb the PB blocks below to overload PLMs, then go up through the crumble blocks to escape, then climb through the Speed blocks."
                 }
               ]
             },
@@ -788,7 +816,7 @@
                   ]
                 },
                 {
-                  "name": "G-Mode Morph Overload PLMs - Bomb the Crumble Blocks",
+                  "name": "G-Mode Morph Overload PLMs - Bomb the PB Blocks",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
@@ -796,15 +824,26 @@
                       "mode": "any",
                       "artificialMorph": true
                     }},
-                    "Gravity",
-                    "h_canArtificialMorphIBJ",
+                    "Bombs",
                     {"or": [
-                      "h_canArtificialMorphCeilingBombJump",
-                      "Morph",
-                      "SpringBall"
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "HiJump",
+                        "canSpringBallJumpMidAir"
+                      ]},
+                      {"and": [
+                        "canSuitlessMaridia",
+                        "HiJump",
+                        "canConsecutiveWalljump",
+                        "canPreciseWalljump"
+                      ]}
                     ]}
                   ],
-                  "note": "Bomb the crumble blocks above to overload PLMs, then IBJ to escape."
+                  "note": "Bomb the PB blocks below to overload PLMs, then go up through the crumble blocks to escape."
                 }
               ]
             }

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -321,6 +321,19 @@
                     "After storing the shinecharge, spin jump back to the left and spark aligned against the right side of the left shaft.",
                     "At the top of the room, hold right in order to land on the platform below the door."
                   ]
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ"
+                  ]
                 }
               ]
             }
@@ -694,6 +707,14 @@
             "The Snail's positioning is very precise, but it is more lenient with Morph and an X-Ray Turn Around. X-Ray can also be useful for helping position the Snail.",
             "This clip can be used to get to the middle left door and the items in the top right of the room."
           ]
+        },
+        {
+          "name": "Aqueduct G-Mode Overload PLMs - PB the Items",
+          "note": [
+            "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
+            "There is a row of tiles that works, just above and to the left of the right door.",
+            "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
+          ]
         }
       ],
       "links": [
@@ -872,6 +893,118 @@
                     "Stop the snail when it is on the lower part of the overhang (hug the snail to gain extra jump height).",
                     "Climb it by waiting until it is just about to become active to jump."
                   ]
+                },
+                {
+                  "name": "G-Mode Overload PLMs with Grapple",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5],
+                      "mode": "any",
+                      "artificialMorph": false
+                    }},
+                    "Grapple",
+                    "h_canNavigateUnderwater",
+                    {"or":[
+                      "canSnailClimb",
+                      {"and":[
+                        "Gravity",
+                        "SpaceJump"
+                      ]}
+                    ]}
+                  ]
+                },
+                {
+                  "name": "G-Mode Morph Overload PLMs - Bomb the Speed Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ"
+                  ]
+                },
+                {
+                  "name": "G-Mode Overload PLMs - Bomb the Speed Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5],
+                      "mode": "any",
+                      "artificialMorph": false
+                    }},
+                    "h_canUseMorphBombs",
+                    "h_canNavigateUnderwater",
+                    {"or":[
+                      "canSnailClimb",
+                      {"and":[
+                        "Gravity",
+                        "SpaceJump"
+                      ]}
+                    ]}
+                  ]
+                },
+                {
+                  "name": "G-Mode Overload PLMs - PB the Items (To the Left Door)",
+                  "notable": true,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5],
+                      "mode": "direct",
+                      "artificialMorph": false
+                    }},
+                    {"itemNotCollectedAtNode": 7},
+                    {"itemNotCollectedAtNode": 8},
+                    "canRiskPermanentLossOfAccess",
+                    "Morph",
+                    {"ammo": { "type": "PowerBomb", "count": 2 }},
+                    "h_canNavigateUnderwater",
+                    {"or":[
+                      "canSnailClimb",
+                      {"and":[
+                        "Gravity",
+                        "SpaceJump"
+                      ]}
+                    ]}
+                  ],
+                  "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+                  "note": [
+                    "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
+                    "There is a row of tiles that works, just above and to the left of the right door.",
+                    "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
+                  ]
+                },
+                {
+                  "name": "G-Mode Morph Overload PLMs - PB the Items (To the Left Door)",
+                  "notable": true,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5],
+                      "mode": "direct",
+                      "artificialMorph": true
+                    }},
+                    {"itemNotCollectedAtNode": 7},
+                    {"itemNotCollectedAtNode": 8},
+                    "canRiskPermanentLossOfAccess",
+                    "SpringBall",
+                    {"ammo": { "type": "PowerBomb", "count": 2 }},
+                    "h_canNavigateUnderwater",
+                    "canSnailClimb",
+                    {"or":[
+                      "Gravity",
+                      "HiJump"
+                    ]}
+                  ],
+                  "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+                  "note": [
+                    "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
+                    "There is a row of tiles that works, just above and to the left of the right door.",
+                    "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
+                  ],
+                  "devNote": "canSnailClimb could be avoided from the right door with Gravity and Space Jump, but that is ignored here."
                 }
               ]
             },

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -738,6 +738,30 @@
               ]
             },
             {
+              "id": 7,
+              "strats": [
+                {
+                  "name": "G-Mode Morph Overload PLMs - Bomb the Crumble Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ",
+                    {"or": [
+                      "h_canArtificialMorphCeilingBombJump",
+                      "Morph",
+                      "SpringBall"
+                    ]}
+                  ],
+                  "note": "Bomb the crumble blocks above to overload PLMs, then IBJ to escape. IBJ through the Speed Blocks to get to the items."
+                }
+              ]
+            },
+            {
               "id":  9,
               "strats": [
                 {
@@ -762,6 +786,25 @@
                     "Fall out of the wall by turning to the right, from a crouch if possible.",
                     "This XRay climb has a window of 4 crouches, but with a way to break bomb blocks it can be ended earlier."
                   ]
+                },
+                {
+                  "name": "G-Mode Morph Overload PLMs - Bomb the Crumble Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ",
+                    {"or": [
+                      "h_canArtificialMorphCeilingBombJump",
+                      "Morph",
+                      "SpringBall"
+                    ]}
+                  ],
+                  "note": "Bomb the crumble blocks above to overload PLMs, then IBJ to escape."
                 }
               ]
             }

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -989,8 +989,7 @@
                     "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
                     "There is a row of tiles that works, just above and to the left of the right door.",
                     "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
-                  ],
-                  "devNote": "canSnailClimb could be avoided from the right door with Gravity and Space Jump, but that is ignored here."
+                  ]
                 }
               ]
             },
@@ -1123,6 +1122,143 @@
                       "useFrames": 45
                     }}
                   ]
+                },
+                {
+                  "name": "G-Mode Overload PLMs with Grapple",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5,6],
+                      "mode": "any",
+                      "artificialMorph": false
+                    }},
+                    "Grapple",
+                    "h_canNavigateUnderwater",
+                    "canSnailClimb",
+                    {"or":[
+                      "Gravity",
+                      "h_canMaxHeightSpringBallJump",
+                      {"and":[
+                        "HiJump",
+                        {"or":[
+                          "canCrouchJump",
+                          "canDownGrab"
+                        ]}
+                      ]}
+                    ]}
+                  ]
+                },
+                {
+                  "name": "G-Mode Morph Overload PLMs - Bomb the Speed Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5,6],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ"
+                  ]
+                },
+                {
+                  "name": "G-Mode Overload PLMs - Bomb the Speed Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5,6],
+                      "mode": "any",
+                      "artificialMorph": false
+                    }},
+                    "h_canUseMorphBombs",
+                    "h_canNavigateUnderwater",
+                    "canSnailClimb",
+                    {"or":[
+                      "Gravity",
+                      "h_canMaxHeightSpringBallJump",
+                      {"and":[
+                        "HiJump",
+                        {"or":[
+                          "canCrouchJump",
+                          "canDownGrab"
+                        ]}
+                      ]}
+                    ]}
+                  ]
+                },
+                {
+                  "name": "G-Mode Overload PLMs - PB the Items (To the Left Door)",
+                  "notable": true,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5,6],
+                      "mode": "direct",
+                      "artificialMorph": false
+                    }},
+                    {"or":[
+                      {"itemNotCollectedAtNode": 7},
+                      {"itemNotCollectedAtNode": 8}
+                    ]},
+                    "Morph",
+                    {"ammo": { "type": "PowerBomb", "count": 2 }},
+                    "h_canNavigateUnderwater",
+                    "canSnailClimb",
+                    {"or":[
+                      "Gravity",
+                      "h_canMaxHeightSpringBallJump",
+                      {"and":[
+                        "HiJump",
+                        {"or":[
+                          "canCrouchJump",
+                          "canDownGrab"
+                        ]}
+                      ]}
+                    ]}
+                  ],
+                  "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+                  "note": [
+                    "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
+                    "There is a row of tiles that works, just above and to the left of the right door.",
+                    "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
+                  ],
+                  "devNote": "This does not include canRiskPermanentLossOfAccess, as it is only worth doing this strat if the items are there."
+                },
+                {
+                  "name": "G-Mode Morph Overload PLMs - PB the Items (To the Left Door)",
+                  "notable": true,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5,6],
+                      "mode": "direct",
+                      "artificialMorph": true
+                    }},
+                    {"or":[
+                      {"itemNotCollectedAtNode": 7},
+                      {"itemNotCollectedAtNode": 8}
+                    ]},
+                    "SpringBall",
+                    {"ammo": { "type": "PowerBomb", "count": 2 }},
+                    "h_canNavigateUnderwater",
+                    "canSnailClimb",
+                    {"or":[
+                      "Gravity",
+                      "h_canMaxHeightSpringBallJump",
+                      {"and":[
+                        "HiJump",
+                        {"or":[
+                          "canCrouchJump",
+                          "canDownGrab"
+                        ]}
+                      ]}
+                    ]}
+                  ],
+                  "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+                  "note": [
+                    "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
+                    "There is a row of tiles that works, just above and to the left of the right door.",
+                    "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
+                  ],
+                  "devNote": "This does not include canRiskPermanentLossOfAccess, as it is only worth doing this strat if the items are there."
                 }
               ],
               "note": "This direct link is just for the shinespark"

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -963,7 +963,7 @@
                     {"or": [
                       {"and": [
                         "h_canArtificialMorphIBJ",
-                        "Gravity",
+                        "Gravity"
                       ]},
                       {"ammo": {"type": "PowerBomb","count": 1}},
                       {"and": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -661,6 +661,13 @@
           "name": "Aqueduct Junction (Below Top Door)",
           "nodeType": "junction",
           "nodeSubType": "junction"
+        },
+        {
+          "id": 10,
+          "name": "G-Mode Overloaded PLMs Junction (Right Door)",
+          "nodeType": "junction",
+          "nodeSubType": "junction",
+          "note": "Represents being at the right door in G-Mode with PLMs overloaded."
         }
       ],
       "obstacles": [
@@ -899,7 +906,7 @@
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [2,5],
+                      "fromNodes": [2,5,6],
                       "mode": "any",
                       "artificialMorph": false
                     }},
@@ -919,7 +926,7 @@
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [2],
+                      "fromNodes": [2,6],
                       "mode": "any",
                       "artificialMorph": true
                     }},
@@ -932,7 +939,7 @@
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [2,5],
+                      "fromNodes": [2,5,6],
                       "mode": "any",
                       "artificialMorph": false
                     }},
@@ -952,7 +959,7 @@
                   "notable": true,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [2,5],
+                      "fromNodes": [2,5,6],
                       "mode": "direct",
                       "artificialMorph": false
                     }},
@@ -982,7 +989,7 @@
                   "notable": true,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [2,5],
+                      "fromNodes": [2,5,6],
                       "mode": "direct",
                       "artificialMorph": true
                     }},
@@ -1228,6 +1235,138 @@
                   ]
                 }
               ]
+            },
+            {
+              "id": 10,
+              "strats": [
+                {
+                  "name": "G-Mode Overload PLMs with Grapple or Bombs",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,6],
+                      "mode": "any",
+                      "artificialMorph": false
+                    }},
+                    {"or": [
+                      "Grapple",
+                      "h_canUseMorphBombs"
+                    ]},
+                    {"or":[
+                      {"and": [
+                        "canSnailClimb",
+                        "canSuitlessMaridia"
+                      ]},
+                      {"and":[
+                        "Gravity",
+                        {"or":[
+                          "canWalljump",
+                          "h_canFly",
+                          "SpeedBooster",
+                          {"and": [
+                            "HiJump",
+                            "canSpringBallJumpMidAir"
+                          ]},
+                          {"and": [
+                            "HiJump",
+                            "canUseEnemies"
+                          ]}
+                        ]}
+                      ]}
+                    ]}
+                  ]
+                },
+                {
+                  "name": "G-Mode Morph Overload PLMs - Bomb the Speed Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5,6],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ"
+                  ]
+                },
+                {
+                  "name": "G-Mode Overload PLMs - PB the Items",
+                  "notable": true,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5,6],
+                      "mode": "direct",
+                      "artificialMorph": false
+                    }},
+                    {"or":[
+                      {"and": [
+                        "canSnailClimb",
+                        "canSuitlessMaridia"
+                      ]},
+                      {"and":[
+                        "Gravity",
+                        {"or":[
+                          "canWalljump",
+                          "SpaceJump",
+                          "SpeedBooster",
+                          {"and": [
+                            "HiJump",
+                            "canSpringBallJumpMidAir"
+                          ]},
+                          {"and": [
+                            "HiJump",
+                            "canUseEnemies"
+                          ]}
+                        ]}
+                      ]}
+                    ]},
+                    {"or": [
+                      {"itemNotCollectedAtNode": 7},
+                      {"itemNotCollectedAtNode": 8}
+                    ]},
+                    "canRiskPermanentLossOfAccess",
+                    "Morph",
+                    {"ammo": { "type": "PowerBomb", "count": 2 }}
+                  ],
+                  "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+                  "note": [
+                    "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
+                    "There is a row of tiles that works, just above and to the left of the right door.",
+                    "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
+                  ]
+                },
+                {
+                  "name": "G-Mode Morph Overload PLMs - PB the Items (To the Left Door)",
+                  "notable": true,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2,5,6],
+                      "mode": "direct",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      {"itemNotCollectedAtNode": 7},
+                      {"itemNotCollectedAtNode": 8}
+                    ]},
+                    "canRiskPermanentLossOfAccess",
+                    "SpringBall",
+                    {"ammo": { "type": "PowerBomb", "count": 2 }},
+                    "h_canNavigateUnderwater",
+                    "canSnailClimb",
+                    {"or":[
+                      "Gravity",
+                      "HiJump"
+                    ]}
+                  ],
+                  "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
+                  "note": [
+                    "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
+                    "There is a row of tiles that works, just above and to the left of the right door.",
+                    "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
+                  ],
+                  "devNote": "canSnailClimb could be avoided from the right door with Gravity and Space Jump, but that is ignored here."
+                }
+              ]
             }
           ]
         },
@@ -1359,6 +1498,35 @@
         {
           "from": 5,
           "to": [
+            {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "G-Mode Morph Overload PLMs - Bomb the Speed Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [5],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    {"or":[
+                      "h_canArtificialMorphIBJ",
+                      "SpringBall"
+                    ]},
+                    "Bombs",
+                    "h_canNavigateUnderwater",
+                    {"or":[
+                      "canSnailClimb",
+                      {"and":[
+                        "Gravity",
+                        "SpaceJump"
+                      ]}
+                    ]}
+                  ]
+                }
+              ]
+            },
             {
               "id": 2,
               "strats": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -952,86 +952,27 @@
                   ]
                 },
                 {
-                  "name": "G-Mode Morph Overload PLMs - Bomb the Speed Blocks",
+                  "name": "G-Mode Morph",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [2,5,6],
+                      "fromNodes": [2],
                       "mode": "any",
                       "artificialMorph": true
                     }},
-                    "Gravity",
-                    "h_canArtificialMorphIBJ"
-                  ]
-                },
-                {
-                  "name": "G-Mode Overload PLMs - Bomb the Speed Blocks",
-                  "notable": false,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [2,5,6],
-                      "mode": "any",
-                      "artificialMorph": false
-                    }},
-                    "h_canUseMorphBombs",
-                    "h_canNavigateUnderwater",
-                    "canSnailClimb"
-                  ]
-                },
-                {
-                  "name": "G-Mode Overload PLMs - PB the Items (To the Left Door)",
-                  "notable": true,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [2,5,6],
-                      "mode": "direct",
-                      "artificialMorph": false
-                    }},
-                    {"or":[
-                      {"itemNotCollectedAtNode": 7},
-                      {"itemNotCollectedAtNode": 8}
-                    ]},
-                    "canRiskPermanentLossOfAccess",
-                    "Morph",
-                    {"ammo": { "type": "PowerBomb", "count": 2 }},
-                    "h_canNavigateUnderwater",
-                    "canSnailClimb"
-                  ],
-                  "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
-                  "note": [
-                    "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
-                    "There is a row of tiles that works, just above and to the left of the right door.",
-                    "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
-                  ]
-                },
-                {
-                  "name": "G-Mode Morph Overload PLMs - PB the Items (To the Left Door)",
-                  "notable": true,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [2,5,6],
-                      "mode": "direct",
-                      "artificialMorph": true
-                    }},
-                    {"or":[
-                      {"itemNotCollectedAtNode": 7},
-                      {"itemNotCollectedAtNode": 8}
-                    ]},
-                    "canRiskPermanentLossOfAccess",
-                    "SpringBall",
-                    {"ammo": { "type": "PowerBomb", "count": 2 }},
-                    "h_canNavigateUnderwater",
-                    "canSnailClimb",
-                    {"or":[
-                      "Gravity",
-                      "HiJump"
+                    {"or": [
+                      {"and": [
+                        "h_canArtificialMorphIBJ",
+                        "Gravity",
+                      ]},
+                      {"ammo": {"type": "PowerBomb","count": 1}},
+                      {"and": [
+                        "Bombs",
+                        "HiJump",
+                        "SpringBall",
+                        "canSnailClimb"
+                      ]}
                     ]}
-                  ],
-                  "reusableRoomwideNotable": "Aqueduct G-Mode Overload PLMs - PB the Items",
-                  "note": [
-                    "PLMs can be overloaded in direct G-Mode with a single Power Bomb if both items are still there and 2 PBs if only one item is.",
-                    "There is a row of tiles that works, just above and to the left of the right door.",
-                    "The row is one tile higher than the horizontal pipe that is part of the door frame, spanning from the left to one tile away from the right wall."
                   ]
                 }
               ]
@@ -1524,6 +1465,43 @@
           "from": 5,
           "to": [
             {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [5],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        {"ammo": {"type": "PowerBomb","count": 1}},
+                        "SpringBall",
+                        {"or": [
+                          "Gravity",
+                          "HiJump",
+                          "canUseEnemies"
+                        ]},
+                        {"and": [
+                          "Bombs",
+                          "HiJump",
+                          "SpringBall",
+                          "canSnailClimb"
+                        ]}
+                      ]}
+                    ]}
+                  ]
+                }
+              ]
+            },
+            {
               "id": 2,
               "strats": [
                 {
@@ -1603,6 +1581,32 @@
         {
           "from": 6,
           "to": [
+            {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [6],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      {"ammo": {"type": "PowerBomb","count": 1}},
+                      {"and": [
+                        "Bombs",
+                        {"or": [
+                          "Gravity",
+                          "SpringBall"
+                        ]}
+                      ]}
+                    ]}
+                  ]
+                }
+              ]
+            },
             {
               "id": 9,
               "strats": [

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -754,7 +754,6 @@
             {
               "id": 7,
               "strats": [
-                ,
                 {
                   "name": "G-Mode Morph Overload PLMs - Bomb the PB Blocks",
                   "notable": false,

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -744,9 +744,9 @@
                       "mode": "any",
                       "artificialMorph": true
                     }},
-                    {"ammo": { "type": "PowerBomb", "count": 1 }},
-                    "clearsObstacles": ["A"]
+                    {"ammo": { "type": "PowerBomb", "count": 1 }}
                   ],
+                  "clearsObstacles": ["A"],
                   "note": "Place a PB then exit G-Mode."
                 }
               ]

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -1230,7 +1230,7 @@
                   ]
                 },
                 {
-                  "name": "G-Mode Overload PLMs - PB the Items (To the Left Door)",
+                  "name": "G-Mode Overload PLMs - PB the Items (To the Items)",
                   "notable": true,
                   "requires": [
                     {"comeInWithGMode": {
@@ -1267,7 +1267,7 @@
                   "devNote": "This does not include canRiskPermanentLossOfAccess, as it is only worth doing this strat if the items are there."
                 },
                 {
-                  "name": "G-Mode Morph Overload PLMs - PB the Items (To the Left Door)",
+                  "name": "G-Mode Morph Overload PLMs - PB the Items (To the Items)",
                   "notable": true,
                   "requires": [
                     {"comeInWithGMode": {
@@ -1285,7 +1285,6 @@
                     "canSnailClimb",
                     {"or":[
                       "Gravity",
-                      "h_canMaxHeightSpringBallJump",
                       {"and":[
                         "HiJump",
                         {"or":[


### PR DESCRIPTION
I went back and forth on ways to bypass snail climbs, and eventually settled on ignoring them. It ended up making way too many things far too complex. 

I doubt it would ever come up that a player can do these g-mode strats without the snail climb, but could be a problem in an enemizer (along with many other things)