### PR TITLE
Grapple Beam Room strats for item grab+shinespark

### DIFF
--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -234,6 +234,19 @@
       "clearsObstacles": ["A"]
     },
     {
+      "link": [2, 2],
+      "name": "Shinespark Escape",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        {"shinespark": {
+          "frames": 6
+        }}
+      ],
+      "exitCondition": {
+        "leaveWithSpark": {}
+      }
+    },
+    {
       "link": [2, 3],
       "name": "Base",
       "requires": []


### PR DESCRIPTION
This is handled with an abstract obstacle like we did in Screw Attack Room.

The main scenario here is coming in shinecharged from the top door, grabbing the item, and leaving back out the top with a shinespark. 

Coming in from the bottom door shinecharged (or shinecharging) and/or sparking out the bottom right door is also modeled: it can come into play if going back through the right door to set up the shinecharge afterward would not be possible (or come with extra costs, e.g. more heat damage), such as if the room to the right is Croc Escape.