### PR TITLE
Add canPauseAbuse tech, refine heated farms

### DIFF
--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -6437,7 +6437,7 @@
                         {"heatFrames": 50}
                       ]}
                     ]},
-                    {"refill": ["Energy", "Missile", "Super"]}
+                    {"refill": ["Energy", "Super"]}
                   ]
                 }
               ]
@@ -6503,7 +6503,7 @@
                         {"heatFrames": 50}
                       ]}
                     ]},
-                    {"refill": ["Energy", "Missile", "Super"]}
+                    {"refill": ["Energy", "Super"]}
                   ]
                 }
               ]

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -6421,6 +6421,27 @@
               ]
             },
             {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "Zebbo Farm",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      {"and": [
+                        "canPauseAbuse",
+                        "Grapple"
+                      ]},
+                      {"and": [
+                        "h_heatResistant",
+                        {"heatFrames": 50}
+                      ]}
+                    ]}
+                  ]
+                }
+              ]
+            },
+            {
               "id": 4,
               "strats": [
                 {
@@ -6460,6 +6481,27 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     {"heatFrames": 210}
+                  ]
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "strats": [
+                {
+                  "name": "Zebbo Farm",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      {"and": [
+                        "canPauseAbuse",
+                        "Grapple"
+                      ]},
+                      {"and": [
+                        "h_heatResistant",
+                        {"heatFrames": 50}
+                      ]}
+                    ]}
                   ]
                 }
               ]

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -6436,7 +6436,8 @@
                         "h_heatResistant",
                         {"heatFrames": 50}
                       ]}
-                    ]}
+                    ]},
+                    {"refill": ["Energy", "Missile", "Super"]}
                   ]
                 }
               ]
@@ -6501,7 +6502,8 @@
                         "h_heatResistant",
                         {"heatFrames": 50}
                       ]}
-                    ]}
+                    ]},
+                    {"refill": ["Energy", "Missile", "Super"]}
                   ]
                 }
               ]

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -6331,6 +6331,22 @@
                     }},
                     {"heatFrames": 230}
                   ]
+                },
+                {
+                  "name": "Zebbo and Viola Farm",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    {"heatFrames": 150},
+                    {"resetRoom": {
+                      "nodes": [1, 2],
+                      "mustStayPut": false
+                    }},
+                    "canPauseAbuse",
+                    "Grapple",
+                    {"refill": ["Super", "PowerBomb"]}
+                  ],
+                  "note": ["Use the Zebbo farm with Grapple and pause abuse if needed, to maintain (but not fully refill) energy while farming Supers and Power Bombs and crossing the room."]
                 }
               ]
             },
@@ -6386,6 +6402,22 @@
                     }},
                     {"heatFrames": 190}
                   ]
+                },
+                {
+                  "name": "Zebbo and Viola Farm",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    {"heatFrames": 150},
+                    {"resetRoom": {
+                      "nodes": [1, 2],
+                      "mustStayPut": false
+                    }},
+                    "canPauseAbuse",
+                    "Grapple",
+                    {"refill": ["Super", "PowerBomb"]}
+                  ],
+                  "note": ["Use the Zebbo farm with Grapple and pause abuse if needed, to maintain (but not fully refill) energy while farming Supers and Power Bombs and crossing the room."]
                 }
               ]
             },
@@ -6424,23 +6456,52 @@
               "id": 3,
               "strats": [
                 {
-                  "name": "Zebbo Farm",
+                  "name": "Heat-proof Zebbo Farm",
                   "notable": false,
                   "requires": [
-                    {"or": [
-                      {"and": [
-                        "canPauseAbuse",
-                        "Grapple"
-                      ]},
-                      {"and": [
-                        "h_heatResistant",
-                        {"heatFrames": 50}
-                      ]}
-                    ]},
-                    {"refill": ["Energy", "Super"]}
+                    "h_heatProof",
+                    {"refill": ["Energy", "Missile", "Super"]}
+                  ]
+                },
+                {
+                  "name": "Heat-proof Viola Farm",
+                  "notable": false,
+                  "requires": [
+                    "h_heatProof",
+                    {"resetRoom": {
+                      "nodes": [1],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["PowerBomb"]}
+                  ]
+                },
+                {
+                  "name": "Zebbo and Viola Farm",
+                  "notable": false,
+                  "requires": [
+                    "h_heatProof",
+                    {"resetRoom": {
+                      "nodes": [1],
+                      "mustStayPut": false
+                    }},
+                    "canPauseAbuse",
+                    "Grapple",
+                    {"refill": ["Super", "PowerBomb"]}
+                  ],
+                  "note": ["Use the Zebbo farm with Grapple and pause abuse if necessary, to maintain (but not fully refill) energy while farming Supers and Power Bombs."]
+                },
+                {
+                  "name": "Very Patient Zebbo Energy Farm",
+                  "notable": false,
+                  "requires": [
+                    "canPauseAbuse",
+                    "Grapple",
+                    "canBeVeryPatient",
+                    {"refill": ["Energy"]}
                   ]
                 }
-              ]
+              ],
+              "devNote": "FIXME: Add heat-resistant strats later if there is a use case for them."
             },
             {
               "id": 4,
@@ -6490,23 +6551,52 @@
               "id": 4,
               "strats": [
                 {
-                  "name": "Zebbo Farm",
+                  "name": "Heat-proof Zebbo Farm",
                   "notable": false,
                   "requires": [
-                    {"or": [
-                      {"and": [
-                        "canPauseAbuse",
-                        "Grapple"
-                      ]},
-                      {"and": [
-                        "h_heatResistant",
-                        {"heatFrames": 50}
-                      ]}
-                    ]},
-                    {"refill": ["Energy", "Super"]}
+                    "h_heatProof",
+                    {"refill": ["Energy", "Missile", "Super"]}
+                  ]
+                },
+                {
+                  "name": "Heat-proof Viola Farm",
+                  "notable": false,
+                  "requires": [
+                    "h_heatProof",
+                    {"resetRoom": {
+                      "nodes": [2],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["PowerBomb"]}
+                  ]
+                },
+                {
+                  "name": "Zebbo and Viola Farm",
+                  "notable": false,
+                  "requires": [
+                    "h_heatProof",
+                    {"resetRoom": {
+                      "nodes": [2],
+                      "mustStayPut": false
+                    }},
+                    "canPauseAbuse",
+                    "Grapple",
+                    {"refill": ["Super", "PowerBomb"]}
+                  ],
+                  "note": ["Use the Zebbo farm with Grapple and pause abuse if necessary, to maintain (but not fully refill) energy while farming Supers and Power Bombs."]
+                },
+                {
+                  "name": "Very Patient Zebbo Energy Farm",
+                  "notable": false,
+                  "requires": [
+                    "canPauseAbuse",
+                    "Grapple",
+                    "canBeVeryPatient",
+                    {"refill": ["Energy"]}
                   ]
                 }
-              ]
+              ],
+              "devNote": "FIXME: Add heat-resistant strats later if there is a use case for them."
             }
           ]
         }

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -6331,22 +6331,6 @@
                     }},
                     {"heatFrames": 230}
                   ]
-                },
-                {
-                  "name": "Zebbo and Viola Farm",
-                  "notable": false,
-                  "requires": [
-                    "h_canNavigateHeatRooms",
-                    {"heatFrames": 150},
-                    {"resetRoom": {
-                      "nodes": [1, 2],
-                      "mustStayPut": false
-                    }},
-                    "canPauseAbuse",
-                    "Grapple",
-                    {"refill": ["Super", "PowerBomb"]}
-                  ],
-                  "note": ["Use the Zebbo farm with Grapple and pause abuse if needed, to maintain (but not fully refill) energy while farming Supers and Power Bombs and crossing the room."]
                 }
               ]
             },
@@ -6402,22 +6386,6 @@
                     }},
                     {"heatFrames": 190}
                   ]
-                },
-                {
-                  "name": "Zebbo and Viola Farm",
-                  "notable": false,
-                  "requires": [
-                    "h_canNavigateHeatRooms",
-                    {"heatFrames": 150},
-                    {"resetRoom": {
-                      "nodes": [1, 2],
-                      "mustStayPut": false
-                    }},
-                    "canPauseAbuse",
-                    "Grapple",
-                    {"refill": ["Super", "PowerBomb"]}
-                  ],
-                  "note": ["Use the Zebbo farm with Grapple and pause abuse if needed, to maintain (but not fully refill) energy while farming Supers and Power Bombs and crossing the room."]
                 }
               ]
             },
@@ -6476,28 +6444,17 @@
                   ]
                 },
                 {
-                  "name": "Zebbo and Viola Farm",
-                  "notable": false,
-                  "requires": [
-                    "h_heatProof",
-                    {"resetRoom": {
-                      "nodes": [1],
-                      "mustStayPut": false
-                    }},
-                    "canPauseAbuse",
-                    "Grapple",
-                    {"refill": ["Super", "PowerBomb"]}
-                  ],
-                  "note": ["Use the Zebbo farm with Grapple and pause abuse if necessary, to maintain (but not fully refill) energy while farming Supers and Power Bombs."]
-                },
-                {
-                  "name": "Very Patient Zebbo Energy Farm",
+                  "name": "Very Patient Zebbo and Viola Farm",
                   "notable": false,
                   "requires": [
                     "canPauseAbuse",
                     "Grapple",
                     "canBeVeryPatient",
-                    {"refill": ["Energy"]}
+                    {"resetRoom": {
+                      "nodes": [1],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Energy", "Super", "PowerBomb"]}
                   ]
                 }
               ],
@@ -6571,28 +6528,17 @@
                   ]
                 },
                 {
-                  "name": "Zebbo and Viola Farm",
-                  "notable": false,
-                  "requires": [
-                    "h_heatProof",
-                    {"resetRoom": {
-                      "nodes": [2],
-                      "mustStayPut": false
-                    }},
-                    "canPauseAbuse",
-                    "Grapple",
-                    {"refill": ["Super", "PowerBomb"]}
-                  ],
-                  "note": ["Use the Zebbo farm with Grapple and pause abuse if necessary, to maintain (but not fully refill) energy while farming Supers and Power Bombs."]
-                },
-                {
-                  "name": "Very Patient Zebbo Energy Farm",
+                  "name": "Very Patient Zebbo and Viola Farm",
                   "notable": false,
                   "requires": [
                     "canPauseAbuse",
                     "Grapple",
                     "canBeVeryPatient",
-                    {"refill": ["Energy"]}
+                    {"resetRoom": {
+                      "nodes": [1],
+                      "mustStayPut": false
+                    }},
+                    {"refill": ["Energy", "Super", "PowerBomb"]}
                   ]
                 }
               ],

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1632,7 +1632,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 100}
+                    {"heatFrames": 35}
                   ]
                 }
               ]
@@ -1722,6 +1722,22 @@
                     "h_canNavigateHeatRooms",
                     "canUseFrozenEnemies",
                     {"heatFrames": 250}
+                  ]
+                }
+              ]
+            },
+            {
+              "id": 5,
+              "strats": [
+                {
+                  "name": "Gamet Farm",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "canPauseAbuse",
+                      {"heatFrames": 50}
+                    ]},
+                    {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
                   ]
                 }
               ]
@@ -1980,7 +1996,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 50}
+                    {"heatFrames": 10}
                   ]
                 }
               ]
@@ -1999,6 +2015,22 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     {"heatFrames": 50}
+                  ]
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "strats": [
+                {
+                  "name": "Gamet Farm",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "canPauseAbuse",
+                      {"heatFrames": 50}
+                    ]},
+                    {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
                   ]
                 }
               ]
@@ -3348,13 +3380,23 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                      {"or": [
-                        "canWalljump",
-                        "HiJump",
-                        "SpaceJump",
-                        "canUseFrozenEnemies"
-                      ]},
+                    {"or": [
+                      "canWalljump",
+                      "HiJump",
+                      "SpaceJump",
+                      "canTrickyUseFrozenEnemies",
+                      "canSpringBallJumpMidAir"
+                    ]},
                     {"heatFrames": 350}
+                  ]
+                },
+                {
+                  "name": "Precise Walljump",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "canPreciseWalljump",
+                    {"heatFrames": 220}
                   ]
                 }
               ]
@@ -3372,7 +3414,18 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 250}
+                    {"or": [
+                      {"heatFrames": 230},
+                      {"and": [
+                        "canDamageBoost",
+                        {"heatFrames": 200},
+                        {"enemyDamage": {
+                          "enemy": "Skree",
+                          "type": "particle",
+                          "hits": 1
+                        }}
+                      ]}
+                    ]}
                   ]
                 }
               ]
@@ -3385,7 +3438,11 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 50}
+                    {"heatFrames": 10}
+                  ],
+                  "devNote": [
+                    "Heat frames here are artifically lower to allow using canPauseAbuse on the farm.",
+                    "This is compensated for by extra heat frames on the farm itself as an alternative to canPauseAbuse."
                   ]
                 }
               ]
@@ -3407,6 +3464,22 @@
                   ]
                 }
               ]
+            },
+            {
+              "id": 3,
+              "strats": [
+                {
+                  "name": "Gamet Farm",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "canPauseAbuse",
+                      {"heatFrames": 50}
+                    ]},
+                    {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
+                  ]
+                }
+              ]              
             }
           ]
         }
@@ -6896,7 +6969,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 80}
+                    {"heatFrames": 70}
                   ]
                 }
               ]
@@ -7003,6 +7076,22 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     {"heatFrames": 210}
+                  ]
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "strats": [
+                {
+                  "name": "Gamet Farm",
+                  "notable": false,
+                  "requires": [
+                    {"or": [
+                      "canPauseAbuse",
+                      {"heatFrames": 60}
+                    ]},
+                    {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
                   ]
                 }
               ]

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -3418,10 +3418,10 @@
                       {"heatFrames": 230},
                       {"and": [
                         "canDamageBoost",
-                        {"heatFrames": 200},
+                        {"heatFrames": 160},
                         {"enemyDamage": {
                           "enemy": "Skree",
-                          "type": "particle",
+                          "type": "contact",
                           "hits": 1
                         }}
                       ]}

--- a/tech.json
+++ b/tech.json
@@ -1340,6 +1340,14 @@
             "This can be done by jumping in place; changing Samus' hitbox with aim down will scroll the camera lower.",
             "By running back and forth the camera will scroll horizontally; Moonwalk can be used to camera scroll without travelling as far."
           ]
+        },
+        {
+          "name": "canPauseAbuse",
+          "requires": [],
+          "note": [
+            "The ability to pause in order to avoid death while reaching 0 energy.",
+            "Energy must be obtained before the unpause fade-in finishes."
+          ]
         }
       ]
     }


### PR DESCRIPTION
This adds a new tech canPauseAbuse for pausing to prevent death just before collecting an energy drop. (For the moment at least, manual reserve usage is out of scope of the tech.)

Farming strats are added for heated rooms, using the new tech. I took the opportunity to tighten some of the heat frames as well. Bat Room could still use some tightening for the walljumpless strats.

Closes issue #952.
