### PR TITLE
Snail Clip - Morph, no X-Ray

### DIFF
--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -137,10 +137,10 @@
       "note": "Snail Climb without movement items by better coordinating the movements of both the snail and Samus."
     },
     {
-      "name": "Aqueduct Snail Clip",
+      "name": "Aqueduct Snail Clip With Gravity and Morph",
       "note": [
         "Jump on the Snail when it is at a precise location, and then crouch jump through the ceiling and jump again, without moving between jumps.",
-        "The Snail's positioning is very precise, but it is more lenient with Morph and an X-Ray Turn Around. X-Ray can also be useful for helping position the Snail.",
+        "The Snail's positioning is very precise. Morph can be used to help get onto the Snail and get off without taking a hit if it is in the wrong location.",
         "This clip can be used to get to the middle left door and the items in the top right of the room."
       ]
     },
@@ -525,7 +525,6 @@
       "id": 13,
       "link": [2, 1],
       "name": "Snail Clip to the Left Middle Door",
-      "notable": true,
       "requires": [
         "Gravity",
         "canUseEnemies",
@@ -534,11 +533,27 @@
           "canXRayCeilingClip"
         ]}
       ],
-      "reusableRoomwideNotable": "Aqueduct Snail Clip",
       "flashSuitChecked": true,
       "note": [
         "Jump on the Snail when it is at a precise location, and then crouch jump through the ceiling and jump again, without moving between jumps.",
         "The Snail's positioning is very precise, but it is more lenient with Morph and an X-Ray Turn Around. X-Ray can also be useful for helping position the Snail."
+      ]
+    },
+    {
+      "link": [2, 1],
+      "name": "Snail Clip with Morph to the Left Middle Door",
+      "notable": true,
+      "requires": [
+        "Gravity",
+        "canUseEnemies",
+        "Morph",
+        "canCeilingClip"
+      ],
+      "reusableRoomwideNotable": "Aqueduct Snail Clip With Gravity and Morph",
+      "flashSuitChecked": true,
+      "note": [
+        "Jump on the Snail when it is at a precise location, and then crouch jump through the ceiling and jump again, without moving between jumps.",
+        "The Snail's positioning is very precise. Morph can be used to help get onto the Snail and get off without taking a hit if it is in the wrong location."
       ]
     },
     {
@@ -1772,7 +1787,6 @@
       "id": 82,
       "link": [5, 7],
       "name": "Snail Clip to the Items",
-      "notable": true,
       "requires": [
         "Gravity",
         "canUseEnemies",
@@ -1781,11 +1795,27 @@
           "canXRayCeilingClip"
         ]}
       ],
-      "reusableRoomwideNotable": "Aqueduct Snail Clip",
       "flashSuitChecked": true,
       "note": [
         "Jump on the Snail when it is at a precise location, and then crouch jump through the ceiling and jump again, without moving between jumps.",
         "The Snail's positioning is very precise, but it is more lenient with Morph and an X-Ray Turn Around. X-Ray can also be useful for helping position the Snail."
+      ]
+    },
+    {
+      "link": [5, 7],
+      "name": "Snail Clip with Morph to the Items",
+      "notable": true,
+      "requires": [
+        "Gravity",
+        "canUseEnemies",
+        "Morph",
+        "canCeilingClip"
+      ],
+      "reusableRoomwideNotable": "Aqueduct Snail Clip With Gravity and Morph",
+      "flashSuitChecked": true,
+      "note": [
+        "Jump on the Snail when it is at a precise location, and then crouch jump through the ceiling and jump again, without moving between jumps.",
+        "The Snail's positioning is very precise. Morph can be used to help get onto the Snail and get off without taking a hit if it is in the wrong location."
       ]
     },
     {


### PR DESCRIPTION
This is an attempt to lower the difficulty of the snail clip strat with just Morph (no x-ray). I don't think the general clip needs to be notable, since it is so well known. Instead, I repurposed the notable to only be used for placing this middle tier version (precise positioning with morph, but no x-ray) in a lower difficulty than `canPreciseCeilingClip`. 

To me, this one feels easier than normal `canPreciseCeilingClip` strats, as there is no precise refreeze to move it a pixel or two at a time with risk of killing the enemy.