### PR TITLE
Fix Beetom farms

### DIFF
--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -2135,18 +2135,7 @@
                       "ScrewAttack",
                       {"and": [
                         "Ice",
-                        "Morph",
-                        {"or": [
-                          "Bombs",
-                          {"and": [
-                            {"resourceCapacity": [ {"type": "PowerBomb", "count": 1} ]},
-                            {"or": [
-                              {"ammo": {"type": "Missile", "count": 4}},
-                              {"ammo": {"type": "Super", "count": 4}},
-                              {"ammo": {"type": "PowerBomb", "count": 4}}
-                            ]}
-                          ]}
-                        ]}
+                        "h_canUseMorphBombs"
                       ]}
                     ]},
                     {"refill": ["PowerBomb"]}
@@ -2155,8 +2144,8 @@
                   "devNote": [
                     "Using an adjacent 2-tile runway doesn't seem workable since heat frames may be too much to maintain energy.",
                     "We can't use Missiles for the farm since the Beetoms don't drop Missiles.",
-                    "Using a Missile or Super at the start is in logic to get the first Power Bomb if needed; the requirement of 4 is to handle the worst case of coming in with less than 10 energy, with neighboring heated rooms, where you would need to get health bombed 3 times before getting any Power Bomb drops.",
-                    "Potentially there could be some other way to dodge the Beetoms, to kill them without Ice or Screw"
+                    "Potentially there could be some other way to dodge the Beetoms, to kill them without Ice or Screw",
+                    "FIXME: Using a Missile, Super, or Power Bomb at the start could be added to the logic to get the first Power Bombs to use for further farming, but this needs a way to express that we're not in health-bomb energy range."
                   ]
                 }
               ]

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -2139,12 +2139,12 @@
                         {"or": [
                           "Bombs",
                           {"and": [
-                            "PowerBomb",
+                            {"resourceCapacity": [ {"type": "PowerBomb", "count": 1} ]},
                             {"or": [
-                              {"ammo": {"type": "Missile", "count": 1}},
-                              {"ammo": {"type": "Super", "count": 1}},
-                              {"ammo": {"type": "PowerBomb", "count": 1}}
-                            ]}    
+                              {"ammo": {"type": "Missile", "count": 4}},
+                              {"ammo": {"type": "Super", "count": 4}},
+                              {"ammo": {"type": "PowerBomb", "count": 4}}
+                            ]}
                           ]}
                         ]}
                       ]}
@@ -2155,7 +2155,7 @@
                   "devNote": [
                     "Using an adjacent 2-tile runway doesn't seem workable since heat frames may be too much to maintain energy.",
                     "We can't use Missiles for the farm since the Beetoms don't drop Missiles.",
-                    "Using 1 Missile or Super at the start is in logic to get the first Power Bomb if needed.",
+                    "Using a Missile or Super at the start is in logic to get the first Power Bomb if needed; the requirement of 4 is to handle the worst case of coming in with less than 10 energy, with neighboring heated rooms, where you would need to get health bombed 3 times before getting any Power Bomb drops.",
                     "Potentially there could be some other way to dodge the Beetoms, to kill them without Ice or Screw"
                   ]
                 }

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -647,25 +647,14 @@
                           "Ice",
                           "canCarefulJump"
                         ]},
-                        "Morph",
-                        {"or": [
-                          "Bombs",
-                          {"and": [
-                            {"resourceCapacity": [ {"type": "PowerBomb", "count": 1} ]},
-                            {"or": [
-                              {"ammo": {"type": "Missile", "count": 4}},
-                              {"ammo": {"type": "Super", "count": 4}},
-                              {"ammo": {"type": "PowerBomb", "count": 4}}
-                            ]}
-                          ]}
-                        ]}
+                        "h_canUseMorphBombs"
                       ]}
                     ]},
                     {"refill": ["Energy", "PowerBomb"]}
                   ],
                   "note": "Kill the Beetoms with Screw Attack or by freezing or carefully avoiding them and using Bombs or Power Bombs.",
                   "devNote": [
-                    "Using a Missile or Super at the start is in logic to get the first Power Bomb if needed; the requirement of 4 is to handle the worst case of coming in with less than 10 energy, with a neighboring heated room, where you would need to get health bombed 3 times before getting any Power Bomb drops."
+                    "FIXME: Using a Missile, Super, or Power Bomb at the start could be added to the logic to get the first Power Bombs to use for further farming, but this needs a way to express that we're not in health-bomb energy range."
                   ]
                 }
               ]

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -651,12 +651,12 @@
                         {"or": [
                           "Bombs",
                           {"and": [
-                            "PowerBomb",
+                            {"resourceCapacity": [ {"type": "PowerBomb", "count": 1} ]},
                             {"or": [
-                              {"ammo": {"type": "Missile", "count": 1}},
-                              {"ammo": {"type": "Super", "count": 1}},
-                              {"ammo": {"type": "PowerBomb", "count": 1}}
-                            ]}    
+                              {"ammo": {"type": "Missile", "count": 4}},
+                              {"ammo": {"type": "Super", "count": 4}},
+                              {"ammo": {"type": "PowerBomb", "count": 4}}
+                            ]}
                           ]}
                         ]}
                       ]}
@@ -665,7 +665,7 @@
                   ],
                   "note": "Kill the Beetoms with Screw Attack or by freezing or carefully avoiding them and using Bombs or Power Bombs.",
                   "devNote": [
-                    "Using 1 Missile or Super at the start is in logic to get the first Power Bomb if needed."
+                    "Using a Missile or Super at the start is in logic to get the first Power Bomb if needed; the requirement of 4 is to handle the worst case of coming in with less than 10 energy, with a neighboring heated room, where you would need to get health bombed 3 times before getting any Power Bomb drops."
                   ]
                 }
               ]

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -264,8 +264,8 @@
                     {"or": [
                       "ScrewAttack",
                       "h_canUseMorphBombs",
-                      "Missile",
-                      "Super"
+                      {"resourceCapacity": [ {"type": "Missile", "count": 1} ]},
+                      {"resourceCapacity": [ {"type": "Super", "count": 1} ]}
                     ]},
                     {"refill": ["Energy", "Missile", "Super", "PowerBomb"]}
                   ]

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1407,12 +1407,12 @@
                       "SpeedBooster",
                       {"and": [
                         "Morph",
-                        "PowerBomb",
+                        {"resourceCapacity": [ {"type": "PowerBomb", "count": 1} ]},
                         {"or": [
-                          {"ammo": {"type": "Missile", "count": 1}},
-                          {"ammo": {"type": "Super", "count": 1}},
-                          {"ammo": {"type": "PowerBomb", "count": 1}}
-                        ]}    
+                          {"ammo": {"type": "Missile", "count": 4}},
+                          {"ammo": {"type": "Super", "count": 4}},
+                          {"ammo": {"type": "PowerBomb", "count": 4}}
+                        ]}
                       ]},
                       {"and": [
                         "Ice",
@@ -1421,7 +1421,10 @@
                     ]},
                     {"refill": ["PowerBomb"]}
                   ],
-                  "devNote": "FIXME: Resetting the room with door node 2 would also be possible."
+                  "devNote": [
+                    "FIXME: Resetting the room with door node 2 would also be possible.",
+                    "Using a Missile or Super at the start is in logic to get the first Power Bomb if needed; the requirement of 4 is to handle the worst case of coming in with less than 10 energy, with a neighboring heated room, where you would need to get health bombed 3 times before getting any Power Bomb drops."
+                  ]
                 }
               ]
             },

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -1406,15 +1406,6 @@
                       "ScrewAttack",
                       "SpeedBooster",
                       {"and": [
-                        "Morph",
-                        {"resourceCapacity": [ {"type": "PowerBomb", "count": 1} ]},
-                        {"or": [
-                          {"ammo": {"type": "Missile", "count": 4}},
-                          {"ammo": {"type": "Super", "count": 4}},
-                          {"ammo": {"type": "PowerBomb", "count": 4}}
-                        ]}
-                      ]},
-                      {"and": [
                         "Ice",
                         "h_canUseMorphBombs"
                       ]}
@@ -1423,7 +1414,7 @@
                   ],
                   "devNote": [
                     "FIXME: Resetting the room with door node 2 would also be possible.",
-                    "Using a Missile or Super at the start is in logic to get the first Power Bomb if needed; the requirement of 4 is to handle the worst case of coming in with less than 10 energy, with a neighboring heated room, where you would need to get health bombed 3 times before getting any Power Bomb drops."
+                    "FIXME: Using a Missile, Super, or Power Bomb at the start could be added to the logic to get the first Power Bombs to use for further farming, but this needs a way to express that we're not in health-bomb energy range."
                   ]
                 }
               ]


### PR DESCRIPTION
This is to handle the situation where you may come into the room with low energy, where health bomb would prevent you from getting Power Bomb drops from Beetoms initially. We could refine this further if we had a requirement type to check for a minimal amount of a resource (energy), i.e. >= 30 energy, without consuming it. In practice, 4 Missiles will probably be available anyway, so not much is lost by doing it this way, by assuming you just need to reload the room a few times to get your health up first.

We also change the "PowerBomb" requirement to a "resourceCapacity" requirement: this will be more clear for readers of the logic; the meaning of a "PowerBomb" requirement is not intuitive and kyleb is working on phasing it out.