### PR TITLE
Fix Wasteland traversal missing a Power Bomb

### DIFF
--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -1671,8 +1671,14 @@
         "h_bombThings",
         {"or": [
           "h_usePowerBomb",
-          "canInsaneJump",
-          {"obstaclesCleared": ["E"]}
+          {"and": [
+            "h_useMorphBombs",
+            "canInsaneJump"
+          ]},
+          {"and": [
+            "h_useMorphBombs",
+            {"obstaclesCleared": ["E"]}
+          ]}
         ]},
         {"heatFrames": 350}
       ],


### PR DESCRIPTION
This should fix the error that Nito found, where it expected him to traverse Wasteland from bottom to top with 2 PBs instead of 3.