### PR TITLE
Add Warehouse Zeela blue bounce unmorph strat

### DIFF
--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -466,7 +466,10 @@
       "requires": [
         "canChainTemporaryBlue",
         "canSpringBallBounce",
-        "canInsaneJump"
+        {"or": [
+          "canInsaneJump",
+          "canPauseRemorphTemporaryBlue"
+        ]}
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {
@@ -479,8 +482,8 @@
       "flashSuitChecked": true,
       "note": [
         "Unmorph immediately after exiting the tunnel while still descending, to continue chaining temporary blue.",
-        "The frame window for the unmorph depends on the alignment of Samus' bounces;",
-        "in the worst case where Samus bounces upward while exiting, this method will unavoidably fail."
+        "The frame window for the unmorph depends on the alignment of Samus' bounces.",
+        "Even if Samus bounces upward out of the tunnel, it is possible to unmorph and use a pause buffer to remorph while retaining blue."
       ],
       "devNote": "The runway has 1 unusable tile, to allow space to perform the blue bounce."
     },


### PR DESCRIPTION
Video: https://videos.maprando.com/video/648

This adds a strat that comes in shinecharging, bounces through the tunnel, then leaves with temporary blue up through the door.

Edit: I was going to also adjust the runway lengths, but decided it's probably better to address separately later, so reverted those changes.