### PR TITLE
Update Fast Pillars Setup Ascent

### DIFF
--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -2284,7 +2284,7 @@
       "name": "HiJump",
       "requires": [
         "HiJump",
-        {"heatFrames": 250},
+        {"heatFrames": 200},
         {"or": [
           {"and": [
             "h_usePowerBomb",
@@ -2309,11 +2309,17 @@
       "name": "HiJumpless",
       "requires": [
         {"or": [
-          "canPreciseWalljump",
+          {"and": [
+            "canPreciseWalljump",
+            {"or": [
+              "canStationarySpinJump",
+              {"heatFrames": 250}
+            ]}
+          ]},
           "canSpringBallJumpMidAir",
           "SpaceJump"
         ]},
-        {"heatFrames": 400},
+        {"heatFrames": 250},
         {"or": [
           "h_usePowerBomb",
           {"obstaclesCleared": ["A"]}


### PR DESCRIPTION
This puts tech on jumping through the 1 tile gap first try.
FastPillarsSetupRoom was too uncomfortable for Hard in our weekly race.  

These made it look like all the heat frames need to be looked at.
I didn't see a way to help with Top of PillerSetupRoom->Tourian Hoppers on 1 Etank+Screw.