### PR TITLE
Refine Moat CWJ

### DIFF
--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -411,9 +411,13 @@
       "collectsItems": [3],
       "flashSuitChecked": true,
       "note": [
-        "Aligning against the closed door shell on the other side of the transition.",
+        "Align against the closed door shell on the other side of the transition.",
         "Run towards the water and jump on the last possible frame.",
         "Perform the CWJ off of the item pedestal to cross to the other side."
+      ],
+      "detailNote": [
+        "This requires running and jumping on the last possible frame before Samus would run off into the water.",
+        "If the setup is done correctly, there will then be a 2-frame window for the wall jump."
       ]
     },
     {
@@ -441,6 +445,13 @@
         "Stand on the farthest pixel into the door possible using moonwalk, X-Ray, or morphball turn around.",
         "Run towards the water and jump on the last possible frame.",
         "Perform the CWJ off of the item pedestal to cross to the other side."
+      ],
+      "detailNote": [
+        "This requires running and jumping on the last possible frame before Samus would run off into the water.",
+        "There is either a 1-frame or 2-frame window for the wall jump, depending on Samus' X subpixel position.",
+        "To get a 2-frame window, Samus must start in the leftmost 75% of the pixel next to the transition.",
+        "One method to guarantee that Samus gets a good subpixel is to jump and press against the overhang to align with it,",
+        "then land, turn around, and moonwalk back into position."
       ]
     },
     {


### PR DESCRIPTION
The idea is that "First-Try CWJ" will be an Expert notable, while "canCWJ" will move down to Very Hard. This is the only case that will be affected by moving down canCWJ, as all other uses have additional requirements that put them into Extreme or higher. The strat is written assuming that in VH you can reasonably get it in 4 tries (so using 3 Power Bombs); it can be adjusted if you think a different amount of lenience sounds better @osse101 