### PR TITLE
Add missing requirements in Rinka Shaft shinecharges

### DIFF
--- a/region/tourian/main/Rinka Shaft.json
+++ b/region/tourian/main/Rinka Shaft.json
@@ -1186,7 +1186,7 @@
     {
       "id": 54,
       "link": [3, 2],
-      "name": "Come in Shinecharged, Leave With Spark (Hi-Jump Platforming)",
+      "name": "Come in Shinecharged, Leave With Spark (HiJump Platforming)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },


### PR DESCRIPTION
Several of the strats here had HiJump and/or wall-jump requirements mentioned in the strat names while omitting them from the actual requirements.