### PR TITLE
Random Cleanup

### DIFF
--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -1050,7 +1050,7 @@
                   ],
                   "clearsObstacles": ["A"],
                   "note": [
-                    "The shot block may respawn while bomb jumping and can be cleared by weaving a power bomb into the IBJ, or with a morph bomb placed overhead while bomb jumping.",
+                    "The shot block may respawn while bomb jumping and can be cleared by weaving a Power Bomb into the IBJ, or with a bomb placed overhead while bomb jumping.",
                     "The Power Bomb can be placed one tile higher than the doors to also clear the Power Bomb Blocks above at the same time."
                   ],
                   "devNote": "Placing a power bomb to break the shot block and the power bomb blocks without dropping the IBJ is the same level of control as canBombAboveIBJ."
@@ -1307,7 +1307,7 @@
                   ]
                 }
               ],
-              "devNote": "Potentially doable with morph bombs and enough energy."
+              "devNote": "Potentially doable with bombs and enough energy."
             }
           ]
         },
@@ -1454,7 +1454,7 @@
                   ]
                 }
               ],
-              "devNote": "Potentially doable with morph bombs and enough energy."
+              "devNote": "Potentially doable with bombs and enough energy."
             }
           ]
         }
@@ -1819,7 +1819,7 @@
                     "Deal an exact amount of damage to a wall pirate to freeze it while breaking the bomb blocks with a power bomb without taking damage.",
                     "Wait briefly on the left side of the center platform, then jump and shoot 4 missiles at the top pirate.",
                     "Walljump up the left wall such that the lower pirates are on screen long enough to jump accross to the left.",
-                    "Place a Morph Bomb on the left wall to hit the top pirate when it jumps over, followed by a power bomb.",
+                    "Place a Bomb on the left wall to hit the top pirate when it jumps over, followed by a power bomb.",
                     "Unmorph precisely below the middle pirate so both top pirates will jump back to the right, and begin charging Ice.",
                     "Walljump up the left wall with charge held and freeze the top pirate when it jumps over and use it to reach the upper region."
                   ]
@@ -1899,7 +1899,7 @@
                     }}
                   ],
                   "note": "Being heatproof allows slower kill methods.",
-                  "devNote": "Morph bombs are still excluded because they take 30 bombs each and that's ridiculous."
+                  "devNote": "Bombs are still excluded because they take 30 bombs each and that's ridiculous."
                 },
                 {
                   "name": "Screw Attack Pirates Kill",
@@ -3675,7 +3675,7 @@
               "id": 6,
               "strats": [
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -3739,7 +3739,7 @@
               "id": 6,
               "strats": [
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -3984,7 +3984,7 @@
               "id": 2,
               "strats": [
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -4008,7 +4008,7 @@
               "id": 7,
               "strats": [
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -4068,8 +4068,8 @@
                     "Watch for the KiHunter to move right before jumping up to get a safe predicatable swoop."
                   ],
                   "devNote": [
-                    "This requires Power Bombs because it saves neither energy nor ammo using Morph Bombs.",
-                    "It's slower than Spring Ball mainly because X-Ray scope won't activate during the PB explosion."
+                    "This requires Power Bombs because it saves neither energy nor ammo using Bombs.",
+                    "It's slower than Spring Ball mainly because X-Ray scope won't activate during the Power Bomb explosion."
                   ]
                 },
                 {
@@ -4094,7 +4094,7 @@
                     "Wait for the bomb blocks to reappear.  Two crouches worth of height are needed before jumping through the rest of the blocks.",
                     "Watch for the KiHunter to move right before jumping up to get a safe predicatable swoop."
                   ],
-                  "devNote": "This requires Power Bombs because it saves neither energy nor ammo using Morph Bombs."
+                  "devNote": "This requires Power Bombs because it saves neither energy nor ammo using Bombs."
                 },
                 {
                   "name": "Spring Power Bombs",
@@ -4465,7 +4465,7 @@
               "id": 7,
               "strats": [
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -4573,7 +4573,7 @@
                     }}
                   ],
                   "clearsObstacles": ["D"],
-                  "devNote": "Morph Bombs excluded because that'd probably cost more health than just running through."
+                  "devNote": "Bombs excluded because that'd probably cost more health than just running through."
                 },
                 {
                   "name": "Screw Kill",
@@ -4666,7 +4666,7 @@
                     }}
                   ],
                   "clearsObstacles": ["C"],
-                  "devNote": "Morph Bombs excluded because that'd probably cost more health than just running through."
+                  "devNote": "Bombs excluded because that'd probably cost more health than just running through."
                 },
                 {
                   "name": "Tank the Damage",
@@ -4750,7 +4750,7 @@
                   "clearsObstacles": ["B"]
                 },
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -4808,7 +4808,7 @@
                     }}
                   ],
                   "clearsObstacles": ["C"],
-                  "devNote": "Morph Bombs excluded because that'd probably cost more health than just running through."
+                  "devNote": "Bombs excluded because that'd probably cost more health than just running through."
                 },
                 {
                   "name": "Screw Kill",
@@ -4872,7 +4872,7 @@
                   "devNote": "Note that if using PBs, two is required. One each from h_canBombThings, h_canUsePowerBombs."
                 },
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -4931,7 +4931,7 @@
                     }}
                   ],
                   "clearsObstacles": ["C","D"],
-                  "devNote": "Morph Bombs are not excluded here because there are consistent, safe setups for all Dessgeegas from this direction."
+                  "devNote": "Bombs are not excluded here because there are consistent, safe setups for all Dessgeegas from this direction."
                 },
                 {
                   "name": "Screw Kill",
@@ -7952,7 +7952,7 @@
                   ],
                   "clearsObstacles": ["C","E"],
                   "note": "Some weapons are very slow at killing the Multiviolas and require use of the safe spot in the bottom right Multiviola cage.",
-                  "devNote": "Morph Bombs are excluded because there is no safe setup."
+                  "devNote": "Bombs are excluded because there is no safe setup."
                 },
                 {
                   "name": "Wave Plasma Kill",
@@ -8444,7 +8444,7 @@
                   ]
                 },
                 {
-                  "name": "Mickey Mouse Multiviola Clip (Morph Bombs)",
+                  "name": "Mickey Mouse Multiviola Clip (Bombs)",
                   "notable": true,
                   "requires": [
                     "h_heatProof",
@@ -8795,7 +8795,7 @@
                   "note": "Use SpringBall to get up and over the Fune."
                 },
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canUseMorphBombs",
@@ -9168,10 +9168,10 @@
                   "note": "Use SpringBall to get up and over the Fune.  Jump when slightly away from the Fune."
                 },
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": ["h_canUseMorphBombs"],
-                  "note": "Use a Morph Bomb to get up and over the Fune."
+                  "note": "Use a Bomb to get up and over the Fune."
                 },
                 {
                   "name": "Kill the Fune",
@@ -9716,7 +9716,7 @@
                   ]
                 },
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -11356,7 +11356,7 @@
                   ]
                 },
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -440,7 +440,7 @@
               "id": 5,
               "strats": [
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -538,7 +538,7 @@
               "id": 4,
               "strats": [
                 {
-                  "name": "Morph Bombs",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -586,7 +586,7 @@
                     "Grapple"
                   ],
                   "note": "Menu to Grappling Beam before the crystal flash ends and mash shoot while holding down.",
-                  "devNote": "The extra power bomb or morph bombs is to get through the bomb blocks."
+                  "devNote": "The extra Power Bomb or bombs is to get through the bomb blocks."
                 }
               ]
             }
@@ -1420,7 +1420,7 @@
                   ]
                 },
                 {
-                  "name": "GT Supers Morph Bomb Springwall",
+                  "name": "Golden Torizo Supers Springwall with Bombs",
                   "notable": true,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -2052,7 +2052,7 @@
                   "note": "Expects that you fall down afterwards."
                 },
                 {
-                  "name": "Space Morph Bombs",
+                  "name": "Space Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -2063,7 +2063,7 @@
                   "clearsObstacles": ["A"]
                 },
                 {
-                  "name": "Screw Attack Room Springwall Morph Bombs",
+                  "name": "Screw Attack Room Springwall with Bombs",
                   "notable": true,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -2072,10 +2072,10 @@
                     {"heatFrames": 300}
                   ],
                   "clearsObstacles": ["A"],
-                  "note": "Use a Springwall to get up to the bomb blocks, to break them with a morph bomb."
+                  "note": "Use a Springwall to get up to the bomb blocks, to break them with a bomb."
                 },
                 {
-                  "name": "Screw Attack Room Transition Speedjump (Morph Bombs)",
+                  "name": "Screw Attack Room Transition Speedjump with Bombs",
                   "notable": true,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -2089,7 +2089,7 @@
                     {"heatFrames": 200}
                   ],
                   "clearsObstacles": ["A"],
-                  "note": "Run in the adjacent room and jump through the door, to place a Morph Bomb to break the obstacle."
+                  "note": "Run in the adjacent room and jump through the door, to place a Bomb to break the obstacle."
                 }
               ],
               "note": "The heat frames for these strats assumes you've already fallen from the door, because the cost is already baked into the subsequent 5-> 3 heat costs when relevant."
@@ -2272,7 +2272,7 @@
                   "clearsObstacles": ["B"]
                 },
                 {
-                  "name": "Morph Bomb",
+                  "name": "Bomb",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
@@ -2629,7 +2629,6 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canOpenGreenDoors",
                     {"heatFrames": 450},
                     {"enemyDamage": {
                       "enemy": "Ripper 2 (red)",
@@ -2643,7 +2642,6 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canOpenGreenDoors",
                     {"heatFrames": 350},
                     "ScrewAttack"
                   ]
@@ -2653,12 +2651,9 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canOpenGreenDoors",
                     {"heatFrames": 450},
                     {"enemyKill":{
-                      "enemies": [
-                        [ "Ripper 2 (red)", "Ripper 2 (red)"]
-                      ],
+                      "enemies": [ [ "Ripper 2 (red)", "Ripper 2 (red)"] ],
                       "explicitWeapons": [
                         "Super",
                         "PowerBomb"
@@ -2729,9 +2724,7 @@
                     "h_canNavigateHeatRooms",
                     {"heatFrames": 600},
                     {"enemyKill":{
-                      "enemies": [
-                        [ "Ripper 2 (red)", "Ripper 2 (red)"]
-                      ],
+                      "enemies": [ [ "Ripper 2 (red)", "Ripper 2 (red)"] ],
                       "explicitWeapons": [
                         "Super",
                         "PowerBomb"
@@ -2754,7 +2747,7 @@
                     {"or": [
                       {"and": [
                         {"heatFrames": 50},
-                        "h_canOpenGreenDoors"
+                        {"ammo": { "type": "Super", "count": 1 }}
                       ]},
                       {"obstaclesCleared": ["A"]}
                     ]}

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -2184,7 +2184,7 @@
                     "Find the crumble blocks and crystal flash mid-air, just below them.",
                     "They are on the far right of the ceiling of the bottom right pathway.",
                     "Hold down as the CF ends to break the non-respawning crumble blocks.",
-                    "The vertical positioning can be setup using Gravity and Morph Bombs."
+                    "The vertical positioning can be setup using Gravity and Bombs."
                   ]
                 },
                 {
@@ -2198,7 +2198,7 @@
                     "Find the crumble blocks and crystal flash mid-air, just below them.",
                     "They are on the far right of the ceiling of the bottom right pathway.",
                     "Hold down as the CF ends to break the non-respawning crumble blocks.",
-                    "This is for the much harder version, without Gravity and Morph Bombs."
+                    "This is for the much harder version, without Gravity and Bombs."
                   ]
                 }
               ]
@@ -2254,7 +2254,7 @@
                     "Find the crumble blocks and crystal flash mid-air, just below them.",
                     "They are on the far left of the ceiling of the middle left pathway.",
                     "Hold down as the CF ends to break the non-respawning crumble blocks.",
-                    "The vertical positioning can be setup using Gravity and Morph Bombs."
+                    "The vertical positioning can be setup using Gravity and Bombs."
                   ]
                 },
                 {
@@ -2268,7 +2268,7 @@
                     "Find the crumble blocks and crystal flash mid-air, just below them.",
                     "They are on the far left of the ceiling of the middle left pathway.",
                     "Hold down as the CF ends to break the non-respawning crumble blocks.",
-                    "This is for the much harder version, without Gravity and Morph Bombs."
+                    "This is for the much harder version, without Gravity and Bombs."
                   ]
                 }
               ]

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -2934,7 +2934,7 @@
               "id": 4,
               "strats": [
                 {
-                  "name": "Speed Blocks Cleared",
+                  "name": "Speed Blocks Already Broken Suitless",
                   "notable": false,
                   "requires": [
                     "canSuitlessMaridia",
@@ -2945,7 +2945,10 @@
                     ]},
                     {"obstaclesCleared": ["A"]}
                   ],
-                  "devNote": "Gravity can run across the sand with speed again."
+                  "devNote": [
+                    "Gravity can run across the sand with speed again.",
+                    "FIXME: This is possible without HiJump by breaking spin before landing, then quickly jumping again. Useful in other places as well, like Aqueduct."
+                  ]
                 },
                 {
                   "name": "Base",

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -1033,11 +1033,10 @@
               "id": 2,
               "strats": [
                 {
-                  "name": "Kill or Tank the Menus",
+                  "name": "Kill the Menus",
                   "notable": false,
                   "requires": [
                     {"or":[
-                      {"enemyDamage": { "enemy": "Menu", "type": "contact", "hits": 1 }},
                       {"and":[
                         "canDodgeWhileShooting",
                         {"enemyKill":{ "enemies": [ [ "Menu", "Menu" ] ] }}
@@ -1063,6 +1062,12 @@
                       ]}
                     ]}
                   ],
+                  "clearsObstacles": ["A"]
+                },
+                {
+                  "name": "Tank the Menus",
+                  "notable": false,
+                  "requires": [ {"enemyDamage": { "enemy": "Menu", "type": "contact", "hits": 1 }} ],
                   "clearsObstacles": ["A"]
                 }
               ]

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -6819,7 +6819,7 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      "h_canOpenGreenDoors",
+                      {"ammo": { "type": "Super", "count": 1 }},
                       {"obstaclesCleared": ["A"]}
                     ]}
                   ],
@@ -7475,7 +7475,7 @@
                   ],
                   "clearsObstacles": ["A"],
                   "note": [
-                    "Starting from the top left ledge, wall jump to place a morph bomb or power bomb just below and to the right of the bottom left plant on the wall.",
+                    "Starting from the top left ledge, wall jump to place a bomb or Power Bomb just below and to the right of the bottom left plant on the wall.",
                     "Use the bomb to boost you towards the item, then unmorph to reduce your fall speed and barely reach the item."
                   ]
                 },
@@ -8161,7 +8161,7 @@
                 {
                   "name": "Base",
                   "notable": false,
-                  "requires": [ "h_canOpenGreenDoors" ]
+                  "requires": [ {"ammo": { "type": "Super", "count": 1 }} ]
                 },
                 {
                   "name": "Indirect G-Mode Despawn Gate",

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -2647,7 +2647,7 @@
                   "notable": false,
                   "requires": [
                     {"or": [
-                      "h_canOpenGreenDoors",
+                      {"ammo": { "type": "Super", "count": 1 }},
                       {"obstaclesCleared": ["A"]}
                     ]}
                   ],

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -4328,7 +4328,7 @@
                   ]
                 },
                 {
-                  "name": "Morph Bomb",
+                  "name": "Bombs",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -3413,7 +3413,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_canOpenGreenDoors",
+                    {"ammo": { "type": "Super", "count": 1 }},
                     {"heatFrames": 150}
                   ]
                 }

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -2662,7 +2662,10 @@
                 {
                   "name": "Bowling Alley Ceiling Bomb Jump",
                   "notable": true,
-                  "requires": [ "h_canCeilingBombJump" ],
+                  "requires": [
+                    "h_canCeilingBombJump",
+                    "canBeVeryPatient"
+                  ],
                   "reusableRoomwideNotable": "Bowling Alley Ceiling Bomb Jump",
                   "note": "This is a very long ceiling bomb jump."
                 },
@@ -2671,6 +2674,7 @@
                   "notable": true,
                   "requires": [
                     "h_canArtificialMorphCeilingBombJump",
+                    "canBeVeryPatient",
                     {"comeInWithGMode": {
                       "fromNodes": [1],
                       "mode": "any",


### PR DESCRIPTION
- Double checked and fixed some minor things with Maridia Obstacles
- Reduced the number of places where bombs are called morph bombs
- Removed places where opening a green gate required `h_canOpenGreenDoors`, replaced it with a super
- Removed duplicate super requirements in Fast Ripper Room. It looks like L->R always required 2 supers to open the gate
- Add `canBeVeryPatient` to the Bowling Ceiling Bomb Jump