### PR TITLE
Bump up requirement for Frozen Pirate Plasma Escape

### DIFF
--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -4994,12 +4994,14 @@
                   "name": "Frozen Wall Pirate Plasma Escape",
                   "notable": false,
                   "requires": [
-                    "canUseFrozenEnemies",
+                    "canTrickyUseFrozenEnemies",
                     "canPreciseWalljump"
                   ],
                   "note": [
                     "It's possible to climb up with just ice by freezing the wall space pirates (who can be frozen and killed without Plasma).",
-                    "Clearing the grey door lock would require killing the frozen pirate after using it to climb."
+                    "Clearing the grey door lock would require killing the frozen pirate after using it to climb.",
+                    "To do this most easily, freeze the Pirate as high as possible on the left wall.",
+                    "After reaching the top, it can help to reset the camera by moving to the right on the center platform and then back left."
                   ]
                 },
                 {

--- a/region/maridia/inner-yellow.json
+++ b/region/maridia/inner-yellow.json
@@ -5001,6 +5001,7 @@
                     "It's possible to climb up with just ice by freezing the wall space pirates (who can be frozen and killed without Plasma).",
                     "Clearing the grey door lock would require killing the frozen pirate after using it to climb.",
                     "To do this most easily, freeze the Pirate as high as possible on the left wall.",
+                    "Bait the pirate to jump across the room early so that it stays high on the wall, or bring it on camera by jumping below the platform if the wall pirate gets too low.",
                     "After reaching the top, it can help to reset the camera by moving to the right on the center platform and then back left."
                   ]
                 },


### PR DESCRIPTION
This upgrades the `canUseFrozenEnemies` requirement to `canTrickyUseFrozenEnemies` and adds more details to the description of the strat. This only affects the 3 -> 1 link, the one that requires killing all the pirates, which is what makes the strat tricky.