### PR TITLE
Lava Dive pause abuse

### DIFF
--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -682,7 +682,7 @@
         ]},
         "canTrickyJump",
         "canBounceBall",
-        {"heatFrames": 435},
+        {"heatFrames": 365},
         {"lavaFrames": 305}
       ],
       "note": [
@@ -762,7 +762,7 @@
         ]},
         "canTrickyJump",
         "canBounceBall",
-        {"heatFrames": 330},
+        {"heatFrames": 260},
         {"lavaFrames": 200}
       ],
       "note": [
@@ -1182,9 +1182,33 @@
         {"enemyDamage": {"enemy": "Namihe", "type": "fireball", "hits": 1}}
       ],
       "note": [
-        "Use the bottommost right side Namihe to generate a flame and walk with it to the bottommost left Namihe head",
+        "Use the bottom-most right-side Namihe to generate a flame and walk with it to the bottom-most left Namihe head.",
         "Use a turnaround animation as Samus is hit by the flame to cancel out knockback frames.",
         "While invulnerability frames are active, walljump up the spikes either 2 or 3 times and jump accross to catch the middle wall and climb from there."
+      ]
+    },
+    {
+      "link": [5, 3],
+      "name": "HiJumpless Dive with Pause Abuse",
+      "requires": [
+        {"notable": "HiJumpless Dive"},
+        "canSuitlessLavaDive",
+        "canUseIFrames",
+        "canStaggeredWalljump",
+        "canFastWalljumpClimb",
+        "canUseEnemies",
+        "canCameraManip",
+        {"heatFrames": 175},
+        {"gravitylessLavaFrames": 175},
+        "h_pauseAbuseMinimalReserveRefill",
+        {"heatFrames": 375},
+        {"gravitylessLavaFrames": 300}
+      ],
+      "note": [
+        "Use the bottom-most right-side Namihe to generate a flame and walk with it to the bottommost left Namihe head.",
+        "Pause and use a turnaround animation as Samus is hit by the flame to cancel out knockback frames.",
+        "Manually refill energy from reserves.",
+        "While invulnerability frames are active, wall jump up the spikes either 2 or 3 times and jump accross to catch the middle wall and climb from there."
       ]
     },
     {


### PR DESCRIPTION
This adds a pause abuse version of the hijumpless lava dive. With a (in-room) bounceball entry, this now becomes logical with Varia in Extreme with 0+1 tanks (normally 2 tanks would be needed), and suitless in Insane with 2+3 tanks (normally 7 tanks would be needed, or 6 with the Namihe kago).

I also noticed the in-room bounceball entry strats had too many heat frames: for the 2->5 one I'm guessing the 330 value was just copied from the regular "Suitless Lava Entry" heat frames and wasn't updated. This ends up making the difference in the 2+3 scenario being logically possible.

Videos:
- Varia: https://videos.maprando.com/video/7148
- suitless: https://videos.maprando.com/video/7168

(I noticed this strat based on Sam's video, which does the trick with Varia after a CF: https://videos.maprando.com/video/5612)