### PR TITLE
Double Chamber Wall Jump

### DIFF
--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -4746,18 +4746,73 @@
               "id": 1,
               "strats": [
                 {
-                  "name": "Walljump",
+                  "name": "Walljump on the Kamer",
                   "notable": false,
                   "requires": [
                     "h_canNavigateHeatRooms",
+                    "canPreciseWalljump",
+                    "canConsecutiveWalljump",
+                    "canUseEnemies",
                     {"or":[
-                      "canConsecutiveWalljump",
-                      {"and": [
-                        "HiJump",
-                        "canWalljump"
+                      {"heatFrames": 560},
+                      {"and":[
+                        "canCarefulJump",
+                        {"heatFrames": 384}
+                      ]},
+                      {"and":[
+                        "canTrickyJump",
+                        {"heatFrames": 276}
+                      ]},
+                      {"and":[
+                        {"or":[
+                          "canUseFrozenEnemies",
+                          {"ammo": { "type": "Super", "count": 1 }}
+                        ]},
+                        {"heatFrames": 432}
+                      ]},
+                      {"and":[
+                        {"ammo": {"type": "PowerBomb","count": 1}},
+                        {"heatFrames": 456}
                       ]}
-                    ]},
-                    {"heatFrames": 250}
+                    ]}
+                  ],
+                  "note": [
+                    "Wall jump up the left wall and then on the moving platform (Kamer) while avoiding the Fune's fireball.",
+                    "The Kamers will temporarily move down if Samus is below them, so it is best to walk under them before climbing the wall.",
+                    "It is possible to freeze or kill the Fune with a Super or Power Bomb to make things easier."
+                  ]
+                },
+                {
+                  "name": "Delayed Walljump",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "canDelayedWalljump",
+                    "canConsecutiveWalljump",
+                    "canUseEnemies",
+                    {"heatFrames": 200}
+                  ],
+                  "note": "Wall jump up the left wall, perform a delayed wall jump on the Fune to reach the door."
+                },
+                {
+                  "name": "Walljump with HiJump",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "HiJump",
+                    "canUseEnemies",
+                    "canWalljump",
+                    {"or":[
+                      {"heatFrames": 360},
+                      {"and":[
+                        "canCarefulJump",
+                        {"heatFrames": 250}
+                      ]}
+                    ]}
+                  ],
+                  "note": [
+                    "Wall jump up the left wall and then on the moving platform (Kamer) while avoiding the Fune's fireball.",
+                    "The Kamers will temporarily move down if Samus is below them, so it is best to walk under them before climbing the wall."
                   ]
                 },
                 {

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -4822,6 +4822,7 @@
                     "h_canNavigateHeatRooms",
                     "canDelayedWalljump",
                     "canConsecutiveWalljump",
+                    "canTrickyJump",
                     "canUseEnemies",
                     {"or": [
                       {"heatFrames": 190},

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -4706,6 +4706,16 @@
           "dropRequires": ["h_heatProof"]
         }
       ],
+      "reusableRoomwideNotable": [
+        {
+          "name": "Double Chamber Walljump Climb Using the Kamer",
+          "note": [
+            "Wall jump up the left wall and then on the moving platform (Kamer) while avoiding the Fune's fireball.",
+            "The Kamers will temporarily move down if Samus is below them, so it is best to walk under the first Kamer before climbing the wall.",
+            "It is possible to freeze or kill the Fune with a Super or Power Bomb to make things easier."
+          ]
+        }
+      ],
       "links": [
         {
           "from": 1,
@@ -4746,8 +4756,8 @@
               "id": 1,
               "strats": [
                 {
-                  "name": "Walljump on the Kamer",
-                  "notable": false,
+                  "name": "Double Chamber Walljump Climb Using the Kamer",
+                  "notable": true,
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "canPreciseWalljump",
@@ -4761,7 +4771,7 @@
                       ]},
                       {"and":[
                         "canTrickyJump",
-                        {"heatFrames": 276}
+                        {"heatFrames": 240}
                       ]},
                       {"and":[
                         {"or":[
@@ -4776,33 +4786,16 @@
                       ]}
                     ]}
                   ],
+                  "reusableRoomwideNotable": "Double Chamber Walljump Climb Using the Kamer",
                   "note": [
                     "Wall jump up the left wall and then on the moving platform (Kamer) while avoiding the Fune's fireball.",
-                    "The Kamers will temporarily move down if Samus is below them, so it is best to walk under them before climbing the wall.",
+                    "The Kamers will temporarily move down if Samus is below them, so it is best to walk under the first Kamer before climbing the wall.",
                     "It is possible to freeze or kill the Fune with a Super or Power Bomb to make things easier."
                   ]
                 },
                 {
-                  "name": "Delayed Walljump",
-                  "notable": false,
-                  "requires": [
-                    "h_canNavigateHeatRooms",
-                    "canDelayedWalljump",
-                    "canConsecutiveWalljump",
-                    "canUseEnemies",
-                    {"or": [
-                      {"heatFrames": 200},
-                      {"and": [   
-                        "canPrepareForNextRoom",
-                        {"heatFrames": 120}
-                      ]}
-                    ]}
-                  ],
-                  "note": "Wall jump up the left wall, perform a delayed wall jump on the Fune to reach the door."
-                },
-                {
-                  "name": "Walljump with HiJump",
-                  "notable": false,
+                  "name": "Double Chamber Walljump Climb Using the Kamer with HiJump",
+                  "notable": true,
                   "requires": [
                     "h_canNavigateHeatRooms",
                     "HiJump",
@@ -4816,10 +4809,29 @@
                       ]}
                     ]}
                   ],
+                  "reusableRoomwideNotable": "Double Chamber Walljump Climb Using the Kamer",
                   "note": [
                     "Wall jump up the left wall and then on the moving platform (Kamer) while avoiding the Fune's fireball.",
-                    "The Kamers will temporarily move down if Samus is below them, so it is best to walk under them before climbing the wall."
+                    "The Kamers will temporarily move down if Samus is below them, so it is best to walk under the first Kamer before climbing the wall."
                   ]
+                },
+                {
+                  "name": "Delayed Walljump",
+                  "notable": false,
+                  "requires": [
+                    "h_canNavigateHeatRooms",
+                    "canDelayedWalljump",
+                    "canConsecutiveWalljump",
+                    "canUseEnemies",
+                    {"or": [
+                      {"heatFrames": 190},
+                      {"and": [   
+                        "canPrepareForNextRoom",
+                        {"heatFrames": 120}
+                      ]}
+                    ]}
+                  ],
+                  "note": "Wall jump up the left wall, perform a delayed wall jump on the Fune to reach the door."
                 },
                 {
                   "name": "Space Jump",

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -4790,7 +4790,13 @@
                     "canDelayedWalljump",
                     "canConsecutiveWalljump",
                     "canUseEnemies",
-                    {"heatFrames": 200}
+                    {"or": [
+                      {"heatFrames": 200},
+                      {"and": [   
+                        "canPrepareForNextRoom",
+                        {"heatFrames": 120}
+                      ]}
+                    ]}
                   ],
                   "note": "Wall jump up the left wall, perform a delayed wall jump on the Fune to reach the door."
                 },

--- a/region/norfair/east.json
+++ b/region/norfair/east.json
@@ -4767,7 +4767,7 @@
                       {"heatFrames": 560},
                       {"and":[
                         "canCarefulJump",
-                        {"heatFrames": 384}
+                        {"heatFrames": 360}
                       ]},
                       {"and":[
                         "canTrickyJump",


### PR DESCRIPTION
I know this doesn't address all of the concerns in #988, but this is how I would write the strat.
- It's still in `Basic` with HiJump, but with ~50% more frames. 
- It's also still in `Medium` without HiJump, but now requires `canPreciseWalljump` in addition to `canConsecutiveWalljump`, and either more than 2x the frames or `canCarefulJump` and 1.5x the frames.
- It's now tighter with `canDelayedWalljump`

I wouldn't be opposed to moving `canPreciseWalljump` into `Hard`