### PR TITLE
Simplify Morph Ball Room Speedball (Right to Left)

### DIFF
--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -492,10 +492,7 @@
                   "name": "Morph Ball Room Speedball (Right to Left)",
                   "notable": false,
                   "requires": [
-                    {"or": [
-                      "h_canUsePowerBombs",
-                      {"obstaclesCleared": ["B"]}
-                    ]},
+                    {"obstaclesCleared": ["B"]},
                     {"canShineCharge": {
                       "usedTiles": 21,
                       "shinesparkFrames": 0,
@@ -503,7 +500,7 @@
                     }},
                     "canMockball"
                   ],
-                  "clearsObstacles": ["A","B"],
+                  "clearsObstacles": ["A"],
                   "note": [
                     "It's a short charge into a speedball to break the Bomb Blocks.",
                     "The Power Bomb Blocks need to be destroyed to have enough running room."


### PR DESCRIPTION
The Power Bomb option in this Speedball strat (for breaking the PB blocks to open the runway to the right) doesn't seem useful. With the ability to use a power bomb, you could just use it to break the left blocks directly, which is already covered under a different strat.