### PR TITLE
Split off canBeVeryPatient and add patience on X-ray climb strats

### DIFF
--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -781,7 +781,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "This is a short climb of only a few tiles."
                 }
               ]
             }

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -510,7 +510,8 @@
                         }}
                       ]}
                     ]}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 }
               ],
               "note": "This link is only for the X-Ray climb, which skips the junction altogether."
@@ -547,8 +548,10 @@
                       "usedTiles": 0.5,
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
-                    }}
-                  ]
+                    }},
+                    "canBePatient"
+                  ],
+                  "note": "Climb up 4 screens."
                 }
               ],
               "note": "This link is only for the X-Ray climb, which skips the junction altogether."
@@ -2626,7 +2629,7 @@
                   "notable": false,
                   "requires": [
                     "h_canLeftDoorXRayClimb",
-                    { "resetRoom": {
+                    {"resetRoom": {
                       "nodes": [3],
                       "mustStayPut": true
                     }},
@@ -2637,7 +2640,8 @@
                       "useFrames": 200
                     }}
                   ],
-                  "note": "In truth this goes to node 1, but there's no need to make a link for this since movement between 1 and 2 is free (via 5)."
+                  "note": "Climb up 1 screen.",
+                  "devNote": "In truth this goes to node 1, but there's no need to make a link for this since movement between 1 and 2 is free (via 5)."
                 }
               ]
             },
@@ -2676,7 +2680,7 @@
                   "notable": true,
                   "requires": [
                     "canTurnaroundAimCancel",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"thornHits": 180}
                   ],
                   "note": "Wiggle through the thorns. It is a long wiggle with a lot of thorn hits."

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -1039,7 +1039,8 @@
                       "type": "contact",
                       "hits": 1
                     }}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen"
                 }
               ]
             }
@@ -1953,7 +1954,7 @@
                       {"and": [
                         {"ammo": { "type": "Super", "count": 1 }},
                         "canDodgeWhileShooting",
-                        "canBePatient"
+                        "canBeVeryPatient"
                       ]}
                     ]}
                   ],

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -158,7 +158,8 @@
                       "usedTiles": 0.5,
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
-                    }}
+                    }},
+                    "canBeVeryPatient"
                   ],
                   "note": "6 screen X-Ray climb, and global Zeelas are still active even off camera."
                 }
@@ -918,6 +919,7 @@
                       "useFrames": 200
                     }}
                   ],
+                  "note": "Climb up 1 screen.",
                   "devNote": [
                     "Normally, an XRayClimb's resetRoom has mustStayPut true, but because node 5 is configured to spawn at 14, Samus will be expected to visit 14 before 5 when setting up.",
                     "This is a technicality based on the spawnAt at 14, since in reality Samus just gets doorstuck at 5 immediately in this scenario.",
@@ -1072,7 +1074,8 @@
                         }}
                       ]}
                     ]}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 }
               ]
             }
@@ -1921,7 +1924,8 @@
                         }}
                       ]}
                     ]}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 }
               ]
             },
@@ -2583,7 +2587,8 @@
                       "usedTiles": 0.5,
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
-                    }}
+                    }},
+                    "canBeVeryPatient"
                   ],
                   "note": "Climb up 8 screens."
                 }

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -245,7 +245,8 @@
             "This will force Samus to stand up, briefly clipping into the wall above.",
             "Immediately freeze the Beetom inside the wall, by buffering a shot during the reserve trigger.",
             "Use a Ripper to get knocked back onto the frozen Beetom.",
-            "This will clip Samus one pixel left into the wall, making it possible to X-ray climb."
+            "This will clip Samus one pixel left into the wall, making it possible to X-ray climb.",
+            "X-ray climb up 2 screens."
           ]
         }
       ],
@@ -293,7 +294,14 @@
                   "note": [
                     "Gain R-mode while entering the room.",
                     "Use the respawning bugs to refill reserve energy.",
-                    "Get grabbed by the Beetom and carry it to the 4-tile high gap one screen above the bottom-left door."
+                    "Get grabbed by the Beetom and carry it to the 4-tile high gap one screen above the bottom-left door.",
+                    "Position Samus one pixel to the right of being against the wall.",
+                    "Jump and aim down, reaching the ceiling at the same time that reserves are triggered.",
+                    "This will force Samus to stand up, briefly clipping into the wall above.",
+                    "Immediately freeze the Beetom inside the wall, by buffering a shot during the reserve trigger.",
+                    "Use a Ripper to get knocked back onto the frozen Beetom.",
+                    "This will clip Samus one pixel left into the wall, making it possible to X-ray climb.",
+                    "X-ray climb up 2 screens."
                   ],
                   "devNote": "Given the ability to freeze enemies, nodes 1 and 5 are freely connected, so lumping these into one strat is sound."
                 }
@@ -384,7 +392,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "This is a short climb of only a few tiles."
                 }
               ]
             }
@@ -615,13 +624,16 @@
                   ],
                   "reusableRoomwideNotable": "Red Tower R-Mode Frozen Beetom X-Ray Climb",
                   "note": [
+                    "Gain R-mode while entering the room.",
+                    "Use the respawning bugs to refill reserve energy.",        
                     "Get grabbed by the Beetom and carry it to the 4-tile high gap one screen above the bottom-left door.",
                     "Position Samus one pixel to the right of being against the wall.",
                     "Jump and aim down, reaching the ceiling at the same time that reserves are triggered.",
                     "This will force Samus to stand up, briefly clipping into the wall above.",
                     "Immediately freeze the Beetom inside the wall, by buffering a shot during the reserve trigger.",
                     "Use a Ripper to get knocked back onto the frozen Beetom.",
-                    "This will clip Samus one pixel left into the wall, making it possible to X-ray climb."
+                    "This will clip Samus one pixel left into the wall, making it possible to X-ray climb.",
+                    "X-ray climb up 2 screens."
                   ]
                 }
               ]
@@ -1698,7 +1710,8 @@
                         }}
                       ]}
                     ]}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 }
               ]
             }

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -698,7 +698,8 @@
                       "mode": "direct",
                       "artificialMorph": false
                     }},
-                    "canXRayClimb"
+                    "canXRayClimb",
+                    "canBePatient"
                   ],
                   "note": "Climb up 3 screens."
                 },
@@ -713,8 +714,10 @@
                       "framesRemaining": 1
                     }},
                     "canShinesparkDeepStuck",
-                    "canXRayClimb"
-                  ]
+                    "canXRayClimb",
+                    "canBePatient"
+                  ],
+                  "note": "Climb up 3 screens."
                 }
               ]
             },
@@ -1536,7 +1539,7 @@
                   "requires": [
                     "f_ZebesAwake",
                     {"or": [
-                      "canBePatient",
+                      "canBeVeryPatient",
                       {"ammo": {"type": "Super", "count": 1}}
                     ]}
                   ],
@@ -1554,7 +1557,7 @@
               }},
               "f_ZebesAwake",
               {"or": [
-                "canBePatient",
+                "canBeVeryPatient",
                 {"ammo": {"type": "Super", "count": 1}}
               ]}
             ],
@@ -1923,7 +1926,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "This is a short climb of only a few tiles."
                 },
                 {
                   "name": "G-Mode Morph out of Save",
@@ -2122,7 +2126,7 @@
                     "Morph",
                     "canTrickyUseFrozenEnemies",
                     {"or": [
-                       "canBePatient",
+                       "canBeVeryPatient",
                        {"ammo": {"type": "Super", "count": 1}}
                      ]},
                     {"or": [
@@ -2144,7 +2148,7 @@
                   "name": "Ceiling Clip Alcatraz Escape",
                   "notable": false,
                   "requires": [
-                    "canBePatient",
+                    "canBeVeryPatient",
                     "canPreciseCeilingClip",
                     "canTrickyUseFrozenEnemies",
                     "Morph",
@@ -3050,9 +3054,10 @@
                           "useFrames": 200
                         }}
                       ]}
-                    ]}
+                    ]},
+                    "canBeVeryPatient"
                   ],
-                  "note": "Climb 7 screens."
+                  "note": "Climb up 7 screens."
                 },
                 {
                   "name": "G-Mode Morph",
@@ -3078,7 +3083,7 @@
                   "notable": true,
                   "requires": [
                     "h_canArtificialMorphIBJ",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"comeInWithGMode": {
                       "fromNodes": [4],
                       "mode": "any",
@@ -3210,7 +3215,7 @@
                       "artificialMorph": true
                     }},
                     "h_canArtificialMorphIBJ",
-                    "canBePatient"
+                    "canBeVeryPatient"
                   ],
                   "reusableRoomwideNotable": "Climb G-Mode Morph Insane IBJ to Top",
                   "note": [
@@ -5258,9 +5263,10 @@
                       "usedTiles": 0.5,
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
-                    }}
+                    }},
+                    "canBeVeryPatient"
                   ],
-                  "note": "Climb 7 map tiles."
+                  "note": "Climb up 7 screens."
                 }
               ]
             },
@@ -5368,7 +5374,7 @@
                       "h_canLeftDoorXRayClimb"
                     ]},
                     {"ammo": { "type": "PowerBomb", "count": 9 }},
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"comeInWithGMode": {
                       "fromNodes": [2],
                       "mode": "direct",
@@ -5402,7 +5408,7 @@
                   "notable": true,
                   "requires": [
                     "h_canArtificialMorphCeilingBombJump",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"comeInWithGMode": {
                       "fromNodes": [2],
                       "mode": "any",

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -1202,7 +1202,8 @@
                       "canWalljump"
                     ]},
                     "canXRayClimb"
-                  ]
+                  ],
+                  "note": "Climb up 2 screens."
                 },
                 {
                   "name": "Shinespark Deep Stuck X-Ray Climb",
@@ -1216,7 +1217,8 @@
                     }},
                     "canShinesparkDeepStuck",
                     "canXRayClimb"
-                  ]
+                  ],
+                  "note": "Climb up 2 screens."
                 }
               ],
               "devNote": [
@@ -1310,8 +1312,10 @@
                       "mode": "direct",
                       "artificialMorph": false
                     }},
-                    "canXRayClimb"
-                  ]
+                    "canXRayClimb",
+                    "canBePatient"
+                  ],
+                  "note": "Climb up 3 screens."
                 },
                 {
                   "name": "Shinespark Deep Stuck X-Ray Climb",
@@ -1324,8 +1328,10 @@
                       "framesRemaining": 1
                     }},
                     "canShinesparkDeepStuck",
-                    "canXRayClimb"
-                  ]
+                    "canXRayClimb",
+                    "canBePatient"
+                  ],
+                  "note": "Climb up 3 screens."
                 }
               ]
             },
@@ -1643,7 +1649,8 @@
                       "artificialMorph": false
                     }},
                     "canXRayClimb"
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 },
                 {
                   "name": "Shinespark Deep Stuck X-Ray Climb",
@@ -1657,7 +1664,8 @@
                     }},
                     "canShinesparkDeepStuck",
                     "canXRayClimb"
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 }
               ]
             }
@@ -1813,7 +1821,7 @@
                   "notable": false,
                   "requires": [
                     "canUseEnemies",
-                    "canBePatient"
+                    "canBeVeryPatient"
                   ]
                 }
               ]
@@ -2019,7 +2027,7 @@
                     "SpaceJump",
                     {"or": [
                       "h_canCeilingBombJump",
-                      "canBePatient"
+                      "canBeVeryPatient"
                     ]}
                   ],
                   "note": "The crumble block is the leftmost flat ceiling tile."

--- a/region/crateria/west.json
+++ b/region/crateria/west.json
@@ -443,7 +443,7 @@
               "id": 9,
               "strats": [
                 {
-                  "name": "Xray Climb",
+                  "name": "X-Ray Climb",
                   "notable": false,
                   "requires": [
                     "h_canLeftDoorXRayClimb",
@@ -470,10 +470,11 @@
                             "Missile",
                             "Super"
                           ] } }
-                     ]}
+                     ]},
+                     "canBePatient"
                   ],
                   "note": [
-                    "Xray climb 2 screen lengths and until the camera shows Samus' helmet on the bottom of the screen.",
+                    "X-Ray climb about 2.5 screen lengths, until the camera shows Samus' helmet on the bottom of the screen.",
                     "Shoot up to clear the shot blocks and resume climbing until you can walk out to the right.",
                     "Fix the camera by shooting the floor shot block and jumping down.",
                     "The pirate will attack while climbing past it."
@@ -535,7 +536,7 @@
               "id": 9,
               "strats": [
                 {
-                  "name": "Xray Climb",
+                  "name": "X-Ray Climb",
                   "notable": false,
                   "requires": [
                     "h_canRightDoorXRayClimb",
@@ -576,10 +577,11 @@
                           "Super"
                         ]
                       }}
-                    ]}
+                    ]},
+                    "canBePatient"
                   ],
                   "note": [
-                    "Xray climb 2 screen lengths and until the camera shows Samus' helmet on the bottom of the screen.",
+                    "X-Ray climb about 2.5 screen lengths, until the camera shows Samus' helmet on the bottom of the screen.",
                     "Shoot up to clear the shot blocks and resume climbing until you can walk out to the left.",
                     "Fix the camera by shooting the floor shot block and jumping down.",
                     "The pirate will attack while climbing past it."
@@ -667,7 +669,7 @@
                     "canXRayClimb",
                     "Morph",
                     "canWallIceClip",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"enemyDamage": { "enemy": "Beetom", "hits": 25, "type": "contact"}},
                     {"or": [
                       { "resetRoom": { "nodes": [ 1, 2, 3, 4 ], "nodesToAvoid": [ 5 ] } },

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -811,7 +811,8 @@
                     }},
                     "canXRayClimb",
                     {"heatFrames": 1600}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 },
                 {
                   "name": "Shinespark Deep Stuck X-Ray Climb",
@@ -825,7 +826,8 @@
                     "canShinesparkDeepStuck",
                     "canXRayClimb",
                     {"heatFrames": 1600}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 }
               ]
             },
@@ -4139,7 +4141,7 @@
                   "notable": false,
                   "requires": [
                     "h_heatProof",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"enemyKill":{
                       "enemies": [[ "Kihunter (red)", "Kihunter (red)" ]]
                     }}
@@ -4448,7 +4450,8 @@
                     }},
                     {"heatFrames": 2800}
                   ],
-                  "note": [
+                  "note": "Climb up 2 screens.",
+                  "devNote": [
                     "Ever so slightly shorter than the long climb in Screw Attack Room (1 tile), we'll just put the same value.",
                     "Heat frames split into the actual climb and the setup in the adjacent room."
                   ]
@@ -5494,7 +5497,7 @@
                       "requires": [
                         "h_heatProof",
                         "canDodgeWhileShooting",
-                        "canBePatient",
+                        "canBeVeryPatient",
                         {"or": [
                           "Spazer",
                           "Charge"

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -750,7 +750,7 @@
                   "requires": [
                     "h_heatProof",
                     "Charge",
-                    "canBePatient"
+                    "canBeVeryPatient"
                   ],
                   "reusableRoomwideNotable": "Golden Torizo Safe Spot",
                   "note": "Stand in the safe spot and fire Charge shots into GT."
@@ -904,7 +904,7 @@
                       "type": "contact",
                       "hits": 2
                     }},
-                    "canBePatient"
+                    "canBeVeryPatient"
                   ],
                   "note": [
                     "Killing Golden Torizo only with missiles using enemy state manipulation to get missiles to connect.",
@@ -1766,7 +1766,8 @@
                     }},
                     {"heatFrames": 1000}
                   ],
-                  "note": "Heat frames split into the actual climb and the setup in the adjacent room."
+                  "note": "Climb up half a screen.",
+                  "devNote": "Heat frames split into the actual climb and the setup in the adjacent room."
                 }
               ],
               "note": "Shinespark and XRayClimb have a direct link. Other strats should go 1 -> 4 -> 2."
@@ -1816,7 +1817,8 @@
                     }},
                     {"heatFrames": 2800}
                   ],
-                  "note": "Heat frames split into the actual climb and the setup in the adjacent room."
+                  "note": "Climb up 2 screens.",
+                  "devNote": "Heat frames split into the actual climb and the setup in the adjacent room."
                 }
               ],
               "note": "Shinespark and XRayClimb have a direct link. Other strats should go 1 -> 4 -> 2 -> 3."
@@ -1964,7 +1966,8 @@
                     ]},
                     {"heatFrames": 1600}
                   ],
-                  "note": "Heat frames split into the actual climb and the setup in the adjacent room."
+                  "note": "Climb up 1 screen.",
+                  "devNote": "Heat frames split into the actual climb and the setup in the adjacent room."
                 }
               ]
             },

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -140,7 +140,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "This is a short climb, only a few tiles."
                 }
               ],
               "note": "This link is only for the X-Ray climb, which skips the junction altogether."
@@ -191,7 +192,8 @@
                         }}
                       ]}
                     ]}
-                  ]
+                  ],
+                  "note": "This is a short climb, only a few tiles."
                 }
               ],
               "note": "This link is only for the X-Ray climb, which skips the junction altogether."
@@ -2365,9 +2367,13 @@
                       "usedTiles": 0.5,
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
-                    }}
+                    }},
+                    "canBePatient"
                   ],
-                  "note": "This climb is left side of the left room - the room with the breakable grapple block."
+                  "note": [
+                    "This climb is from the left side of the left room, the room with the breakable grapple block.",
+                    "Climb up 3 screens."
+                  ]
                 }
               ],
               "note": "This link is only for the X-Ray climb, which skips the junction altogether."
@@ -2439,9 +2445,13 @@
                           "useFrames": 200
                         }}
                       ]}
-                    ]}
+                    ]},
+                    "canBePatient"
                   ],
-                  "note": "This climb is right side of the left room - the room with the breakable grapple block."
+                  "note": [
+                    "This climb is right side of the left room - the room with the breakable grapple block.",
+                    "Climb up 3 screens."
+                  ]
                 }
               ],
               "note": "This link is only for the X-Ray climb, which skips the junction altogether."

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -924,6 +924,7 @@
                     }}
                   ],
                   "note": [
+                    "Climb up 1 screen.",
                     "Aim to end this XRay climb when Samus is visually near but not above the top of the left side door.",
                     "Fall out of the wall by turning to the right, from a crouch if possible.",
                     "This XRay climb has a window of 4 crouches, but with a way to break bomb blocks it can be ended earlier."
@@ -1018,7 +1019,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 },
                 {
                   "name": "Suitless Jump Assist",
@@ -1725,7 +1727,8 @@
                         }}
                       ]}
                     ]}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 }
               ]
             }
@@ -2440,7 +2443,7 @@
                   "notable": true,
                   "requires": [
                     "h_canNavigateUnderwater",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"enemyKill": {
                       "enemies": [ [ "Reverse Botwoon 1" ], [ "Reverse Botwoon 2" ] ],
                       "explicitWeapons": [ "Super" ]
@@ -3973,7 +3976,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 },
                 {
                   "name": "Cross Room Jump",
@@ -5605,7 +5609,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "Climb up 2 screens."
                 },
                 {
                   "name": "Suitless Jump Assist",
@@ -6391,7 +6396,8 @@
                      "overrideRunwayRequirements": true,
                      "useFrames": 200
                    }}
-                  ]
+                  ],
+                  "note": "Climb up a little less than 1 screen."
                 },
                 {
                   "name": "Cross Room Jump",

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -791,10 +791,10 @@
                   "name": "Get Hit By Menu",
                   "notable": false,
                   "requires": [
-                    "canBePatient",
+                    "canBeVeryPatient",
                     "canManipulateMellas"
                   ],
-                  "devNote": "FIXME Add details on how this works and check if it actually requires canBePatient."
+                  "devNote": "FIXME Add details on how this works and check if it actually requires canBeVeryPatient."
                 }
               ]
             }
@@ -2126,7 +2126,7 @@
                         ]
                       }},
                       {"and": [
-                        "canBePatient",
+                        "canBeVeryPatient",
                         {"enemyKill":{"enemies": [ [ "Choot" ] ]}}
                       ]}
                     ]}
@@ -4286,7 +4286,7 @@
                       {"ammo": {"type": "PowerBomb","count": 2}},
                       {"and": [
                         "h_canArtificialMorphStaggeredIBJ",
-                        "canBePatient"
+                        "canBeVeryPatient"
                       ]}
                     ]}
                   ],
@@ -4426,7 +4426,7 @@
                 {
                   "name": "Get Hit By Puyo",
                   "notable": false,
-                  "requires": [ "canBePatient" ],
+                  "requires": [ "canBeVeryPatient" ],
                   "note": "It takes approximately 3 minutes for the Puyos to wake up and get to the doorway."
                 }
               ]
@@ -4434,7 +4434,7 @@
           ],
           "gModeImmobile": {
             "requires": [
-              "canBePatient",
+              "canBeVeryPatient",
               {"enemyDamage": {
                 "enemy": "Puyo",
                 "type": "contact",

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -1483,7 +1483,8 @@
                         }}
                       ]}
                     ]}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 }
               ],
               "note": "This link is only for the cross room jump and X-ray climb. Other strats should go 2 -> 8 -> 3."
@@ -1521,7 +1522,7 @@
                       "h_canArtificialMorphJumpIntoIBJ",
                       "canDoubleBombJump",
                       "canStaggeredIBJ",
-                      "canBePatient"
+                      "canBeVeryPatient"
                     ]}
                   ],
                   "note": "This is a long climb, and getting around the fish under the missiles can be tricky or slow."
@@ -1616,7 +1617,7 @@
                       ]},
                       "canDoubleBombJump",
                       "canStaggeredIBJ",
-                      "canBePatient",
+                      "canBeVeryPatient",
                       {"enemyKill": {
                         "enemies": [ [ "Skultera" ] ],
                         "explicitWeapons": [ "PowerBomb" ]
@@ -1625,7 +1626,7 @@
                     {"or":[
                       "SpringBall",
                       "h_canArtificialMorphCeilingBombJump",
-                      "canBePatient"
+                      "canBeVeryPatient"
                     ]}
                   ],
                   "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
@@ -1656,7 +1657,7 @@
                     ]},
                     {"or":[
                       "SpringBall",
-                      "canBePatient",
+                      "canBeVeryPatient",
                       {"and":[
                         "Gravity",
                         "h_canCeilingBombJump",
@@ -1687,7 +1688,7 @@
                       "h_canArtificialMorphJumpIntoIBJ",
                       "canDoubleBombJump",
                       "canStaggeredIBJ",
-                      "canBePatient",
+                      "canBeVeryPatient",
                       {"enemyKill": {
                         "enemies": [ [ "Skultera" ] ],
                         "explicitWeapons": [ "PowerBomb" ]
@@ -1792,7 +1793,7 @@
                   "requires": [
                     "canSuitlessMaridia",
                     "canCrazyCrabClimb",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"ammo": { "type": "Super", "count": 1 }}
                   ],
                   "reusableRoomwideNotable": "Main Street Crab Climb with Only Ice and Supers",
@@ -1810,7 +1811,7 @@
                   "requires": [
                     "canSuitlessMaridia",
                     "canCrazyCrabClimb",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"or": [
                       "canSunkenTileWideWallClimb",
                       "canTrickyJump"
@@ -1987,7 +1988,7 @@
                       "SpringBall",
                       {"and":[
                         "Morph",
-                        "canBePatient"
+                        "canBeVeryPatient"
                       ]},
                       {"and":[
                         "Gravity",
@@ -1997,7 +1998,7 @@
                       {"and":[
                         "Gravity",
                         "h_canArtificialMorphIBJ",
-                        "canBePatient"
+                        "canBeVeryPatient"
                       ]}
                     ]}
                   ],
@@ -2272,7 +2273,7 @@
                     "canSuitlessMaridia",
                     "canCrazyCrabClimb",
                     "canSunkenTileWideWallClimb",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     "canMidairWiggle",
                     {"obstaclesNotCleared": ["A"]}
                   ],
@@ -2578,7 +2579,7 @@
                       ]},
                       "canDoubleBombJump",
                       "canStaggeredIBJ",
-                      "canBePatient",
+                      "canBeVeryPatient",
                       {"enemyKill": {
                         "enemies": [ [ "Skultera" ] ],
                         "explicitWeapons": [ "PowerBomb" ]
@@ -2587,7 +2588,7 @@
                     {"or":[
                       "SpringBall",
                       "h_canArtificialMorphCeilingBombJump",
-                      "canBePatient"
+                      "canBeVeryPatient"
                     ]}
                   ],
                   "reusableRoomwideNotable": "Main Street G-Mode Overload Speed Blocks then use Frozen Crab",
@@ -2618,7 +2619,7 @@
                     ]},
                     {"or":[
                       "SpringBall",
-                      "canBePatient",
+                      "canBeVeryPatient",
                       {"and":[
                         "Gravity",
                         "h_canCeilingBombJump",
@@ -2649,7 +2650,7 @@
                       "h_canArtificialMorphJumpIntoIBJ",
                       "canDoubleBombJump",
                       "canStaggeredIBJ",
-                      "canBePatient",
+                      "canBeVeryPatient",
                       {"enemyKill": {
                         "enemies": [ [ "Skultera" ] ],
                         "explicitWeapons": [ "PowerBomb" ]
@@ -2862,7 +2863,7 @@
                       "canSpringBallJumpMidAir"
                     ]},
                     "canUseFrozenEnemies",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"obstaclesNotCleared": ["A"]}
                   ],
                   "note": "Wait for the global crab to come around and freeze it to get up to the second ledge on the right.",
@@ -2905,7 +2906,7 @@
                   "name": "Main Street Top Crab Climb with Supers",
                   "notable": true,
                   "requires": [
-                    "canBePatient",
+                    "canBeVeryPatient",
                     "canSuitlessMaridia",
                     "canCrazyCrabClimb",
                     "Super",
@@ -2929,7 +2930,7 @@
                   "name": "Main Street Ice Only Top Crab Climb",
                   "notable": true,
                   "requires": [
-                    "canBePatient",
+                    "canBeVeryPatient",
                     "canSuitlessMaridia",
                     "canCrazyCrabClimb",
                     "canTrickyJump",
@@ -5952,7 +5953,7 @@
                     "canSuitlessMaridia",
                     "canCrazyCrabClimb",
                     "canTrickyJump",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"ammo": { "type": "Super", "count": 1 }}
                   ],
                   "obstacles": [
@@ -5982,7 +5983,7 @@
                     "canSuitlessMaridia",
                     "canCrazyCrabClimb",
                     "canTrickyJump",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"ammo": { "type": "Super", "count": 1 }}
                   ],
                   "obstacles": [
@@ -6461,7 +6462,7 @@
                     "canSuitlessMaridia",
                     "canCrazyCrabClimb",
                     "canTrickyJump",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     "Super",
                     {"ammo": {
                       "type": "Super",
@@ -8698,7 +8699,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 },
                 {
                   "name": "Suitless HiJump Crab Hole Ascent",
@@ -8871,7 +8873,8 @@
                         }}
                       ]}
                     ]}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 },
                 {
                   "name": "Cross Room Jump",

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -163,7 +163,7 @@
                   "notable": true,
                   "requires": [
                     "canDodgeWhileShooting",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     {"or": [
                       {"ammo": { "type": "Missile", "count": 2 }},
                       {"ammo": { "type": "Super", "count": 2 }}
@@ -1804,7 +1804,7 @@
                   "requires": [
                     "canUseFrozenEnemies",
                     "canManipulateMellas",
-                    "canBePatient",
+                    "canBeVeryPatient",
                     "canConsecutiveWalljump",
                     {"or":[
                       {"obstaclesCleared": ["B"]},
@@ -1999,7 +1999,7 @@
                   ]
                 },
                 {
-                  "name": "XRay Climb",
+                  "name": "X-Ray Climb",
                   "notable": false,
                   "requires": [
                     "h_canRightDoorXRayClimb",
@@ -2026,7 +2026,8 @@
                         }}
                       ]}
                     ]}
-                  ]
+                  ],
+                  "note": "Climb up 2 screens."
                 }
               ]
             },

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -2355,7 +2355,8 @@
                       "useFrames": 200
                     }}
                   ]
-                }
+                },
+                "note": "Climb up 1 screen."
               ],
               "note": "This link is only for the X-Ray climb, which skips the junction altogether."
             },
@@ -2392,7 +2393,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "Climb up 2 screens."
                 }
               ],
               "note": "This link is only for the X-Ray climb, which skips the junction altogether."
@@ -2440,7 +2442,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "Climb up 1 screen."
                 }
               ],
               "note": "This link is only for the X-Ray climb, which skips the junction altogether."

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -2354,9 +2354,9 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
-                },
-                "note": "Climb up 1 screen."
+                  ],
+                  "note": "Climb up 1 screen."
+                }
               ],
               "note": "This link is only for the X-Ray climb, which skips the junction altogether."
             },

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -1087,7 +1087,8 @@
                       "overrideRunwayRequirements": true,
                       "useFrames": 200
                     }}
-                  ]
+                  ],
+                  "note": "Climb up 2 screens."
                 }
               ]
             },
@@ -2576,9 +2577,11 @@
                         }}
                       ]}
                     ]},
-                    {"heatFrames": 4000}
+                    {"heatFrames": 4000},
+                    "canBePatient"
                   ],
-                  "note": "Heat frames split into the actual climb and the setup in the adjacent room."
+                  "note": "Climb up 3 screens.",
+                  "devNote": "Heat frames split into the actual climb and the setup in the adjacent room."
                 }
               ]
             },

--- a/region/tourian/main.json
+++ b/region/tourian/main.json
@@ -4203,7 +4203,7 @@
                     "h_canArtificialMorphIBJ",
                     {"or": [
                       "h_canArtificialMorphCeilingBombJump",
-                      "canBePatient"
+                      "canBeVeryPatient"
                     ]}
                   ],
                   "note": "Take the bottom path and place many bombs near the speed blocks to overload PLMs and go through them."

--- a/tech.json
+++ b/tech.json
@@ -8,7 +8,14 @@
         {
           "name": "canBePatient",
           "requires": [],
-          "note": "Executing a strat that requires waiting or doing the same thing over and over again for over 3 minutes, even with good execution."
+          "note": "Executing a strat that requires waiting or doing the same thing over and over again for a substantial amount of time, potentially more than 1.5 minutes, even with good execution.",
+          "extensionTechs": [
+            {
+                "name": "canBeVeryPatient",
+                "requires": ["canBePatient"],
+                "note": "Executing a strat that requires waiting or doing the same thing over and over again for a long time, potentially more than 3 minutes, even with good execution."
+            }
+          ]
         },
         {
           "name": "canPrepareForNextRoom",


### PR DESCRIPTION
The definitions are roughly

canBePatient: >1.5 minutes, translating to >2 screens of X-ray climbing
canBeVeryPatient: >3 minutes, translating to >4 screens of X-ray climbing

For Map Rando, the plan is to have canBePatient in Extreme and canBeVeryPatient in Insane. And then X-ray climbs of 2 or fewer screens can be put back into logic on Expert settings.

The wording in the definitions of canBe(Very)Patient is deliberately made a little more vague, to allow us some wiggle room for certain strats, particularly non-respawning enemy farms, where the amount of time required is variable and we don't intend to model it exactly.

This is intended only as a starting point to introduce the new patience tech split. It is expected that follow-up pull requests will be needed to add "canBePatient" in more places.