### PR TITLE
Damage Boost Rework

### DIFF
--- a/region/brinstar/blue.json
+++ b/region/brinstar/blue.json
@@ -1123,17 +1123,24 @@
                   "note": "An alternate strat to canBombAboveIBJ. Shoot the block, jump into an IBJ, then do a quick double bomb jump to make it in time."
                 },
                 {
-                  "name": "Ceiling E-Tank Dboost",
-                  "notable": false,
+                  "name": "Blue Brinstar E-Tank Ceiling Damage Boost",
+                  "notable": true,
                   "requires": [
                     "f_ZebesAwake",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     {"enemyDamage": {
-                      "enemy": "Reo",
+                      "enemy": "Geemer (blue)",
                       "hits": 1,
                       "type": "contact"
                     }}
-                  ]
+                  ],
+                  "note": [
+                    "Have Samus shoot the shot block revealing the item and then quickly get hit by an enemy at the peak of her jump in order to reach the item.",
+                    "No directional inputs should be held while getting hit by the enemy in order to have a neutral boost and reach the item.",
+                    "This is traditionally done with the swooping Reo; after a few failed tries, it may help to reset the room to reposition it.",
+                    "The global Geemer may be easier to use, although it takes longer to get there; jump as it starts moving horizontally again while it is 3 tiles away from the item."
+                  ],
+                  "devNote": "Although the Reo is traditionally used for the boost, the Geemer does less damage and should still put this in logic with low energy."
                 },
                 {
                   "name": "Ceiling E-Tank Speed Jump",

--- a/region/brinstar/green.json
+++ b/region/brinstar/green.json
@@ -1185,7 +1185,7 @@
                       "mustStayPut": true
                     }},
                     "canCrouchGateClip",
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Zeb",
                       "hits": 2,

--- a/region/brinstar/kraid.json
+++ b/region/brinstar/kraid.json
@@ -1065,7 +1065,7 @@
                   "notable": false,
                   "requires": [
                     {"obstaclesNotCleared": ["C"]},
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Kihunter (green)",
                       "type": "contact",

--- a/region/brinstar/pink.json
+++ b/region/brinstar/pink.json
@@ -1496,7 +1496,7 @@
                       "canTrickyUseFrozenEnemies",
                       {"and": [
                         "canTrickyJump",
-                        "canDamageBoost",
+                        "canHorizontalDamageBoost",
                         {"enemyDamage": {
                           "enemy": "Zeb",
                           "type": "contact",

--- a/region/brinstar/red.json
+++ b/region/brinstar/red.json
@@ -1055,7 +1055,7 @@
                   "name": "X-Ray Exit Damage Boost",
                   "notable": true,
                   "requires": [
-                    "canContinuousDboost",
+                    "canHorizontalDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Waver",
                       "type": "contact",
@@ -1237,18 +1237,18 @@
                       {"spikeHits": 1},
                       {"and": [
                         {"enemyDamage": {
-                            "enemy": "Fireflea",
-                            "type": "contact",
-                            "hits": 1
-                          }},
-                        "canDamageBoost"
+                          "enemy": "Fireflea",
+                          "type": "contact",
+                          "hits": 1
+                        }},
+                        "canHorizontalDamageBoost"
                       ]}
                     ]},
                     {"or": [
                       "canInsaneWalljump",
                       {"and": [
                         {"spikeHits": 1},
-                        "canDamageBoost"
+                        "canHorizontalDamageBoost"
                       ]}
                     ]}
                   ],
@@ -1278,7 +1278,7 @@
                   "name": "X-Ray Access Damage Boost",
                   "notable": true,
                   "requires": [
-                    "canContinuousDboost",
+                    "canHorizontalDamageBoost",
                     "canTrickyJump",
                     {"enemyDamage": {
                       "enemy": "Waver",
@@ -2672,7 +2672,7 @@
                         }}
                       ]},
                       {"and": [
-                        "canDamageBoost",
+                        "canHorizontalDamageBoost",
                         {"enemyDamage": {
                           "enemy": "Boyon",
                           "type": "contact",
@@ -2744,7 +2744,7 @@
                         }}
                       ]},
                       {"and": [
-                        "canDamageBoost",
+                        "canHorizontalDamageBoost",
                         {"enemyDamage": {
                           "enemy": "Boyon",
                           "type": "contact",

--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -1742,7 +1742,7 @@
                       "h_canArtificialMorphMovement",
                       "h_canArtificialMorphBombHorizontally",
                       {"and": [
-                        "canDamageBoost",
+                        "canNeutralDamageBoost",
                         "f_ZebesAwake",
                         {"enemyDamage": {
                           "enemy": "Geemer (blue)",

--- a/region/crateria/east.json
+++ b/region/crateria/east.json
@@ -1539,7 +1539,7 @@
                   "notable": true,
                   "requires": [
                     "Morph",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     "canTrickyUseFrozenEnemies",
                     {"enemyDamage": {
                       "enemy": "Zeb",
@@ -1560,7 +1560,7 @@
                   "name": "West Ocean Bug Boost with Wave or Spazer",
                   "notable": true,
                   "requires": [
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     "canMockball",
                     {"enemyDamage": {
                       "enemy": "Zeb",
@@ -1580,7 +1580,7 @@
                   "name": "West Ocean Bug Boost",
                   "notable": true,
                   "requires": [
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     "canMockball",
                     {"enemyDamage": {
                       "enemy": "Zeb",
@@ -1642,7 +1642,7 @@
                             {"ammo": { "type": "PowerBomb", "count": 1 }}
                           ]},
                           {"and": [
-                            "canDamageBoost",
+                            "canNeutralDamageBoost",
                             {"enemyDamage": {
                               "enemy": "Zeb",
                               "hits": 3,
@@ -2635,7 +2635,7 @@
                   "notable": true,
                   "requires": [
                     "canSuitlessMaridia",
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     "canCrouchJump",
                     {"enemyDamage": {
                       "enemy": "Choot",
@@ -2829,7 +2829,7 @@
                   "notable": true,
                   "requires": [
                     "canSuitlessMaridia",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     "h_canCrouchJumpDownGrab",
                     {"enemyDamage": {
                       "enemy": "Skultera",
@@ -2837,7 +2837,7 @@
                       "type": "contact"
                     }}
                   ],
-                  "note": "Crouch jump down grab to get over the first two pillars. Crouch jump damage boost on the Skultera to get over the third."
+                  "note": "Crouch jump down grab to get over the first two pillars. Crouch jump damage boost on the Skultera then down grab to get over the third."
                 }
               ]
             }

--- a/region/lowernorfair/east.json
+++ b/region/lowernorfair/east.json
@@ -8821,7 +8821,7 @@
                         ]}
                       ]},
                       {"and": [
-                        "canDamageBoost",
+                        "canNeutralDamageBoost",
                         {"enemyDamage": {
                           "enemy": "Fune",
                           "type": "fireball",
@@ -8837,7 +8837,7 @@
                   "notable": true,
                   "requires": [
                     "h_canThreeTileJumpMorph",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     "canTrickyJump",
                     {"enemyDamage": {
                       "enemy": "Fune",
@@ -9109,7 +9109,7 @@
                   "notable": false,
                   "requires": [
                     "HiJump",
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     "canTrickyJump",
                     "canCrouchJump",
                     {"enemyDamage": {
@@ -9137,7 +9137,7 @@
                   "requires": [
                     "canStaggeredWalljump",
                     "canCarefulJump",
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Fireflea",
                       "type": "contact",
@@ -11011,7 +11011,7 @@
                     "canTrickyJump",
                     {"or": [
                       {"and": [
-                        "canDamageBoost",
+                        "canHorizontalDamageBoost",
                         "canHitbox",
                         {"enemyDamage": {
                           "enemy": "Kihunter (red)",

--- a/region/lowernorfair/west.json
+++ b/region/lowernorfair/west.json
@@ -297,7 +297,7 @@
                     {"or": [
                       "canTrickyJump",
                       {"and": [
-                        "canDamageBoost",
+                        "canHorizontalDamageBoost",
                         "canCarefulJump",
                         {"enemyDamage": {
                           "enemy": "Magdollite",
@@ -486,7 +486,7 @@
                     {"or": [
                       "canTrickyJump",
                       {"and": [
-                        "canDamageBoost",
+                        "canHorizontalDamageBoost",
                         "canCarefulJump",
                         {"enemyDamage": {
                           "enemy": "Magdollite",
@@ -1523,7 +1523,7 @@
                       ]}
                     ]},
                     "canSpringBallJumpMidAir",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Golden Torizo",
                       "type": "contact",

--- a/region/maridia/inner-green.json
+++ b/region/maridia/inner-green.json
@@ -1770,7 +1770,7 @@
                     {"or": [
                       "canTrickyUseFrozenEnemies",
                       {"and": [
-                        "canDamageBoost",
+                        "canNeutralDamageBoost",
                         {"enemyDamage": { "enemy": "Evir", "type": "contact", "hits": 1 }}
                       ]}
                     ]},
@@ -2133,7 +2133,7 @@
                   "requires": [
                     "Gravity",
                     "canTrickyJump",
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Evir",
                       "type": "particle",

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -4950,7 +4950,7 @@
                         "canSuitlessMaridia",
                         "canPlayInSand",
                         "HiJump",
-                        "canDamageBoost",
+                        "canHorizontalDamageBoost",
                         "canSpringBallJumpMidAir",
                         {"spikeHits": 2}
                       ]},
@@ -4968,7 +4968,7 @@
                     {"spikeHits": 1},
                     {"or": [
                       {"spikeHits": 1},
-                      "canDamageBoost"
+                      "canHorizontalDamageBoost"
                     ]}
                   ],
                   "note": [
@@ -4983,7 +4983,7 @@
                   "requires": [
                     "canWalljump",
                     "canTrickyJump",
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     "canIframeSpikeJump",
                     {"spikeHits": 3},
                     {"or": [
@@ -5305,7 +5305,7 @@
                     "canIframeSpikeJump",
                     {"spikeHits": 3},
                     {"or": [
-                      "canDamageBoost",
+                      "canHorizontalDamageBoost",
                       {"spikeHits": 1}
                     ]}
                   ],
@@ -6517,10 +6517,10 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     { "enemyDamage": { "enemy": "Cacatac", "hits": 1, "type": "spike" } }
                   ],
-                  "note": "Damage boost up to the higher ledge using a Cacatac spike.  Spikes only exist on camera so follow a vertically fired spike up to the correct height."
+                  "note": "Damage boost up to the higher ledge using a Cacatac spike. Spikes only exist on camera so follow a vertically fired spike up to the correct height."
                 },
                 {
                   "name": "Suitless HiJump plus Assist",
@@ -7396,7 +7396,7 @@
                   "requires": [
                     "Gravity",
                     "Morph",
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     "canIframeSpikeJump",
                     { "enemyDamage": { "enemy": "Cacatac", "hits": 1, "type": "contact" } }
                   ],
@@ -7483,7 +7483,7 @@
                     "canCarefulJump",
                     "canSpringBallJumpMidAir",
                     "canLateralMidAirMorph",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     { "enemyDamage": { "enemy": "Cacatac", "hits": 2, "type": "spike" } }
                   ],
                   "note": "When the Cacatac on the ground fires a spike, perform a  springball Jump to break the waterline and then hit the spike for extra height."

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -5304,8 +5304,9 @@
                     "canTrickyJump",
                     "canIframeSpikeJump",
                     {"spikeHits": 3},
+                    "canNeutralDamageBoost",
                     {"or": [
-                      "canNeutralDamageBoost",
+                      "canHorizontalDamageBoost",
                       {"spikeHits": 1}
                     ]}
                   ],

--- a/region/maridia/inner-pink.json
+++ b/region/maridia/inner-pink.json
@@ -4950,7 +4950,7 @@
                         "canSuitlessMaridia",
                         "canPlayInSand",
                         "HiJump",
-                        "canHorizontalDamageBoost",
+                        "canNeutralDamageBoost",
                         "canSpringBallJumpMidAir",
                         {"spikeHits": 2}
                       ]},
@@ -5305,7 +5305,7 @@
                     "canIframeSpikeJump",
                     {"spikeHits": 3},
                     {"or": [
-                      "canHorizontalDamageBoost",
+                      "canNeutralDamageBoost",
                       {"spikeHits": 1}
                     ]}
                   ],

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -1116,7 +1116,7 @@
                     "Morph",
                     "h_canNavigateUnderwater",
                     "canTrickyUseFrozenEnemies",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Menu",
                       "type": "contact",
@@ -2634,7 +2634,7 @@
                       "canWalljump",
                       "h_canCrouchJumpDownGrab"
                     ]},
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Zoa",
                       "type": "contact",
@@ -2824,7 +2824,7 @@
                       "canWalljump",
                       "h_canCrouchJumpDownGrab"
                     ]},
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Zoa",
                       "type": "contact",

--- a/region/maridia/outer.json
+++ b/region/maridia/outer.json
@@ -3913,7 +3913,7 @@
                   "notable": false,
                   "requires": [
                     "Gravity",
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     "canPrepareForNextRoom",
                     {"enemyDamage": {
                       "enemy": "Skultera",

--- a/region/norfair/crocomire.json
+++ b/region/norfair/crocomire.json
@@ -710,11 +710,11 @@
                   ]
                 },
                 {
-                  "name": "Post Crocomire Farming Room Dboost",
+                  "name": "Post Crocomire Farming Room Damage Boost",
                   "notable": true,
                   "requires": [
                     "canTrickyJump",
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Gamet",
                       "type": "contact",
@@ -2478,7 +2478,7 @@
                   "requires": [
                     "h_canNavigateUnderwater",
                     "canCarefulJump",
-                    "canContinuousDboost",
+                    "canHorizontalDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Gamet",
                       "type": "contact",
@@ -2583,7 +2583,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateUnderwater",
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     "canCarefulJump",
                     {"enemyDamage": {
                       "enemy": "Gamet",

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -225,7 +225,7 @@
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     "Morph",
                     {"enemyDamage": {"enemy": "Sova", "hits": 1, "type": "contact"}},
                     {"or": [
@@ -295,14 +295,14 @@
                     "h_canNavigateHeatRooms",
                     "canInsaneWalljump",
                     "Morph",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     {"enemyDamage": {"enemy": "Sova","hits": 1,"type": "contact"}},
                     {"heatFrames": 1050}
                   ],
                   "note": [
                     "Use a very well timed and precise walljump into morph to hit the global Sova so that the damage bonks Samus up to the door ledge.",
                     "Aim for the lowest part of slope looking wall tile, where it does not look possible to make contact with a walljump, and fully delay the jump.",
-                    "To try again, the Sova loops to the left side wall.  Or a Super can knock it off the wall to climb the right side again."
+                    "To try again, the Sova loops to the left side wall. Or a Super can knock it off the wall to climb the right side again."
                   ]
                 }
               ],
@@ -2371,7 +2371,7 @@
                   "name": "Bubble Mountain Damage Boost (Left to Right)",
                   "notable": true,
                   "requires": [
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Waver",
                       "hits": 1,
@@ -2671,7 +2671,7 @@
                   "name": "Bubble Mountain Damage Boost (Right to Left)",
                   "notable": true,
                   "requires": [
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Waver",
                       "hits": 1,
@@ -3492,7 +3492,7 @@
                     {"or": [
                       {"heatFrames": 230},
                       {"and": [
-                        "canDamageBoost",
+                        "canHorizontalDamageBoost",
                         {"heatFrames": 160},
                         {"enemyDamage": {
                           "enemy": "Skree",
@@ -5342,7 +5342,7 @@
           "name": "Spiky Acid Snake Frozen Platforms",
           "note": [
             "While crossing the Spiky Lava, land on frozen Yapping Maws to reduce the number of spike hits needed.",
-            "Delay the damageboost from the spikes slightly in order to rise above the lava before moving."
+            "Delay the damage boost from the spikes slightly in order to rise above the lava before moving."
           ]
         }
       ],
@@ -5382,7 +5382,7 @@
                     {"or": [
                       {"and": [
                         "canIframeSpikeJump",
-                        "canDamageBoost"
+                        "canHorizontalDamageBoost"
                       ]},
                       {"and": [
                         {"spikeHits": 4},
@@ -5391,7 +5391,7 @@
                       ]}
                     ]}
                   ],
-                  "note": "Damageboosts can be used to save energy - delay the damageboost from the spikes slightly in order to rise above the lava before moving."
+                  "note": "Damage boosts can be used to save energy - delay the damage boost from the spikes slightly in order to rise above the lava before moving."
                 },
                 {
                   "name": "Tank the Damage with Gravity",
@@ -5434,7 +5434,7 @@
                     "canTrickyUseFrozenEnemies",
                     "canTrickyJump",
                     {"or": [
-                      "canDamageBoost",
+                      "canHorizontalDamageBoost",
                       {"and": [
                         {"spikeHits": 2},
                         {"lavaFrames": 30},
@@ -5452,7 +5452,7 @@
                     "Damage boost towards then freeze the Leftmost enemy as it extends.",
                     "Morph and unmorph while above the middle Yapping Maw to land on it just above the lava line.",
                     "Ignore the rightmost Yapping Maw.",
-                    "Delay the damageboost from the spikes slightly in order to rise above the lava before moving."
+                    "Delay the damage boost from the spikes slightly in order to rise above the lava before moving."
                   ]
                 }
               ]
@@ -5494,7 +5494,7 @@
                     {"or": [
                       {"and": [
                         "canIframeSpikeJump",
-                        "canDamageBoost"
+                        "canHorizontalDamageBoost"
                       ]},
                       {"and": [
                         {"spikeHits": 4},
@@ -5503,7 +5503,7 @@
                       ]}
                     ]}
                   ],
-                  "note": "Damageboosts can be used to save energy - delay the damageboost from the spikes slightly in order to rise above the lava before moving."
+                  "note": "Damage boosts can be used to save energy - delay the damage boost from the spikes slightly in order to rise above the lava before moving."
                 },
                 {
                   "name": "Tank the Damage with Gravity",
@@ -5546,7 +5546,7 @@
                     "canTrickyUseFrozenEnemies",
                     "canTrickyJump",
                     {"or": [
-                      "canDamageBoost",
+                      "canHorizontalDamageBoost",
                       {"and": [
                         {"spikeHits": 1},
                         {"lavaFrames": 20},
@@ -5564,7 +5564,7 @@
                     "Morph and unmorph while above the rightmost Yapping Maw to land on it just above the lava line.",
                     "Ignore the second Yapping Maw.",
                     "Freeze the Leftmost enemy as it extends.",
-                    "Delay the damageboost from the spikes slightly in order to rise above the lava before moving."
+                    "Delay the damage boost from the spikes slightly in order to rise above the lava before moving."
                   ]
                 }
               ]
@@ -6261,7 +6261,7 @@
                       "h_lavaProof",
                       "canSuitlessLavaDive"
                     ]},
-                    "canDamageBoost",
+                    "canHorizontalDamageBoost",
                     {"canComeInCharged":{
                       "fromNode": 2,
                       "framesRemaining": 180,
@@ -6277,7 +6277,7 @@
                   ],
                   "note": [
                     "Store the shinespark on the last possible pixels of runway.",
-                    "Quickly drop to the nearby namihe and damageboost using its flame.",
+                    "Quickly drop to the nearby namihe and damage boost using its flame.",
                     "Hold the damage boost until just before being below the above platform and spark upwards"
                   ]
                 },

--- a/region/norfair/west.json
+++ b/region/norfair/west.json
@@ -1797,7 +1797,7 @@
                     "h_canNavigateHeatRooms",
                     "canCrouchJump",
                     "Morph",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Sova",
                       "type": "contact",
@@ -2151,7 +2151,7 @@
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "Morph",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     {"enemyDamage": {
                       "enemy": "Boyon",
                       "type": "contact",

--- a/region/wreckedship/main.json
+++ b/region/wreckedship/main.json
@@ -3529,7 +3529,7 @@
                   "requires": [
                     "HiJump",
                     "canUseEnemies",
-                    "canDamageBoost",
+                    "canNeutralDamageBoost",
                     "canCrouchJump",
                     "Morph",
                     {
@@ -4323,7 +4323,7 @@
                           "canWalljump",
                           "canIframeSpikeJump",
                           "Grapple",
-                          "canDamageBoost"
+                          "canHorizontalDamageBoost"
                         ]}
                       ]}
                     ]}

--- a/tech.json
+++ b/tech.json
@@ -737,8 +737,11 @@
                   "name": "canHorizontalDamageBoost",
                   "requires": [ "canNeutralDamageBoost" ],
                   "note": [
-                    "Using the knockback from taking enemy damage to give Samus a large horizontal knockback.",
-                    "?"
+                    "Using the knockback from taking enemy damage to give Samus a large movement boost by holding the jump and backwards buttons.",
+                    "By changing the timing of the directional input, the way that Samus is knocked back can be changed and has situational uses.",
+                    "Holding forward will knock Samus backwards and down.",
+                    "Holding jump but delaying the back button delays the horizontal damage boost to gain some neutral boost first.",
+                    "Very quickly releasing back and pressing forward will give a forward boost."
                   ]
                 }
               ]

--- a/tech.json
+++ b/tech.json
@@ -729,15 +729,17 @@
               ]
             },
             {
-              "name": "canDamageBoost",
+              "name": "canNeutralDamageBoost",
               "requires": [ "canUseEnemies" ],
-              "note": "Using the knockback from taking enemy damage to assist Samus in her movement.",
-              "devNote": "FIXME This could use a better description",
+              "note": "Using the small vertical knockback from taking enemy damage, while not holding any directional inputs, to assist Samus in her movement.",
               "extensionTechs": [
                 {
-                  "name": "canContinuousDboost",
-                  "requires": [ "canDamageBoost" ],
-                  "note": "A tech that involves multiple damage boosts with precise timing. No room for missing one of them."
+                  "name": "canHorizontalDamageBoost",
+                  "requires": [ "canNeutralDamageBoost" ],
+                  "note": [
+                    "Using the knockback from taking enemy damage to give Samus a large horizontal knockback.",
+                    "?"
+                  ]
                 }
               ]
             },


### PR DESCRIPTION
Split damage boost tech into two: `canNeutralDamageBoost` and `canHorizontalDamageBoost`. Remove `canContinuousDboost`, as its 3 uses were notable horizontal ones.

Looking for help with the `canHorizontalDamageBoost` description