### PR TITLE
Lower Norfair East check flash suits pt. 1 (Amphitheatre)

### DIFF
--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -567,26 +567,6 @@
       ]
     },
     {
-      "link": [1, 4],
-      "name": "Shinespark (Use Flash Suit, No Momentum)",
-      "requires": [
-        "canShinechargeMovementTricky",
-        "canInsaneJump",
-        {"useFlashSuit": {}},
-        {"shinespark": {"frames": 37, "excessFrames": 0}},
-        {"heatFrames": 280}
-      ],
-      "note": [
-        "Spark diagonally to bonk the underside of the top floating platform,",
-        "far enough right to be able to land on the next platform over."
-      ],
-      "devNote": [
-        "This assumes a worst-case entry, e.g. from water physics.",
-        "The canInsaneJump is because of the absence of a good visual cue for where to spark,",
-        "since the stalactite may be far off-camera."
-      ]
-    },
-    {
       "id": 39,
       "link": [1, 5],
       "name": "Base",


### PR DESCRIPTION
Amphitheatre had some interesting `useFlashSuit` strats to add, for both left-to-right and right-to-left.

The wildest one is the "Thread the Needle Shinespark" which Sam shared earlier this year (https://videos.maprando.com/video/3294). I'm thinking probably Insane for this notable? It comes down to a single frame-perfect input with a good visual cue, so it's not that difficult. But you do have to prepare a flash suit for it (at least that's what the logic will expect), and failure results in death. The last-frame jump into the room is also frame-perfect though this should already be well-practiced and I imagine in most scenarios you would be able to retry it; maybe not if the previous room is heated though.

I recorded a bunch of videos to illustrate how the room traversal works out with different runway lengths or suit combinations:
- Left-to-right (Thread the Needle Shinespark, 4-tile runway, suitless, 1 tank): https://videos.maprando.com/video/8400
- Left-to-right (easier shinespark, 3-tile runway, suitless, 1 tank): https://videos.maprando.com/video/8398
- Left-to-right (easier shinespark, 1-tile runway, suitless, 1 tank): https://videos.maprando.com/video/8397
- Left-to-right (harder shinespark, no runway, suitless, 2 tanks): https://videos.maprando.com/video/8399
- Right-to-left (both suits, 1 tank): https://videos.maprando.com/video/8406
- Right-to-left (Gravity only, 3 tanks): https://videos.maprando.com/video/8402
- Right-to-left (Varia only, 2 tanks): https://videos.maprando.com/video/8403
- Right-to-left (suitless, 5 tanks): https://videos.maprando.com/video/8405