### PR TITLE
Convert Metroid Hits to Frames

### DIFF
--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -233,6 +233,14 @@ __Example:__
 {"samusEaterFrames": 160}
 ```
 
+#### metroidFrames object
+A `metroidFrames` object represents the need for Samus to spend time (measured in frames) grappled by a Metroid. When captured, the Metroid deals 3 damage every 4 frames. This is halved by Varia (3 damage every 8 frames), and halved again by Gravity Suit (3 damage every 16 frames).
+
+__Example:__
+```json
+{"metroidFrames": 260}
+```
+
 #### spikeHits object
 A `spikeHits` object represents the need for Samus to intentionally take a number of hits from spikes. This is meant to be converted to a flat health value based on item loadout. The vanilla damage per spike hit is 60 with Power Suit, 30 with Varia, and 15 with Gravity Suit.
 

--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -469,11 +469,7 @@
                       ],
                       "excludedWeapons": [ "Super", "Missile" ]
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 19
-                    }}
+                    {"metroidFrames": 304}
                   ],
                   "obstacles": [
                     {
@@ -529,11 +525,7 @@
                       "type": "contact",
                       "hits": 1
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 18
-                    }}
+                    {"metroidFrames": 288}
                   ],
                   "note": "Taking a rinka hit stops the Metroid damage for a while and is less damage."
                 }
@@ -588,11 +580,7 @@
                       ],
                       "excludedWeapons": [ "Super", "Missile" ]
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 19
-                    }}
+                    {"metroidFrames": 304}
                   ],
                   "obstacles": [
                     {
@@ -648,11 +636,7 @@
                       "type": "contact",
                       "hits": 1
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 18
-                    }}
+                    {"metroidFrames": 288}
                   ],
                   "note": "Taking a rinka hit stops the Metroid damage for a while and is less damage."
                 }
@@ -910,11 +894,7 @@
               }},
               {"or": [
                 "f_KilledMetroidRoom2",
-                {"enemyDamage": {
-                  "enemy": "Metroid",
-                  "type": "contact",
-                  "hits": 8
-                }}
+                {"metroidFrames": 120}
               ]}
             ],
             "note": "If alive, the Metroids do 90 damage before the Rinka hits."
@@ -1013,11 +993,7 @@
                       ],
                       "excludedWeapons": [ "Super", "Missile" ]
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 6
-                    }}
+                    {"metroidFrames": 96}
                   ],
                   "obstacles": [
                     {
@@ -1064,13 +1040,7 @@
                 {
                   "name": "Tank the Damage",
                   "notable": false,
-                  "requires": [
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 5
-                    }}
-                  ]
+                  "requires": [ {"metroidFrames": 80} ]
                 }
               ]
             }
@@ -1122,11 +1092,7 @@
                       ],
                       "excludedWeapons": [ "Super", "Missile" ]
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 6
-                    }}
+                    {"metroidFrames": 96}
                   ],
                   "obstacles": [
                     {
@@ -1173,13 +1139,7 @@
                 {
                   "name": "Tank the Damage",
                   "notable": false,
-                  "requires": [
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 5
-                    }}
-                  ]
+                  "requires": [ {"metroidFrames": 80} ]
                 }
               ]
             }
@@ -1399,11 +1359,7 @@
                       ],
                       "excludedWeapons": [ "Super", "Missile" ]
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 17
-                    }}
+                    {"metroidFrames": 272}
                   ],
                   "obstacles": [
                     {
@@ -1453,13 +1409,7 @@
                 {
                   "name": "Tank the Damage",
                   "notable": false,
-                  "requires": [
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 11
-                    }}
-                  ]
+                  "requires": [ {"metroidFrames": 176} ]
                 }
               ]
             }
@@ -1511,11 +1461,7 @@
                       ],
                       "excludedWeapons": [ "Super", "Missile" ]
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 17
-                    }}
+                    {"metroidFrames": 272}
                   ],
                   "obstacles": [
                     {
@@ -1565,13 +1511,7 @@
                 {
                   "name": "Tank the Damage",
                   "notable": false,
-                  "requires": [
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 11
-                    }}
-                  ]
+                  "requires": [ {"metroidFrames": 176} ]
                 }
               ]
             }
@@ -1646,11 +1586,7 @@
               }},
               {"or": [
                 "f_KilledMetroidRoom4",
-                {"enemyDamage": {
-                  "enemy": "Metroid",
-                  "type": "contact",
-                  "hits": 7
-                }}
+                {"metroidFrames": 104}
               ]}
             ],
             "note": "If alive, the Metroids do up to 78 damage before the Rinka hits. Entering through the middle of the door will require less damage."
@@ -1745,11 +1681,7 @@
                       ],
                       "excludedWeapons": [ "Super", "Missile" ]
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 17
-                    }}
+                    {"metroidFrames": 272}
                   ],
                   "obstacles": [
                     {
@@ -1824,11 +1756,7 @@
                       "type": "contact",
                       "hits": 1
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 16
-                    }}
+                    {"metroidFrames": 256}
                   ],
                   "note": "Taking a rinka hit stops the Metroid damage for a while and is less damage."
                 }
@@ -1882,11 +1810,7 @@
                       ],
                       "excludedWeapons": [ "Super", "Missile" ]
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 17
-                    }}
+                    {"metroidFrames": 272}
                   ],
                   "obstacles": [
                     {
@@ -1905,11 +1829,7 @@
                       ],
                       "excludedWeapons": [ "Super", "Missile" ]
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 8
-                    }}
+                    {"metroidFrames": 128}
                   ],
                   "obstacles": [
                     {
@@ -1988,11 +1908,7 @@
                       "type": "contact",
                       "hits": 1
                     }},
-                    {"enemyDamage": {
-                      "enemy": "Metroid",
-                      "type": "contact",
-                      "hits": 16
-                    }}
+                    {"metroidFrames": 256}
                   ],
                   "note": "Taking a rinka hit stops the Metroid damage for a while and is less damage."
                 }

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -260,6 +260,13 @@
             "title": "Samus Eater Frames",
             "description": "Fulfilled by spending an amount of energy that correlates to the number of frames captured by a Samus Eater."
           },
+          "metroidFrames": {
+            "$id": "#/definitions/logicalRequirement/items/properties/metroidFrames",
+            "type": "integer",
+            "minimum": 1,
+            "title": "Metroid Frames",
+            "description": "Fulfilled by spending an amount of energy that corresponds to spending a number of frames drained by a Metroid."
+          },
           "energyAtMost": {
             "$id": "#/definitions/logicalRequirement/items/properties/energyAtMost",
             "type": "integer",


### PR DESCRIPTION
Enemy hits are generally not needing to be multiplied by a leniency factor as the number of enemy hits is typically fixed based on the strat. Heat, acid, and lava frames do need a leniency factor because it is dependent on how fast the player can platform through the environment. 

Metroid hits are more like environmental damage than discrete hits, and the damage they deal is heavily dependent on the player's platforming ability going through a room. 

Additionally, the number of energy loss which was chosen for the enemy damage was 16 frames (12 damage). Each of these damages are given on an individual frame, not 12 at once. Because of this, strats with precise timing are forced to deal damage with a multiple of 12, which can be a problem (g-mode immobile).

Because of this, metroid damage was converted into `metroidFrames`, dealing 3 damage per 4 frames.