### PR TITLE
Add Majority of Missing G-Mode in Pink Maridia

### DIFF
--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -3012,6 +3012,35 @@
               ]
             },
             {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "SpringBall",
+                        {"or": [
+                          "Gravity",
+                          "HiJump"
+                        ]}
+                      ]}
+                    ]}
+                  ]
+                }
+              ]
+            },
+            {
               "id": 4,
               "strats": [
                 {
@@ -3124,6 +3153,20 @@
                     "Only requires a runway of approximately 1 tile in the adjacent room.",
                     "Take two Mochtroid hits or use a double bomb jump."
                   ]
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ"
+                  ],
+                  "note": "To avoid the Mochtroids, it is possible to place bombs near them while in the Morph Tunnel below to the right."
                 }
               ]
             }
@@ -3301,6 +3344,30 @@
                      ]}
                   ],
                   "devNote": "Run away from the oums and reclimb after each to avoid needing to jump over them."
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "SpringBall",
+                        {"or": [
+                          "Gravity",
+                          "HiJump"
+                        ]}
+                      ]}
+                    ]}
+                  ]
                 }
               ]
             },
@@ -3413,6 +3480,20 @@
                       "openEnd": 2
                     }}
                   ]
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ"
+                  ],
+                  "note": "To avoid the Mochtroids, it is possible to place bombs near them while in the Morph Tunnel to the right."
                 }
               ],
               "devNote": "This link is only for the shinespark, mochtroid climbing or cross room jump. Other strats should go 2 -> 1 -> 4."
@@ -3501,6 +3582,30 @@
                     "Wait for the Oums to roll on their own to a place where they can be climbed.",
                     "Do not stand on the Oums when they begin to attack."
                   ]
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [3],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "SpringBall",
+                        {"or": [
+                          "Gravity",
+                          "HiJump"
+                        ]}
+                      ]}
+                    ]}
+                  ]
                 }
               ]
             },
@@ -3537,6 +3642,19 @@
                     "This is an alternative to wall jumping."
                   ],
                   "devNote": "Jumping into a diagonal spark saves a little energy from both the jump and hitting the slightly lower ceiling by the door."
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [3],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ"
+                  ]
                 }
               ],
               "devNote": "This link is only for the shinespark. Other strats should go 3 -> 2 -> 1 -> 4."
@@ -3553,6 +3671,35 @@
                   "name": "Base",
                   "notable": false,
                   "requires": []
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [4],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "SpringBall",
+                        {"or": [
+                          "Gravity",
+                          "HiJump"
+                        ]}
+                      ]}
+                    ]}
+                  ]
                 }
               ]
             }
@@ -4178,6 +4325,20 @@
                     "canUnderwaterWalljump",
                     "canSpaceJumpWaterBounce"
                   ]
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ"
+                  ],
+                  "note": "Place bombs without moving horizontally, such that multiple hit the Mochtroid immediately as it attaches without being boosted into the doorway or sand."
                 }
               ]
             }
@@ -4764,6 +4925,19 @@
                     "Requires a runway of approximately 7.5 tiles in the adjacent room.",
                     "A momentum conserving turnaround is easier than a midair wiggle."
                   ]
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ"
+                  ]
                 }
               ]
             }
@@ -5033,6 +5207,35 @@
                     }}
                   ],
                   "note": "Requires an air ball and a runway of at least 1.5 tiles in the adjacent room"
+                },
+                {
+                  "name": "G-Mode Morph (Draygon Defeated)",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "f_DefeatedDraygon",
+                    "Gravity",
+                    "h_canArtificialMorphIBJ"
+                  ]
+                },
+                {
+                  "name": "G-Mode Morph (Draygon Alive)",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true,
+                      "mobility": "mobile"
+                    }},
+                    "Gravity",
+                    "h_canArtificialMorphIBJ"
+                  ],
+                  "note": "There is enough time to IBJ to the top door before Draygon appears."
                 }
               ],
               "devNote": "All other strats should go 1 -> 3 -> 2."
@@ -6515,6 +6718,17 @@
                     "canTrickyUseFrozenEnemies",
                     "canPlayInSand"
                   ]
+                },
+                {
+                  "name": "G-Mode",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": false
+                    }}
+                  ]
                 }
               ],
               "devNote": "This link refers specifically to crossing on frozen enemies."
@@ -6573,6 +6787,17 @@
                     "h_canNavigateUnderwater",
                     "canTrickyUseFrozenEnemies",
                     "canPlayInSand"
+                  ]
+                },
+                {
+                  "name": "G-Mode",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [3],
+                      "mode": "any",
+                      "artificialMorph": false
+                    }}
                   ]
                 }
               ],

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -2285,6 +2285,11 @@
           "id": "A",
           "name": "Speed Blocks",
           "obstacleType": "inanimate"
+        },
+        {
+          "id": "B",
+          "name": "G-Mode Grab Item and Leave Before Exiting G-Mode",
+          "obstacleType": "abstract"
         }
       ],
       "enemies": [
@@ -2409,6 +2414,18 @@
                     {"obstaclesCleared": ["A"]}
                   ],
                   "devNote": "Gravity can run across the sand with speed again."
+                },
+                {
+                  "name": "G-Mode Overload PLMs",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }}
+                  ],
+                  "note": "Overload PLMs by touching the sand, then move through the speed blocks. Avoiding the sand pits is easier without Gravity or HiJump."
                 }
               ],
               "devNote": "Direct link passing below. Passage above should go 1 -> 5 -> 4."
@@ -2498,6 +2515,64 @@
                     }}
                   ],
                   "note": "Needs a runway of approximately 7.5 tiles in the adjacent room, to get enough height. This is a peak of height with speed booster, no hjb, while underwater."
+                },
+                {
+                  "name": "G-Mode Morph Direct",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "direct",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "SpringBall",
+                        {"or": [
+                          "Gravity",
+                          "HiJump"
+                        ]},
+                        {"or": [
+                          "canTrickyJump",
+                          {"ammo": {"type": "PowerBomb","count": 1}}
+                        ]}
+                      ]}
+                    ]},
+                    {"obstaclesCleared": ["B"]}
+                  ],
+                  "note": "Be careful not to touch or bomb the sand in order to grab the item before PLMs are overloaded."
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "SpringBall",
+                        {"or": [
+                          "Gravity",
+                          "HiJump"
+                        ]},
+                        {"or": [
+                          "canTrickyJump",
+                          {"ammo": {"type": "PowerBomb","count": 1}}
+                        ]}
+                      ]}
+                    ]}
+                  ]
                 }
               ]
             }
@@ -2625,9 +2700,90 @@
                       "openEnd": 2
                     }}
                   ]
+                },
+                {
+                  "name": "G-Mode Overload PLMs",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      "canTrickyJump",
+                      {"and": [
+                        "Gravity",
+                        "SpaceJump"
+                      ]}
+                    ]}
+                  ],
+                  "note": [
+                    "Overload PLMs by touching the sand, then move through the speed blocks.",
+                    "Avoiding the right pit is much easier without Gravity or HiJump. It is recommended to use a Flatley Jump."
+                  ]
                 }
               ],
               "devNote": "Direct link passing below. Passage above should go 4 -> 6 -> 5 -> 1."
+            },
+            {
+              "id": 5,
+              "strats": [
+                {
+                  "name": "G-Mode Morph Direct",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [4],
+                      "mode": "direct",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "SpringBall",
+                        {"or": [
+                          "Gravity",
+                          "HiJump"
+                        ]}
+                      ]}
+                    ]},
+                    {"obstaclesCleared": ["B"]}
+                  ],
+                  "note": [
+                    "Be careful not to touch or bomb the sand in order to grab the item before PLMs are overloaded.",
+                    "With bombs, kill the Zoas and they will stop spawning."
+                  ]
+                },
+                {
+                  "name": "G-Mode Morph",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    {"or": [
+                      {"and": [
+                        "Gravity",
+                        "h_canArtificialMorphIBJ"
+                      ]},
+                      {"and": [
+                        "SpringBall",
+                        {"or": [
+                          "Gravity",
+                          "HiJump"
+                        ]}
+                      ]}
+                    ]}
+                  ],
+                  "note": "With bombs, kill the Zoas and they will stop spawning."
+                }
+              ]
             },
             {
               "id": 6,
@@ -2740,6 +2896,21 @@
                   "name": "Base",
                   "notable": false,
                   "requires": [ "Morph" ]
+                },
+                {
+                  "name": "G-Mode Morph Exit Tunnel Before Leaving G-Mode",
+                  "notable": false,
+                  "requires": [ {"obstaclesCleared": ["B"]} ]
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "strats": [
+                {
+                  "name": "G-Mode Morph Exit Tunnel Before Leaving G-Mode",
+                  "notable": false,
+                  "requires": [ {"obstaclesCleared": ["B"]} ]
                 }
               ]
             },

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -4167,7 +4167,7 @@
                 {
                   "name": "Space Jump",
                   "notable": false,
-                  "requires": ["SpaceJump"],
+                  "requires": [ "SpaceJump" ],
                   "devNote": "No water involved here, so no need for Gravity or canSuitlessMaridia."
                 },
                 {

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -2233,14 +2233,16 @@
           "name": "Botwoon E-Tank Left Sand Pit (to Botwoon Quicksand Left)",
           "nodeType": "exit",
           "nodeSubType": "sandpit",
-          "nodeAddress": "0x001a858"
+          "nodeAddress": "0x001a858",
+          "devNote": "FIXME Add leaveWithGMode strats. These can't currently be represented in the logic."
         },
         {
           "id": 3,
           "name": "Botwoon E-Tank Right Sand Pit (to Botwoon Quicksand Right)",
           "nodeType": "exit",
           "nodeSubType": "sandpit",
-          "nodeAddress": "0x001a864"
+          "nodeAddress": "0x001a864",
+          "devNote": "FIXME Add leaveWithGMode strats. These can't currently be represented in the logic."
         },
         {
           "id": 4,

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -2924,8 +2924,9 @@
                     {"comeInWithGMode": {
                       "fromNodes": [1],
                       "mode": "any",
-                      "artificialMorph": true
-                    }}
+                      "artificialMorph": false
+                    }},
+                    "canSuitlessMaridia"
                   ],
                   "note": "Overload PLMs by touching the sand, then move through the speed blocks. Avoiding the sand pits is easier without Gravity or HiJump."
                 }
@@ -3030,7 +3031,8 @@
                     {"or": [
                       {"and": [
                         "Gravity",
-                        "h_canArtificialMorphIBJ"
+                        "h_canArtificialMorphIBJ",
+                        "canDodgeWhileShooting"
                       ]},
                       {"and": [
                         "SpringBall",
@@ -3222,7 +3224,10 @@
                   ],
                   "note": [
                     "Overload PLMs by touching the sand, then move through the speed blocks.",
-                    "Avoiding the right pit is much easier without Gravity or HiJump. It is recommended to use a Flatley Jump."
+                    "Shoot the Puyo while crouching to increase accuracy.",
+                    "Avoiding the right pit is much easier without Gravity or HiJump.",
+                    "Standing on the edge and spin jumping to the left is much easier than a running jump.",
+                    "While on the left side of this platform, the Puyo to the left will start moving; carefully kill it."
                   ]
                 }
               ],
@@ -3397,12 +3402,16 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [ "Morph" ]
+                  "requires": [ "Morph" ],
+                  "note": "If the Puyos are alive, lure the first to the right, then roll out of the hole, unmorph and fight them. Crouching while shooting may increase accuracy.",
+                  "devNote": "FIXME This probably shouldnt be free if the Puyos are still alive."
                 },
                 {
                   "name": "G-Mode Morph Exit Tunnel Before Leaving G-Mode",
                   "notable": false,
-                  "requires": [ {"obstaclesCleared": ["B"]} ]
+                  "requires": [ {"obstaclesCleared": ["B"]} ],
+                  "note": "If the Puyos are alive, lure the first to the right, then roll out of the hole, unmorph and fight them. Crouching while shooting may increase accuracy.",
+                  "devNote": "FIXME This probably shouldnt be free if the Puyos are still alive."
                 }
               ]
             },

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -52,6 +52,7 @@ def process_keyvalue(k, v):
         # "groupName",    # !!could check for unique
         # "nodeAddress",  # !!could check for unique
         # "roomAddress",  # !!could check for unique
+        "mobility",     # validated by schema
         "mode",         # validated by schema
         "lockType",     # validated by schema
         "nodeType",     # validated by schema


### PR DESCRIPTION
Rooms that are still missing: 
- East Cac Alley, 
- Crossing the Colosseum with artificial morph IBJ (If it's possible, it sounds like a huge pain)
- Going down the sand pits in Botwoon E-Tank Room (currently a huge pain to represent and it can't work with this schema)