### PR TITLE
Heated Elevator Helpers

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -68,6 +68,30 @@
           "requires": [
             {"refill": ["RegularEnergy"]}
           ]
+        },
+        {
+          "name": "h_LowerNorfairElevatorDownwardFrames",
+          "requires": [
+            {"heatFrames": 60}
+          ],
+          "devNote": "This may be changed if the elevator speed is changed."
+        },
+        {
+          "name": "h_LowerNorfairElevatorUpwardFrames",
+          "requires": [
+            {"heatFrames": 108}
+          ],
+          "devNote": "This may be changed if the elevator speed is changed."
+        },
+        {
+          "name": "h_MainHallElevatorFrames",
+          "requires": [
+            {"heatFrames": 436}
+          ],
+          "devNote": [
+            "This may be changed if the elevator speed is changed.",
+            "Technically it requires 1 more Energy going up than going down, but they're lumped together here."
+          ]
         }
       ]
     },

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -384,7 +384,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 440}
+                    "h_MainHallElevatorFrames"
                   ]
                 }
               ],
@@ -403,7 +403,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 440}
+                    "h_MainHallElevatorFrames"
                   ]
                 }
               ],

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -7785,7 +7785,8 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 235}
+                    "h_LowerNorfairElevatorDownwardFrames",
+                    {"heatFrames": 175}
                   ]
                 }
               ],
@@ -7804,7 +7805,8 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 215}
+                    "h_LowerNorfairElevatorUpwardFrames",
+                    {"heatFrames": 106}
                   ]
                 }
               ],

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -7723,8 +7723,9 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 50}
-                  ]
+                    {"heatFrames": 30}
+                  ],
+                  "devNote": "60 frames to cross the room, but 40 to and from the elevator, so the other 10 frames are listed in 3->4."
                 }
               ]
             }
@@ -7741,8 +7742,9 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 50}
-                  ]
+                    {"heatFrames": 30}
+                  ],
+                  "devNote": "60 frames to cross the room, but 40 to and from the elevator, so the other 10 frames are listed in 3->4."
                 }
               ]
             }
@@ -7759,8 +7761,9 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 50}
-                  ]
+                    {"heatFrames": 30}
+                  ],
+                  "devNote": "60 frames to cross the room, but 40 to and from the elevator, so the other 10 frames are listed in 4->3."
                 }
               ]
             },
@@ -7772,8 +7775,9 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    {"heatFrames": 50}
-                  ]
+                    {"heatFrames": 30}
+                  ],
+                  "devNote": "60 frames to cross the room, but 40 to and from the elevator, so the other 10 frames are listed in 4->3."
                 }
               ]
             },
@@ -7785,11 +7789,13 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_LowerNorfairElevatorDownwardFrames"
+                    "h_LowerNorfairElevatorDownwardFrames",
+                    {"heatFrames": 10}
                   ]
                 }
               ],
-              "note": "This link exists because of how Samus takes heatdamage while riding the elevator."
+              "note": "This link exists because of how Samus takes heatdamage while riding the elevator.",
+              "devNote": "The extra heat frames are included because it is faster to run through the room than 2x the value it would tak to run half way."
             }
           ]
         },
@@ -7804,11 +7810,13 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_LowerNorfairElevatorUpwardFrames"
+                    "h_LowerNorfairElevatorUpwardFrames",
+                    {"heatFrames": 10}
                   ]
                 }
               ],
-              "note": "This link exists because of how Samus takes heatdamage while riding the elevator."
+              "note": "This link exists because of how Samus takes heatdamage while riding the elevator.",
+              "devNote": "The extra heat frames are included because it is faster to run through the room than 2x the value it would tak to run half way."
             }
           ]
         }

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -7785,8 +7785,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_LowerNorfairElevatorDownwardFrames",
-                    {"heatFrames": 175}
+                    "h_LowerNorfairElevatorDownwardFrames"
                   ]
                 }
               ],
@@ -7805,8 +7804,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "h_LowerNorfairElevatorUpwardFrames",
-                    {"heatFrames": 106}
+                    "h_LowerNorfairElevatorUpwardFrames"
                   ]
                 }
               ],


### PR DESCRIPTION
The energy loss I measured:

top going down 14-15
top going up 26-27
bottom going down 108
bottom going up 109-110

vanilla combined, slow elevators:
going down 123
going up 136

The energy loss measured with Map Rando's fast elevators:
top going down 7-8
top going up 11-12
bottom going down 46
bottom going up 47

So Map Rando would be able to change the heat frame values to these:
`h_LowerNorfairElevatorDownwardFrames`: 32
`h_LowerNorfairElevatorUpwardFrames`: 48
`h_MainHallElevatorFrames`: 188