### PR TITLE
Add 'refill' logical requirement to schema & docs

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -408,7 +408,8 @@
             {"ammo": { "type": "PowerBomb", "count": 1 }},
             {"ammo": { "type": "Missile", "count": 10 }},
             {"ammo": { "type": "Super", "count": 10 }},
-            {"ammo": { "type": "PowerBomb", "count": 10 }}
+            {"ammo": { "type": "PowerBomb", "count": 10 }},
+            {"refill": ["Energy"]}
           ]
         },
         {

--- a/logicalRequirements.md
+++ b/logicalRequirements.md
@@ -24,6 +24,9 @@ __Example:__
 ]}
 ```
 
+Requirements are applied in the order in which they are listed; this can matter in cases where "refill",
+"ammoDrain", or "energyAtMost" requirements are involved with other resource usage requirements.
+
 #### or object
 An `or` object is fulfilled if at least one of the logical elements it contains is fulfilled
 
@@ -72,10 +75,6 @@ __Example:__
   "count": 75
 }}
 ```
-
-__Additional considerations__
-
-Whenever an `ammoDrain` object is part of a strat, it should be applied after all other ammo costs.
 
 #### enemyKill object
 An `enemyKill` object communicates the need to kill a given set of enemies, and is satisfied by having the necessary items to use one of the valid [weapons](weapons/weapons-readme.md) that will kill each of the enemies (as well as enough ammo, if applicable).
@@ -263,7 +262,7 @@ __Example:__
 
 #### resourceCapacity object
 A `resourceCapacity` object represents the need for Samus to be capable of holding at least a set amount of a specific resource. It can have the following properties:
-* _type:_ The type ofresource. Can have the following values:
+* _type:_ The type of resource. Can have the following values:
   * Missile
   * Super
   * PowerBomb
@@ -279,6 +278,22 @@ __Example:__
     { "type": "PowerBomb", "count": 11},
     { "type": "RegularEnergy", "count":899}
 ]}
+```
+
+#### refill object
+A `refill` object is always fulfilled and represents a process that refills certain resource types to their current maximum capacity. Possible uses could include a farm, recharge station, or Crystal Flash. The
+refilled resource types are listed as an array having the following possible values:
+
+* Missile
+* Super
+* PowerBomb
+* RegularEnergy
+* ReserveEnergy
+* Energy (shorthand for RegularEnergy + ReserveEnergy)
+
+__Example:__
+```json
+{"refill": ["Energy", "Missile"]}
 ```
 
 ### Momentum-Based Objects

--- a/schema/m3-requirements.schema.json
+++ b/schema/m3-requirements.schema.json
@@ -100,6 +100,26 @@
               }
             }
           },
+          "refill": {
+            "$id": "#/definitions/logicalRequirement/items/properties/refill",
+            "type": "array",
+            "title": "Refill",
+            "description": "Always fulfilled, with an effect of fully refilling the listed resource types.",
+            "items": {
+              "$id": "#/definitions/logicalRequirement/items/properties/refill/items",
+              "type": "string",
+              "title": "Resource Type",
+              "description": "The name of a resource type that becomes fully refilled",
+              "enum": [
+                "Missile",
+                "Super",
+                "PowerBomb",
+                "RegularEnergy",
+                "ReserveEnergy",
+                "Energy"
+              ]
+            }
+          },
           "enemyKill": {
             "$id": "#/definitions/logicalRequirement/items/properties/enemyKill",
             "type": "object",


### PR DESCRIPTION
This adds a new logical requirement type to represent a process that refills certain resource types, potentially in the middle of a strat. This is proposed as a generic, flexible building block applicable to many situations, for example:
- farming in the middle of a boss fight (e.g. GT)
- using a Crystal Flash in the middle of a heat run (or lava/acid dive)
- non-infinitely spawning enemy farms (in conjunction with some other requirement to indicate ability to reset the room through an accessible door)

This would also allow us to represent re-spawning farms (and uses of the Ship or recharge stations) as normal strats, e.g. in a link from a node to itself, eliminating the need for some special handling.

With refills being combined with other resource requirements, it matters what order requirements are applied in: for example you could have heat damage at start of GT room, followed by a refill during the fight, followed by some heat damage at the end of the fight; and in order for the logic to be correct these requirements must be applied in their chronological order. So we update the docs to clarify that requirements in an "and" are to be applied in the order listed.