### PR TITLE
Farms in Central Crateria

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2374,6 +2374,42 @@
                   "requires": []
                 }
               ]
+            },
+            {
+              "id": 8,
+              "strats": [
+                {
+                  "name": "Basic Farm",
+                  "notable": false,
+                  "requires": [
+                    "f_ZebesAwake",
+                    {"resetRoom": {
+                      "nodes": [3, 4, 6, 7],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Energy", "Missile"]}
+                  ],
+                  "devNote": "FIXME: Other nodes could be used to reset the room, with additional requirements."
+                },
+                {
+                  "name": "Very Patient Farm",
+                  "notable": false,
+                  "requires": [
+                    "canBeVeryPatient",
+                    "f_ZebesAwake",
+                    {"resetRoom": {
+                      "nodes": [3, 4, 6, 7],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
+                  ],
+                  "note": [
+                    "The three Skrees each have a 2% Super and 2% Power Bomb drop rate.",
+                    "The Geemers each have a 2% Super drop rate."
+                  ],
+                  "devNote": "FIXME: Other nodes could be used to reset the room, with additional requirements."
+                }
+              ]
             }
           ]
         }
@@ -3490,6 +3526,27 @@
                   "requires": []
                 }
               ]
+            },
+            {
+              "id": 6,
+              "strats": [
+                {
+                  "name": "Basic Farm",
+                  "notable": false,
+                  "requires": [
+                    "f_ZebesAwake",
+                    {"resetRoom": {
+                      "nodes": [1, 5],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Energy", "Missile"]}
+                  ],
+                  "devNote": [
+                    "The Space Pirates (wall) drop Supers and Power Bombs each at a 0.4% rate, too low to put into logic.",
+                    "FIXME: Other nodes could be used to reset the room, with additional requirements."
+                  ]
+                }
+              ]
             }
           ]
         }
@@ -3804,6 +3861,39 @@
               ]
             },
             {
+              "id": 2,
+              "strats": [
+                {
+                  "name": "Basic Farm",
+                  "notable": false,
+                  "requires": [
+                    "Morph",
+                    "Missile",
+                    {"resetRoom": {
+                      "nodes": [1, 2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Energy", "Missile"]}
+                  ]
+                },
+                {
+                  "name": "Patient Farm",
+                  "notable": false,
+                  "requires": [
+                    "Morph",
+                    "Missile",
+                    "canBePatient",
+                    {"resetRoom": {
+                      "nodes": [1, 2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Super", "PowerBomb"]}
+                  ],
+                  "note": "The 4 standing Space Pirates each have an 8% Super drop rate and 4% Power Bomb drop rate."
+                }
+              ]
+            },
+            {
               "id": 3,
               "strats": [
                 {
@@ -4066,6 +4156,37 @@
           "from": 1,
           "to": [
             {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Basic Farm",
+                  "notable": false,
+                  "requires": [
+                    {"resetRoom": {
+                      "nodes": [1, 2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Energy", "Missile"]}
+                  ]
+                },
+                {
+                  "name": "Patient Farm",
+                  "notable": false,
+                  "requires": [
+                    "canBePatient",
+                    {"resetRoom": {
+                      "nodes": [1, 2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Super"]}
+                  ],
+                  "note": [
+                    "There are 12 Mellows, each with a 2% Super drop rate."
+                  ]
+                }
+              ]
+            },
+            {
               "id": 2,
               "strats": [
                 {
@@ -4192,6 +4313,38 @@
         {
           "from": 1,
           "to": [
+            {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Basic Farm",
+                  "notable": false,
+                  "requires": [
+                    {"resetRoom": {
+                      "nodes": [1, 2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Energy", "Missile"]}
+                  ]
+                },
+                {
+                  "name": "Very Patient Farm",
+                  "notable": false,
+                  "requires": [
+                    "canBeVeryPatient",
+                    {"resetRoom": {
+                      "nodes": [1, 2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Super", "PowerBomb"]}
+                  ],
+                  "note": [
+                    "The Reo has a 4% Super and 4% Power Bomb drop rate.",
+                    "Each of the 3 Mellows has a 2% Super drop rate."
+                  ]
+                }
+              ]
+            },
             {
               "id": 2,
               "strats": [
@@ -4859,6 +5012,35 @@
         {
           "from": 1,
           "to": [
+            {
+              "id": 1,
+              "strats": [
+                {
+                  "name": "Basic Farm",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "canDodgeWhileShooting",
+                      "Wave",
+                      "Ice",
+                      "Spazer",
+                      "Plasma"
+                    ]},
+                    {"resetRoom": {
+                      "nodes": [1],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["PowerBomb"]}
+                  ],
+                  "note": [
+                    "The Alcoons have a 99.5% Power Bomb drop rate, after which they only drop small energy."
+                  ],
+                  "devNote": [
+                    "The energy dropped is too low even for a very patient strat, considering worst-case scenarios such as a neighboring heated room, no beams, and the possible need to refill several tanks worth of energy."
+                  ]
+                }
+              ]
+            },
             {
               "id": 2,
               "strats": [

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -3799,7 +3799,7 @@
                       "nodes": [1, 2],
                       "mustStayPut": false
                     }},
-                    {"refill": ["Super", "PowerBomb"]}
+                    {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
                   ],
                   "note": "The 4 standing Space Pirates each have an 8% Super drop rate and 4% Power Bomb drop rate."
                 }
@@ -4076,7 +4076,7 @@
                       "nodes": [1, 2],
                       "mustStayPut": false
                     }},
-                    {"refill": ["Super"]}
+                    {"refill": ["Energy", "Missile", "Super"]}
                   ],
                   "note": [
                     "There are 12 Mellows, each with a 2% Super drop rate."
@@ -4234,7 +4234,7 @@
                       "nodes": [1, 2],
                       "mustStayPut": false
                     }},
-                    {"refill": ["Super", "PowerBomb"]}
+                    {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
                   ],
                   "note": [
                     "The Reo has a 4% Super and 4% Power Bomb drop rate.",

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2344,24 +2344,6 @@
                     {"refill": ["Energy", "Missile"]}
                   ],
                   "devNote": "FIXME: Other nodes could be used to reset the room, with additional requirements."
-                },
-                {
-                  "name": "Very Patient Farm",
-                  "notable": false,
-                  "requires": [
-                    "canBeVeryPatient",
-                    "f_ZebesAwake",
-                    {"resetRoom": {
-                      "nodes": [3, 4, 6, 7],
-                      "mustStayPut": false
-                    }},
-                    {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
-                  ],
-                  "note": [
-                    "The three Skrees each have a 2% Super and 2% Power Bomb drop rate.",
-                    "The Geemers each have a 2% Super drop rate."
-                  ],
-                  "devNote": "FIXME: Other nodes could be used to reset the room, with additional requirements."
                 }
               ]
             }
@@ -3787,21 +3769,6 @@
                     }},
                     {"refill": ["Energy", "Missile"]}
                   ]
-                },
-                {
-                  "name": "Patient Farm",
-                  "notable": false,
-                  "requires": [
-                    "Morph",
-                    "Missile",
-                    "canBePatient",
-                    {"resetRoom": {
-                      "nodes": [1, 2],
-                      "mustStayPut": false
-                    }},
-                    {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
-                  ],
-                  "note": "The 4 standing Space Pirates each have an 8% Super drop rate and 4% Power Bomb drop rate."
                 }
               ]
             },
@@ -4066,21 +4033,6 @@
                     }},
                     {"refill": ["Energy", "Missile"]}
                   ]
-                },
-                {
-                  "name": "Patient Farm",
-                  "notable": false,
-                  "requires": [
-                    "canBePatient",
-                    {"resetRoom": {
-                      "nodes": [1, 2],
-                      "mustStayPut": false
-                    }},
-                    {"refill": ["Energy", "Missile", "Super"]}
-                  ],
-                  "note": [
-                    "There are 12 Mellows, each with a 2% Super drop rate."
-                  ]
                 }
               ]
             },
@@ -4223,22 +4175,6 @@
                       "mustStayPut": false
                     }},
                     {"refill": ["Energy", "Missile"]}
-                  ]
-                },
-                {
-                  "name": "Very Patient Farm",
-                  "notable": false,
-                  "requires": [
-                    "canBeVeryPatient",
-                    {"resetRoom": {
-                      "nodes": [1, 2],
-                      "mustStayPut": false
-                    }},
-                    {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
-                  ],
-                  "note": [
-                    "The Reo has a 4% Super and 4% Power Bomb drop rate.",
-                    "Each of the 3 Mellows has a 2% Super drop rate."
                   ]
                 }
               ]

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -69,7 +69,8 @@ def process_keyvalue(k, v):
         "obstacleType",     # validated by schema
         "physics",          # validated by schema
         "utility",          # validated by schema
-        "resourceCapacity"  # validated by schema
+        "resourceCapacity", # validated by schema
+        "refill",           # validated by schema
     ]
 
     # check if it's a key we want to check


### PR DESCRIPTION
This PR starts with a small number of rooms, to get feedback on the approach before doing more.

To decide which patience tech (if any) to require for a farm, I try to estimate roughly the expected amount of time to collect a certain amount of the given resource, and compare that with thresholds of 1.5 minutes (canBePatient), 3 minutes (canBeVeryPatient), and 12 minutes (not in logic):

Energy: 100 (a full ETank)
Missile: 2
Super: 2
Power Bomb: 2

For Missiles they come in units of 2 anyway, while for Supers it's possible they will be for a gate glitch so a second one is for leniency. For Power Bombs it's because there's a significant possibility of needing two to break blocks in two different places. It's all a little arbitrary but the goal is just to get things roughly on the right scale for the amount of time/patience required.

For now, to handle the worst-case scenario, I'm assuming an expected loss of 10 energy per cycle in case the neighboring room is heated. We could add requirements for a non-heated neighboring room in cases where this would bring a strat into a lower patience tier, but that's a possible refinement for later.

Considering a scenario where you spend 8 seconds in-room to do the farm, plus 7 seconds to reset the room (let's assume no fast doors), for a total of 15 seconds cycle time, the numbers above translate into the following thresholds for the total drop rate on Supers or Power Bombs (summed over all the enemies killed per cycle):

No patience required: 34% or more
canBePatient: 17% - 33%
canBeVeryPatient: 4% - 16%
Out of logic: <4%

If a room has a cycle time in that 15-second ballpark (as seems to be common) I'll just use these ranges. And if its cycle time seems a little higher or lower, I'll try to adjust accordingly, but without trying to grind the room to optimize the times. It's all guesswork anyway so no point trying to make it super precise.