### PR TITLE
Remaining flashSuitChecked

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -26,7 +26,8 @@
           "strats": [
             {
               "name": "Base",
-              "requires": []
+              "requires": [],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -33,6 +33,7 @@
               "requires": [
                 {"obstaclesCleared": ["C"]}
               ],
+              "flashSuitChecked": true,
               "devNote": "Obstacle can be destroyed either going 1 -> 6 or 6 -> 1."
             }
           ],
@@ -110,7 +111,8 @@
                   "h_ZebesIsAwake",
                   "h_allItemsSpawned"
                 ]}
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ],
           "note": "Item doesn't appear before Zebes is awakened."

--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -50,6 +50,7 @@
                 ]}
               ],
               "clearsObstacles": ["A"],
+              "flashSuitChecked": true,
               "note": [
                 "Both sides of the room must be accessed to reach all enemies and unlock the door.",
                 "Beyond that, the enemies can be killed with Power Beam."
@@ -136,7 +137,8 @@
         {"cycleFrames": 120}
       ],
       "resetsObstacles": ["A"],
-      "farmCycleDrops": [{"enemy": "Zeela", "count": 1}]
+      "farmCycleDrops": [{"enemy": "Zeela", "count": 1}],
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -246,6 +248,7 @@
         "canSpeedball"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "devNote": "There are 3 unusable tiles in this runway."
     },
     {
@@ -258,6 +261,7 @@
         "canSpeedball"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Run on the upper platform to perform the speedball."
     },
     {
@@ -271,6 +275,7 @@
         "canSpeedball"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Use a frozen Zeela to extend the upper platform to help set up the speedball."
     },
     {
@@ -425,6 +430,7 @@
           }
         }
       },
+      "flashSuitChecked": true,
       "devNote": "It's also possible to do a neutral bounce into an uncontrolled spring ball bounce through the door; but it's unclear if it has any application."
     },
     {
@@ -440,7 +446,8 @@
           },
           "maxExtraRunSpeed": "$2.4"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -452,7 +459,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 23,

--- a/region/brinstar/green/Brinstar Reserve Tank Room.json
+++ b/region/brinstar/green/Brinstar Reserve Tank Room.json
@@ -179,6 +179,7 @@
         ]}
       ],
       "collectsItems": [3],
+      "flashSuitChecked": true,
       "note": [
         "Speedball through the morph tunnel and use it to break the bomb blocks in front of the hidden Missile location.",
         "This can be done using Spring Ball, or by unmorphing and using temporary blue to bounce through the bomb blocks."
@@ -204,6 +205,7 @@
         ]}
       ],
       "collectsItems": [3],
+      "flashSuitChecked": true,
       "note": [
         "Speedball through the morph tunnel and use it to break the bomb blocks in front of the hidden Missile location.",
         "This can be done using Spring Ball, or by unmorphing and using temporary blue to bounce through the bomb blocks."
@@ -257,6 +259,7 @@
         "canSpringFling"
       ],
       "collectsItems": [3],
+      "flashSuitChecked": true,
       "note": [
         "Gain temporary blue at the end of the runway.",
         "Then spring ball bounce through the tunnel.",
@@ -283,6 +286,7 @@
         "canInsaneJump"
       ],
       "collectsItems": [3],
+      "flashSuitChecked": true,
       "note": [
         "Enter the room with a precisely positioned blue Spring Ball bounce.",
         "Enter the tunnel and bounce all the way through.",

--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -187,6 +187,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Max extra run speed $1.8."
     },
     {
@@ -205,7 +206,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -224,7 +226,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -238,7 +241,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -339,6 +343,7 @@
           "note": "Falls down into node 3 with no possiblity of quick crumble escape."
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Run then do a very small spin jump to clip into the left side of the first gate.",
         "While inside the gate, back up to get the maximum run distance using either Moonwalk or X-Ray Turnaround and repeat for the next gate.",
@@ -366,6 +371,7 @@
           "note": "Falls down into node 3 with no possiblity of quick crumble escape."
         }
       ],
+      "flashSuitChecked": true,
       "note": [
         "Spawn a Zeb then run and do a very small spin jump to clip into the first gate before the Zeb reaches you.",
         "Do a damage boost off of the Zeb while inside the first gate to get enough speed to clip into the next gate.",
@@ -547,6 +553,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "Gain blue speed in the other room, jump through the transition, then speedball under the shutters.",
       "devNote": [
         "Slightly higher run speeds can work but with greater difficulty.",
@@ -573,6 +580,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "Gain blue speed in the other room, Space Jump through the transition, then speedball under the shutters."
     },
     {
@@ -631,6 +639,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "Gain blue speed in the other room, jump through the transition, then speedball under the shutters."
     },
     {
@@ -761,6 +770,7 @@
           "obstruction": [2, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Max extra run speed $2.5."
     },
     {
@@ -780,6 +790,7 @@
           }
         }
       },
+      "flashSuitChecked": true,
       "note": "Use the runway below the crumbles at the right side of the room."
     },
     {
@@ -795,7 +806,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 47,
@@ -979,7 +991,8 @@
           "canSpringBallJumpMidAir"
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -1000,7 +1013,8 @@
           "blockPositions": [[7, 2]]
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 34,

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -248,7 +248,8 @@
           "length": 4,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -300,6 +301,7 @@
         }
       },
       "collectsItems": [5],
+      "flashSuitChecked": true,
       "devNote": "The item could possibly be avoided depending on the run speed."
     },
     {
@@ -322,6 +324,7 @@
         }
       },
       "collectsItems": [5],
+      "flashSuitChecked": true,
       "devNote": "The item could be avoided by using a shorter landing runway and enough speed"
     },
     {
@@ -339,7 +342,8 @@
           }
         }
       },
-      "collectsItems": [5]
+      "collectsItems": [5],
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -352,7 +356,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -641,6 +646,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Land on the crumble blocks while unmorphing, to retain temporary blue.",
         "Then aim down and use a pause buffer to remorph and chain temporary blue."
@@ -997,6 +1003,7 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "With some dash speed, bounce into the opening of the spikeway, and enter X-mode.",
         "The spike knockback will push Samus back out of the spikeway."
@@ -1111,6 +1118,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Enter the room with a blue speed jump to speedball through the spike tunnel.",
         "Then perform a long temporary blue chain across the room."
@@ -1136,6 +1144,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Gain temporary blue, and use Spring Ball to bounce through the spike tunnel.",
         "Then perform a long temporary blue chain across the room."
@@ -1363,6 +1372,7 @@
         "canUseIFrames",
         "canNeutralDamageBoost"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Freeze a Zebbo inside the wall above the right side of the spikeway, close to the ceiling thorns.",
         "Face right, equip X-Ray, move at least a few pixels away from the wall, and jump straight up into the ceiling thorns.",
@@ -1586,6 +1596,7 @@
           "fallSpeedInTiles": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing."
     },
     {
@@ -1604,6 +1615,7 @@
           "fallSpeedInTiles": 2
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
         "After 195 moonfalls, reposition the Beetom to chest height, then continue dancing."
@@ -1683,6 +1695,7 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "While in X-mode on the thorns, Samus' will be flashing as i-frames periodically refresh;",
         "by timing the shinecharge and X-Ray release to happen soon after i-frames refresh,",
@@ -1971,6 +1984,7 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": [
         "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
         "After 195 moonfalls, reposition the Beetom to chest height, then continue dancing.",

--- a/region/brinstar/green/Green Brinstar Beetom Room.json
+++ b/region/brinstar/green/Green Brinstar Beetom Room.json
@@ -151,7 +151,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -171,7 +172,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -233,6 +235,7 @@
           "fallSpeedInTiles": 1
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Set up three frozen Beetoms, in a such a way that Samus can perform a moonfall between the two upper ones and land on the bottom one,",
         "then leave the room with stored fall speed.",
@@ -265,6 +268,7 @@
           "fallSpeedInTiles": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing."
     },
     {
@@ -287,6 +291,7 @@
           "fallSpeedInTiles": 2
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
         "After 195 moonfalls, reposition the Beetom to chest height, then continue dancing."
@@ -376,6 +381,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Run into the room and off the ledge with blue speed, killing any Beetoms in your path.",
       "devNote": "This does not clear the obstacle since it does not kill all the Beetoms."
     },
@@ -412,6 +418,7 @@
       "requires": [
         "canInsaneJump"
       ],
+      "flashSuitChecked": true,
       "note": "Jump on the first possible frame.  Can be buffered to extend the window to 7 frames.  Or jump just before the transition."
     },
     {
@@ -624,6 +631,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Run into the room and off the ledge with blue speed, killing any Beetoms in your path.",
       "devNote": "This does not clear the obstacle since it does not kill all the Beetoms."
     },
@@ -660,6 +668,7 @@
       "requires": [
         "canInsaneJump"
       ],
+      "flashSuitChecked": true,
       "note": "Jump on the first possible frame.  Can be buffered to extend the window to 7 frames.  Or jump just before the transition."
     },
     {
@@ -913,7 +922,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 46,
@@ -933,7 +943,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 51,
@@ -953,6 +964,7 @@
           "fallSpeedInTiles": 1
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Set up three frozen Beetoms, in a such a way that Samus can perform a moonfall between the two upper ones and land on the bottom one,",
         "then leave the room with stored fall speed.",
@@ -985,6 +997,7 @@
           "fallSpeedInTiles": 1
         }
       },
+      "flashSuitChecked": true,
       "note": "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing."
     },
     {
@@ -1007,6 +1020,7 @@
           "fallSpeedInTiles": 2
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Freeze a Beetom at head height where Samus can Spinjump into it and begin Moondancing.",
         "After 195 moonfalls, reposition the Beetom to chest height, then continue dancing."

--- a/region/brinstar/green/Green Brinstar Fireflea Room.json
+++ b/region/brinstar/green/Green Brinstar Fireflea Room.json
@@ -109,6 +109,7 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
+      "flashSuitChecked": true,
       "note": [
         "Gain a shinecharge running left-to-right at the top of the room.",
         "Then run to the left, jump across the room, and shinespark through the door."
@@ -136,6 +137,7 @@
           "maxExtraRunSpeed": "$3.3"
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "This uses the runway at the top-right of the room, requiring an extremely precise jump in order to thread the needle between the platforms and reach the left door.",
         "If obtaining blue speed, a multi-stutter should be used with a 2-tap shortcharge, with an early second tap and a last-frame jump, in order to gain enough momentum for the jump;",

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -177,7 +177,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -1159,7 +1160,8 @@
           "length": 5,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 29,
@@ -1173,7 +1175,8 @@
           "length": 6,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 30,
@@ -1508,6 +1511,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": "Moonfall towards the leftmost tile of the runway without breaking spin, then jump after landing."
     },
     {
@@ -2300,7 +2304,8 @@
       "id": 85,
       "link": [4, 12],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 86,
@@ -2392,7 +2397,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 90,
@@ -2433,7 +2439,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 92,
@@ -2647,7 +2654,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 102,
@@ -2810,7 +2818,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 112,
@@ -2873,7 +2882,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 115,
@@ -2893,6 +2903,7 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
       "note": "After falling through the shot block, bounce on the single-tile platform (rather than unmorphing onto it) to more easily reach the door."
     },
     {
@@ -2914,7 +2925,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 117,
@@ -2949,7 +2961,8 @@
           "fallSpeedInTiles": 1
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 120,
@@ -2960,7 +2973,8 @@
           "fallSpeedInTiles": 2
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 249,
@@ -2975,6 +2989,7 @@
       "requires": [
         "Morph"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Land in the right side of the leftmost Samus Eater of Alpha Power Bomb Room, or the second Samus Eater from the right of Hellway."
       ]
@@ -3033,7 +3048,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 123,
@@ -3097,7 +3113,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 126,
@@ -3252,7 +3269,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 133,
@@ -3329,7 +3347,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 137,
@@ -3473,7 +3492,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 146,
@@ -3493,7 +3513,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 147,
@@ -3512,7 +3533,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 148,
@@ -3547,7 +3569,8 @@
           "fallSpeedInTiles": 1
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 151,
@@ -3558,7 +3581,8 @@
           "fallSpeedInTiles": 2
         }
       },
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 250,
@@ -3573,6 +3597,7 @@
       "requires": [
         "Morph"
       ],
+      "flashSuitChecked": true,
       "note": ["Land in the right side of the third Samus Eater on the floor of Hellway."]
     },
     {
@@ -3583,6 +3608,7 @@
         "comeInWithSuperSink": {}
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "Enter the room with a super sink, and hold left, to clip down past the Power Bomb blocks."
       ]
@@ -3618,7 +3644,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 153,
@@ -3660,7 +3687,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 155,
@@ -3680,7 +3708,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 156,
@@ -3699,7 +3728,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 157,
@@ -3740,7 +3770,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 159,
@@ -3836,7 +3867,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 164,
@@ -4642,6 +4674,7 @@
       "requires": [
         "canTrickyGrappleJump"
       ],
+      "flashSuitChecked": false,
       "devNote": ["Aside from these two, other setup rooms do not appear to work."]
     },
     {
@@ -4654,7 +4687,8 @@
           "length": 9,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 205,
@@ -4876,6 +4910,7 @@
         "canTrickyJump",
         "canSpringBallBounce"
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "This needs a minimum extra run speed of $6.D.",
         "Speeds of $6.0 or $6.1 can also work but wouldn't provide a benefit over the in-room 'canTrickyDashJump' spring ball jump strat."
@@ -4920,6 +4955,7 @@
         "canTrickySpringBallJump"
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "devNote": [
         "This strat is not very useful, since the in-room tricky dash jump into spring ball jump is easier."
       ]
@@ -5082,7 +5118,8 @@
         ]}
       ],
       "resetsObstacles": ["A"],
-      "farmCycleDrops": [{"enemy": "Ripper 2 (red)", "count": 2}]
+      "farmCycleDrops": [{"enemy": "Ripper 2 (red)", "count": 2}],
+      "flashSuitChecked": true
     },
     {
       "id": 229,
@@ -5114,6 +5151,7 @@
         {"notable": "TAS Dance"},
         "canMoonfall"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Moonfall on the Green Brinstar Elevator Platform to build up enough speed to fall through the Power Bomb Blocks below.",
         "Moonfall so as to stay on the platform, break spin, and turnaround between 70 and 76 times total.",
@@ -5140,6 +5178,7 @@
           {"ammo": {"type": "Super", "count": 2}}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Freeze two Zeelas to perform an 'Enemy Stuck Moonfall' in order to clip through the Power Bomb blocks.",
         "Position one Zeela upside down on a ceiling, and another below it on the ground.",
@@ -5251,6 +5290,7 @@
           {"obstaclesNotCleared": ["A"]}
         ]}
       ],
+      "flashSuitChecked": false,
       "note": [
         "Break the bomb block at the bottom right of the main shaft.",
         "Bring a Zeela down to the bottom of the room.",

--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -285,6 +285,7 @@
           "blue": "yes"
         }
       },
+      "flashSuitChecked": true,
       "devNote": "TODO: Instead of using blue speed, the bomb blocks could also be broken in a different way (or gone around) but it's not clear if there's any application."
     },
     {
@@ -297,7 +298,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -465,7 +467,8 @@
       "requires": [
         "canTrickyJump",
         "canLateralMidAirMorph"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 17,
@@ -481,6 +484,7 @@
         "canInsaneJump",
         "canMomentumConservingMorph"
       ],
+      "flashSuitChecked": true,
       "devNote": "This is technically possible with 14 tiles but it might require too much precision."
     },
     {
@@ -583,7 +587,8 @@
         }
       },
       "requires": [],
-      "wallJumpAvoid": true
+      "wallJumpAvoid": true,
+      "flashSuitChecked": true
     },
     {
       "id": 18,
@@ -691,7 +696,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -710,7 +716,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -730,7 +737,8 @@
           "movementType": "uncontrolled"
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -745,7 +753,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -758,7 +767,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 81,
@@ -775,7 +785,8 @@
           "obstruction": [4, 0]
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -844,7 +855,8 @@
         "canTrickyJump",
         "canLateralMidAirMorph",
         "can4HighMidAirMorph"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 32,
@@ -1104,7 +1116,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 43,
@@ -1426,6 +1439,7 @@
         "canInsaneJump"
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": false,
       "note": [
         "After teleporting, extend the Grapple, and swing back and forth to fix the camera and then to gain momentum.",
         "A precisely timed release of Grapple will allow Samus to fling onto the ledge on the right."
@@ -1446,6 +1460,7 @@
         "canInsaneJump"
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": false,
       "note": [
         "After teleporting, swing back and forth to fix the camera.",
         "Swing to the right by soft-bouncing against the door followed by fully extending the Grapple Beam.",
@@ -1492,7 +1507,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 61,
@@ -1510,7 +1526,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 62,
@@ -1529,7 +1546,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 63,
@@ -1543,7 +1561,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 64,
@@ -1555,7 +1574,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 84,
@@ -1583,7 +1603,8 @@
         ]}
       ],
       "resetsObstacles": ["B"],
-      "farmCycleDrops": [{"enemy": "Sm. Sidehopper", "count": 3}]
+      "farmCycleDrops": [{"enemy": "Sm. Sidehopper", "count": 3}],
+      "flashSuitChecked": true
     },
     {
       "id": 65,
@@ -1683,6 +1704,7 @@
         {"notable": "Tunnel Crawl"},
         "canTunnelCrawl"
       ],
+      "flashSuitChecked": true,
       "note": "It's a long Tunnel Crawl, so there's a heavy softlock risk."
     },
     {
@@ -1734,6 +1756,7 @@
         {"notable": "Tunnel Crawl"},
         "canTunnelCrawl"
       ],
+      "flashSuitChecked": true,
       "note": "It's a long Tunnel Crawl, so there's a heavy softlock risk."
     }
   ],

--- a/region/brinstar/green/Noob Bridge.json
+++ b/region/brinstar/green/Noob Bridge.json
@@ -120,6 +120,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Max extra run speed $7.0."
     },
     {
@@ -148,7 +149,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -166,7 +168,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -185,7 +188,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -200,7 +204,8 @@
           },
           "maxExtraRunSpeed": "$6.0"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -212,7 +217,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -412,6 +418,7 @@
           "obstruction": [3, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Max extra run speed $3.F."
     },
     {
@@ -445,7 +452,8 @@
           },
           "minExtraRunSpeed": "$6.2"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -466,6 +474,7 @@
           "movementType": "controlled"
         }
       },
+      "flashSuitChecked": true,
       "note": "Depending on the speed needed, first speedball from the bridge onto the floor and then bounce onto the ledge in front of the door."
     },
     {
@@ -481,7 +490,8 @@
           },
           "minExtraRunSpeed": "$7.0"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 24,
@@ -509,7 +519,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -527,7 +538,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 27,
@@ -546,7 +558,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -560,7 +573,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 29,

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -26,6 +26,7 @@
             {
               "name": "Base",
               "requires": [],
+              "flashSuitChecked": true,
               "note": "The enemies can be killed with Power Beam"
             }
           ],
@@ -53,6 +54,7 @@
             {
               "name": "Base",
               "requires": [],
+              "flashSuitChecked": true,
               "note": "The enemies can be killed with Power Beam"
             }
           ],
@@ -143,7 +145,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 4,
@@ -161,7 +164,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -180,7 +184,8 @@
           },
           "movementType": "uncontrolled"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -194,7 +199,8 @@
             "openEnd": 0
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 7,
@@ -206,7 +212,8 @@
       ],
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -236,7 +243,8 @@
           ]}
         ]}
       ],
-      "farmCycleDrops": [{"enemy": "Kihunter (green)", "count": 3}]
+      "farmCycleDrops": [{"enemy": "Kihunter (green)", "count": 3}],
+      "flashSuitChecked": true
     },
     {
       "id": 8,

--- a/region/brinstar/green/Spore Spawn Room.json
+++ b/region/brinstar/green/Spore Spawn Room.json
@@ -111,6 +111,7 @@
         "canBePatient"
       ],
       "setsFlags": ["f_DefeatedSporeSpawn"],
+      "flashSuitChecked": true,
       "note": [
         "Use the Plasma Special Beam Attack to kill Spore Spawn from above.",
         "Spore Spawn will move out of range after the first hit and it will take 9 cycles to come back into range.",
@@ -131,6 +132,7 @@
         "canXRayWaitForIFrames"
       ],
       "setsFlags": ["f_DefeatedSporeSpawn"],
+      "flashSuitChecked": true,
       "note": [
         "Use the Plasma Special Beam Attack to kill Spore Spawn from above.",
         "Stand in the middle of the second lowest platform above Spore Spawn, facing left and crouched.",
@@ -152,6 +154,7 @@
         "canFreeFallClip",
         {"enemyDamage": {"enemy": "Spore Spawn", "type": "contact", "hits": 1}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Prepare an extended Moondance and wait for SporeSpawn to move to a side.",
         "In quick succession, Moonfall, turn left, and turn right while holding a spin break button to clip down into the fight arena."
@@ -169,6 +172,7 @@
         "comeInWithSuperSink": {}
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": [
         "Enter the room with a super sink, in order to clip down into the fight arena."
       ]
@@ -193,6 +197,7 @@
       "requires": [
         {"shinespark": {"frames": 16, "excessFrames": 16}}
       ],
+      "flashSuitChecked": true,
       "devNote": "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark."
     },
     {
@@ -207,6 +212,7 @@
         "f_DefeatedSporeSpawn",
         {"shinespark": {"frames": 3, "excessFrames": 3}}
       ],
+      "flashSuitChecked": true,
       "devNote": "This strat is not useful in-room, but can satisfy a strat in the room before with an exit shinespark."
     },
     {
@@ -249,7 +255,8 @@
           "canBeVeryPatient"
         ]}
       ],
-      "setsFlags": ["f_DefeatedSporeSpawn"]
+      "setsFlags": ["f_DefeatedSporeSpawn"],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -263,6 +270,7 @@
         ]}
       ],
       "setsFlags": ["f_DefeatedSporeSpawn"],
+      "flashSuitChecked": true,
       "devNote": "No ammo count because Missiles are farmable here."
     },
     {
@@ -278,6 +286,7 @@
         {"ammo": {"type": "Super", "count": 4}}
       ],
       "setsFlags": ["f_DefeatedSporeSpawn"],
+      "flashSuitChecked": true,
       "note": "Spore Spawn's pollen does not drop Supers. The fight requires 4 Supers, where many misses could lead to a softlock."
     },
     {

--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -28,6 +28,7 @@
               "requires": [
                 {"obstaclesCleared": ["A"]}
               ],
+              "flashSuitChecked": true,
               "note": "Enemies can be killed by going between nodes 1 and 2."
             }
           ],
@@ -56,6 +57,7 @@
               "requires": [
                 {"obstaclesCleared": ["A"]}
               ],
+              "flashSuitChecked": true,
               "note": "Enemies can be killed by going between nodes 1 and 2."
             }
           ],

--- a/region/brinstar/kraid/Kraid Eye Door Room.json
+++ b/region/brinstar/kraid/Kraid Eye Door Room.json
@@ -183,6 +183,7 @@
         "canSpikeSuit",
         {"shinespark": {"frames": 4, "excessFrames": 4}}
       ],
+      "flashSuitChecked": true,
       "devNote": ["Leniency is not included, because a farm is available."]
     },
     {
@@ -200,6 +201,7 @@
         "canSpikeSuit",
         {"shinespark": {"frames": 4, "excessFrames": 4}}
       ],
+      "flashSuitChecked": true,
       "devNote": ["Leniency is not included, because a farm is available."]
     },
     {
@@ -722,6 +724,7 @@
         "canSpikeSuit",
         {"shinespark": {"frames": 4, "excessFrames": 4}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Requires precice movement. Down-back during the fall to clear the lower platform while shooting out the blocks."
       ],
@@ -1062,6 +1065,7 @@
         "canSpikeSuit",
         {"shinespark": {"frames": 5, "excessFrames": 5}}
       ],
+      "flashSuitChecked": true,
       "devNote": ["Leniency is not included, because a farm is available."]
     },
     {
@@ -1079,6 +1083,7 @@
         "canSpikeSuit",
         {"shinespark": {"frames": 5, "excessFrames": 5}}
       ],
+      "flashSuitChecked": true,
       "devNote": ["Leniency is not included, because a farm is available."]
     }
   ],

--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -28,7 +28,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedKraid"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -55,7 +56,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedKraid"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -28,6 +28,7 @@
               "requires": [
                 {"obstaclesCleared": ["A"]}
               ],
+              "flashSuitChecked": true,
               "note": "This is a softlock if no means to kill Beetoms are available."
             }
           ],

--- a/region/brinstar/kraid/Warehouse Kihunter Room.json
+++ b/region/brinstar/kraid/Warehouse Kihunter Room.json
@@ -237,6 +237,7 @@
         "canFreeFallClip"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Freeze two Kihunters above the door to be able to moonfall between them.",
         "After gaining enough speed, hold backward to move forward and buffer a turnaround to clip through the door."

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -41,7 +41,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedKraid"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -148,7 +149,8 @@
           "length": 6,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -1523,7 +1523,8 @@
           {"obstaclesCleared": ["B"]}
         ]}
       ],
-      "clearsObstacles": ["B"]
+      "clearsObstacles": ["B"],
+      "flashSuitChecked": true
     },
     {
       "id": 36,
@@ -1760,6 +1761,7 @@
         {"types": ["missiles"], "requires": ["never"]},
         {"types": ["powerbomb"], "requires": ["h_useSpringBall"]}
       ],
+      "flashSuitChecked": true,
       "note": "Jump through the door and shoot it open as you enter, landing on the door frame to avoid falling through the crumbles."
     },
     {

--- a/region/brinstar/pink/Mission Impossible Room.json
+++ b/region/brinstar/pink/Mission Impossible Room.json
@@ -30,6 +30,7 @@
               "requires": [
                 {"obstaclesCleared": ["A"]}
               ],
+              "flashSuitChecked": true,
               "devNote": "Obstacle must be destroyed by going to 4 and back."
             }
           ],
@@ -438,6 +439,7 @@
         "comeInWithSuperSink": {}
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": ["Enter the room with a super sink, in order to clip down to the door below."]
     },
     {

--- a/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
+++ b/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
@@ -30,7 +30,8 @@
               "name": "Base",
               "requires": [
                 {"obstaclesCleared": ["A"]}
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]
@@ -58,7 +59,8 @@
               "name": "Base",
               "requires": [
                 {"obstaclesCleared": ["A"]}
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"],
@@ -710,8 +712,9 @@
         "h_SpikeXModeSpikeSuit",
         {"shinespark": {"frames": 3, "excessFrames": 3}}
       ],
-        "resetsObstacles": ["C"],
-        "note": [
+      "resetsObstacles": ["C"],
+      "flashSuitChecked": true,
+      "note": [
         "A one frame dash jump will give Samus 4 pixels of leniency for the bounce position, two frames is pixel perfect and more than two frames it doesn't work.",
         "Samus will jump approximately two tiles higher with a one frame jump compared to a two frame jump."
       ]
@@ -730,6 +733,7 @@
       "exitCondition": {
         "leaveWithSpark": {"position": "top"}
       },
+      "flashSuitChecked": true,
       "note": [
         "A one frame dash jump will give Samus 4 pixels of leniency for the bounce position, two frames is pixel perfect and more than two frames it doesn't work.",
         "Samus will jump approximately two tiles higher with a one frame jump compared to a two frame jump."
@@ -1246,6 +1250,7 @@
       "resetsObstacles": ["C"],
       "clearsObstacles": ["B"],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "A one frame dash jump will give Samus 4 pixels of leniency for the bounce position, two frames is pixel perfect and more than two frames it doesn't work.",
         "Samus will jump approximately two tiles higher with a one frame jump compared to a two frame jump."
@@ -1258,7 +1263,7 @@
         {"or": [
           "Wave",
           {"obstaclesCleared": ["B"]}
-      ]},
+        ]},
         {"obstaclesCleared": ["A"]},
         {"obstaclesNotCleared": ["C"]},
         "canXMode",
@@ -1271,6 +1276,7 @@
       "resetsObstacles": ["C"],
       "clearsObstacles": ["B"],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "A one frame dash jump will give Samus 4 pixels of leniency for the bounce position, two frames is pixel perfect and more than two frames it doesn't work.",
         "Samus will jump approximately two tiles higher with a one frame jump compared to a two frame jump."

--- a/region/brinstar/pink/Spore Spawn Farming Room.json
+++ b/region/brinstar/pink/Spore Spawn Farming Room.json
@@ -269,7 +269,9 @@
       "requires": [
         {"canShineCharge": {"usedTiles": 21, "steepUpTiles": 2, "openEnd": 0}},
         "canRModeSparkInterrupt"
-      ]
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -28,7 +28,8 @@
               "name": "Base",
               "requires": [
                 {"obstaclesCleared": ["A"]}
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]

--- a/region/brinstar/red/Caterpillar Room.json
+++ b/region/brinstar/red/Caterpillar Room.json
@@ -2223,7 +2223,8 @@
           {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 85,

--- a/region/brinstar/red/X-Ray Scope Room.json
+++ b/region/brinstar/red/X-Ray Scope Room.json
@@ -27,6 +27,7 @@
               "requires": [
                 "h_usePowerBomb"
               ],
+              "flashSuitChecked": true,
               "note": "Raise the shutter before checking the item to not become stuck."
             }
           ]

--- a/region/ceres/main/58 Escape.json
+++ b/region/ceres/main/58 Escape.json
@@ -71,6 +71,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -85,7 +86,8 @@
           "length": 30,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -95,6 +97,7 @@
         "h_usePowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -158,7 +161,8 @@
       "id": 7,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -202,7 +206,8 @@
       "id": 10,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -253,6 +258,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -267,7 +273,8 @@
           "length": 30,
           "openEnd": 0
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 15,

--- a/region/ceres/main/Ceres Elevator Room.json
+++ b/region/ceres/main/Ceres Elevator Room.json
@@ -27,7 +27,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedCeresRidley"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -78,13 +79,15 @@
       "id": 1,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 2,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -96,7 +99,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/ceres/main/Ceres Ridley's Room.json
+++ b/region/ceres/main/Ceres Ridley's Room.json
@@ -27,7 +27,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedCeresRidley"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -66,7 +67,8 @@
           "length": 2,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,
@@ -75,7 +77,8 @@
       "requires": [
         "h_usePowerBomb"
       ],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -90,7 +93,8 @@
           "openEnd": 1
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 6,
@@ -100,6 +104,7 @@
         {"resourceAtMost": [{"type": "RegularEnergy", "count": 29}]}
       ],
       "setsFlags": ["f_DefeatedCeresRidley"],
+      "flashSuitChecked": true,
       "note": "Just taking damage is enough to finish the fight.",
       "devNote": [
         "It is possible to finish the fight with more Reserve Energy.",

--- a/region/ceres/main/Dead Scientist Room.json
+++ b/region/ceres/main/Dead Scientist Room.json
@@ -72,6 +72,7 @@
           "steepUpTiles": 1
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -88,7 +89,8 @@
           "steepUpTiles": 3,
           "steepDownTiles": 3
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -98,6 +100,7 @@
         "h_usePowerBomb"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -161,7 +164,8 @@
       "id": 7,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -205,7 +209,8 @@
       "id": 10,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -257,6 +262,7 @@
           "steepUpTiles": 1
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -273,7 +279,8 @@
           "steepUpTiles": 3,
           "steepDownTiles": 3
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 15,

--- a/region/ceres/main/Falling Tile Room.json
+++ b/region/ceres/main/Falling Tile Room.json
@@ -77,6 +77,7 @@
           "steepUpTiles": 1
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -92,7 +93,8 @@
           "openEnd": 0,
           "steepUpTiles": 3
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -102,6 +104,7 @@
         "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -186,7 +189,8 @@
       "id": 8,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 9,
@@ -235,7 +239,8 @@
       "id": 11,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 12,
@@ -292,6 +297,7 @@
           "steepUpTiles": 1
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -307,7 +313,8 @@
           "openEnd": 0,
           "steepUpTiles": 3
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 16,

--- a/region/ceres/main/Magnet Stairs Room.json
+++ b/region/ceres/main/Magnet Stairs Room.json
@@ -79,6 +79,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -93,7 +94,8 @@
           "length": 11,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -103,6 +105,7 @@
         "h_usePowerBomb"
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -166,7 +169,8 @@
       "id": 7,
       "link": [1, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -210,7 +214,8 @@
       "id": 10,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 11,
@@ -263,6 +268,7 @@
           "openEnd": 0
         }
       },
+      "flashSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -278,7 +284,8 @@
           "openEnd": 0,
           "steepDownTiles": 3
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 15,

--- a/region/crateria/central/230 Missile Room.json
+++ b/region/crateria/central/230 Missile Room.json
@@ -42,6 +42,7 @@
                   "h_allItemsSpawned"
                 ]}
               ],
+              "flashSuitChecked": true,
               "devNote": [
                 "Item doesn't spawn until Zebes is awake.",
                 "Interestingly, the Chozo also has a scope that observes Samus, like in Blue Brinstar."

--- a/region/crateria/central/Blue Brinstar Elevator Room.json
+++ b/region/crateria/central/Blue Brinstar Elevator Room.json
@@ -188,7 +188,8 @@
       "id": 9,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 10,

--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -28,7 +28,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedBombTorizo"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ],
           "note": "If no Bombs in inventory, door stays open"
@@ -42,7 +43,8 @@
               "name": "Base",
               "requires": [
                 "f_AnimalsSaved"
-              ]
+              ],
+              "flashSuitChecked": true              
             }
           ]
         }

--- a/region/crateria/central/Climb Supers Room.json
+++ b/region/crateria/central/Climb Supers Room.json
@@ -99,23 +99,26 @@
           "id": 3,
           "strats": [
             {
-              "name": "Walljump",
+              "name": "Wall Jump",
               "requires": [
                 "canConsecutiveWalljump"
-              ]
+              ],
+              "flashSuitChecked": true
             },
             {
-              "name": "SpaceJump",
+              "name": "Space Jump",
               "requires": [
                 "SpaceJump"
-              ]
+              ],
+              "flashSuitChecked": true
             },
             {
               "name": "IBJ",
               "requires": [
                 "canLongIBJ",
                 "canBePatient"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -929,6 +932,7 @@
         "h_speedKeepSpikeHit",
         "canSpeedball"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Bounce into the spikes and use a SpeedKeep to run on spikes to setup for a speedball towards the item.",
         "Bouncing on the platform near the door saves a spike hit.",
@@ -948,7 +952,7 @@
       "requires": [
         "canSpeedKeep",
         "canCarefulJump",
-        {"canShineCharge": {"usedTiles": 21, "openEnd": 2}},
+        {"getBlueSpeed": {"usedTiles": 21, "openEnd": 2}},
         "h_speedKeepSpikeHit",
         {"or": [
           "h_speedKeepSpikeHit",
@@ -959,6 +963,7 @@
         ]},
         "canSpeedball"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Bounce into the spikes and use a SpeedKeep to run on spikes to setup for a speedball towards the item.",
         "A DamageBoost SpeedKeep could be used instead of a Spike SpeedKeep with enough runspeed."
@@ -980,11 +985,11 @@
         {"or": [
           {"and": [
             "canChainTemporaryBlue",
-            {"canShineCharge": {"usedTiles": 13, "openEnd": 1}},
+            {"getBlueSpeed": {"usedTiles": 13, "openEnd": 1}},
             "h_speedKeepSpikeHit"
           ]},
           {"and": [
-            {"canShineCharge": {"usedTiles": 14, "openEnd": 1}},
+            {"getBlueSpeed": {"usedTiles": 14, "openEnd": 1}},
             "h_speedKeepSpikeHit",
             "h_speedKeepSpikeHit"
           ]},
@@ -997,6 +1002,7 @@
         ]},
         "canSpeedball"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Using only the short runway and spike pit, use one or two SpeedKeeps to Speedball towards the item location.",
         "This requires either a very short shortcharge, or a second SpeedKeep in the spikes which also resets Samus' run speed with a crouch jump before spike i-frames expire."
@@ -1317,6 +1323,7 @@
         {"canShineCharge": {"usedTiles": 34, "openEnd": 0}},
         {"shinespark": {"frames": 128, "excessFrames": 6}}
       ],
+      "flashSuitChecked": true,
       "note": "Charge a Shinespark running left, then get blue speed by running back to the right to jump through the Boyons."
     },
     {

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -57,7 +57,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -91,7 +92,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -126,7 +128,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -161,7 +164,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -747,6 +751,7 @@
         "h_ClimbWithoutLava"
       ],
       "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
       "note": "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right."
     },
     {

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -43,6 +43,7 @@
                   "f_ZebesSetAblaze"
                 ]}
               ],
+              "flashSuitChecked": true,
               "note": "The end game sequence overrides the color lock."
             }
           ]

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -32,7 +32,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -79,7 +80,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -110,7 +112,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -153,7 +156,8 @@
               "name": "Base",
               "requires": [
                 "f_ZebesSetAblaze"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -672,7 +676,8 @@
       "requires": [
         "canBlueSpaceJump"
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 17,

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -32,7 +32,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -63,7 +64,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -94,7 +96,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -157,7 +160,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -188,7 +192,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -30,6 +30,7 @@
                 "Missile",
                 "Morph"
               ],
+              "flashSuitChecked": true,
               "note": [
                 "Entering this room with Morph and any missile capacity (0 current missiles is fine) spawns the enemies in this room and makes both doors gray and unlockable by killing the enemies.",
                 "Once the enemies actually spawn, they can be killed with just Power Beam.",
@@ -63,6 +64,7 @@
             {
               "name": "Base",
               "requires": [],
+              "flashSuitChecked": true,
               "note": "This door is unlocked until having morph and missiles, and then free to open after with just power beam."
             }
           ],
@@ -98,6 +100,7 @@
                   "h_allItemsSpawned"
                 ]}
               ],
+              "flashSuitChecked": true,
               "note": "Item doesn't spawn unless Samus has Morph and Missiles, even if Zebes is awake.",
               "devNote": "canAwakenZebes is included to indicate the knowledge for how to spawn the item, the tech's description discusses this item as well."
             }

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -1399,7 +1399,8 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 67,
@@ -1421,7 +1422,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 52,

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -87,7 +87,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -396,7 +396,7 @@
     {
       "id": 15,
       "link": [1, 2],
-      "name": "Blue SpaceJump (Left to Right, Come in Getting Blue Speed)",
+      "name": "Blue Space Jump (Left to Right, Come in Getting Blue Speed)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 6,
@@ -406,7 +406,7 @@
         }
       },
       "requires": [
-        {"notable": "Blue SpaceJump"},
+        {"notable": "Blue Space Jump"},
         "canBlueSpaceJump",
         "canTrickyJump",
         "h_complexToCarryFlashSuit"
@@ -421,14 +421,14 @@
     {
       "id": 16,
       "link": [1, 2],
-      "name": "Blue SpaceJump (Left to Right, Come in Blue Spinning)",
+      "name": "Blue Space Jump (Left to Right, Come in Blue Spinning)",
       "entranceCondition": {
         "comeInBlueSpinning": {
           "unusableTiles": 0
         }
       },
       "requires": [
-        {"notable": "Blue SpaceJump"},
+        {"notable": "Blue Space Jump"},
         "canBlueSpaceJump",
         "canTrickyJump",
         "h_complexToCarryFlashSuit"
@@ -674,7 +674,7 @@
     {
       "id": 27,
       "link": [2, 1],
-      "name": "Blue SpaceJump (Right to Left, Come in Getting Blue Speed)",
+      "name": "Blue Space Jump (Right to Left, Come in Getting Blue Speed)",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 6,
@@ -684,7 +684,7 @@
         }
       },
       "requires": [
-        {"notable": "Blue SpaceJump"},
+        {"notable": "Blue Space Jump"},
         "canBlueSpaceJump",
         "canTrickyJump",
         "h_complexToCarryFlashSuit"
@@ -699,19 +699,20 @@
     {
       "id": 28,
       "link": [2, 1],
-      "name": "Blue SpaceJump (Right to Left, Come in Blue Spinning)",
+      "name": "Blue Space Jump (Right to Left, Come in Blue Spinning)",
       "entranceCondition": {
         "comeInBlueSpinning": {
           "unusableTiles": 0
         }
       },
       "requires": [
-        {"notable": "Blue SpaceJump"},
+        {"notable": "Blue Space Jump"},
         "canBlueSpaceJump",
         "canTrickyJump",
         "h_complexToCarryFlashSuit"
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": [
         "This is a series of precise jumps to fit between the solid walls while clearing a path through the room.",
         "Breaking the center blocks opens up a runway that can be used to charge a new spark in room."
@@ -1105,7 +1106,7 @@
   "notables": [
     {
       "id": 1,
-      "name": "Blue SpaceJump",
+      "name": "Blue Space Jump",
       "note": "This is a series of precise space jumps that clears a path through the room while avoiding the solid walls."
     },
     {

--- a/region/crateria/west/Green Brinstar Elevator Room.json
+++ b/region/crateria/west/Green Brinstar Elevator Room.json
@@ -186,7 +186,8 @@
       "id": 9,
       "link": [2, 1],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 10,

--- a/region/crateria/west/Lower Mushrooms.json
+++ b/region/crateria/west/Lower Mushrooms.json
@@ -130,7 +130,8 @@
         ]},
         "h_shinechargeMaxRunway",
         "h_RModeKnockbackSpark"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 5,
@@ -321,7 +322,8 @@
         ]},
         "h_shinechargeMaxRunway",
         "h_RModeKnockbackSpark"
-      ]
+      ],
+      "flashSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/west/Statues Room.json
+++ b/region/crateria/west/Statues Room.json
@@ -29,7 +29,8 @@
           "unlockStrats": [
             {
               "name": "Base",
-              "requires": []
+              "requires": [],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -353,6 +353,7 @@
         "canSlopeSpark",
         {"shinespark": {"frames": 9, "excessFrames": 9}}
       ],
+      "flashSuitChecked": true,
       "note": [
         "The Geemer and Samus both need to be in a position relative to the slope where the initial damage boost will allow Samus to land on the slope and perform a slopespark.",
         "A normalized setup can be achieved by entering from the right door, shinecharging down the slope and stopping before the Geemer is on screen (just before the second mushroom).",
@@ -376,6 +377,7 @@
           "position": "bottom"
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Walk the Geemer up the slope, killing any wavers on the way. Once the Geemer reaches the top of the second slope walk left to move it off screen.",
         "Go back down the slope to gain enough runway and build a shinecharge up the slope. Jump over the Geemer and perform a slopespark on the slope close to the door."

--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -364,6 +364,7 @@
         {"shinespark": {"frames": 49, "excessFrames": 8}},
         {"heatFrames": 315}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Gain run speed using 4 tiles, and jump on the last frame through the transition.",
         "Frame-perfectly activate a diagonal spark just below the tip of the stalactite.",
@@ -519,6 +520,7 @@
         {"shinespark": {"frames": 37, "excessFrames": 0}},
         {"heatFrames": 280}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Spark diagonally to bonk the underside of the top floating platform,",
         "far enough right to be able to land on the next platform over."
@@ -544,6 +546,7 @@
         {"shinespark": {"frames": 27, "excessFrames": 0}},
         {"heatFrames": 235}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Spark diagonally to bonk the underside of the top floating platform,",
         "far enough right to be able to land on the next platform over."
@@ -565,6 +568,7 @@
         {"shinespark": {"frames": 31, "excessFrames": 0}},
         {"heatFrames": 250}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Spark diagonally to bonk the underside of the top floating platform,",
         "far enough right to be able to land on the next platform over."

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze.json
@@ -1422,7 +1422,8 @@
           ]}
         ]}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 74,

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -28,7 +28,8 @@
               "name": "Base",
               "requires": [
                 {"obstaclesCleared": ["A"]}
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"],

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -34,6 +34,7 @@
               "requires": [
                 {"obstaclesCleared": ["D"]}
               ],
+              "flashSuitChecked": true,
               "devNote": [
                 "The Multiviolas are far away and can't be killed from here, hence the obstacle requirement.",
                 "The only path through this room where killing them and leaving here would be meaningful would have passed through node 4 at some point.",
@@ -46,6 +47,7 @@
                 {"obstaclesCleared": ["C"]},
                 {"obstaclesCleared": ["E"]}
               ],
+              "flashSuitChecked": true,
               "devNote": "The obstacles must already be cleared on the assumption that Samus travels to 7 or 6 and back to unlock the door."
             }
           ],
@@ -1186,7 +1188,8 @@
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 10, "excessFrames": 6}},
         {"heatFrames": 140}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 39,

--- a/region/lowernorfair/east/Pillar Room.json
+++ b/region/lowernorfair/east/Pillar Room.json
@@ -563,6 +563,7 @@
         }
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "Cross the room with Bombs and minimal damage.",
         "Acid damage is expected, but any mistakes greatly increases the time spent in acid."
@@ -1148,6 +1149,7 @@
         }
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "note": [
         "Cross the room with Bombs and minimal damage.",
         "Acid damage is expected, but any mistakes greatly increases the time spent in acid."

--- a/region/lowernorfair/east/Ridley's Room.json
+++ b/region/lowernorfair/east/Ridley's Room.json
@@ -29,7 +29,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedRidley"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -60,7 +61,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedRidley"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -42,7 +42,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedGoldenTorizo"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -124,7 +125,8 @@
                   ]}
                 ]},
                 {"heatFrames": 180}
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -114,7 +114,8 @@
           "length": 3,
           "openEnd": 1
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 2,

--- a/region/maridia/inner-green/Oasis.json
+++ b/region/maridia/inner-green/Oasis.json
@@ -3256,7 +3256,8 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 55,
@@ -3305,6 +3306,7 @@
         {"shinespark": {"frames": 21, "excessFrames": 2}}
       ],
       "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
       "note": "Diagonal spark mid-air from just below the bomb blocks."
     },
     {
@@ -3513,7 +3515,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 93,

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -299,6 +299,7 @@
         "canTrickySpringBallBounce",
         "canSpringFling"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Enter the room with a normalized extra run speed of $2.0,",
         "which can be obtained by gaining max run speed with Speedbooster unequipped;",
@@ -420,6 +421,7 @@
         "canPreciseSpaceJump",
         "canInsaneJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Space Jump into the room with extra run speed at least $5.2.",
         "Land on the floating block before the first Evir."
@@ -614,6 +616,7 @@
         }
       },
       "requires": [],
+      "flashSuitChecked": true,
       "note": ["Space Jump into the room with extra run speed at least $2.4."]
     },
     {
@@ -630,6 +633,7 @@
         "canLateralMidAirMorph",
         "canTrickyJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Space Jump into the room with max run speed without Speed Booster, then quickly airball after the transition."
       ]
@@ -1468,7 +1472,8 @@
           "canTrickyDodgeEnemies",
           {"enemyDamage": {"enemy": "Evir", "type": "particle", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 58,

--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -2484,6 +2484,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Sparking up right from a snail can save some Energy.",
         "With very little Energy, spark up the center of the speed blocks to clear both sides, then snail clip through the last one.",

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -28,7 +28,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedBotwoon"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -152,6 +153,7 @@
           "obstruction": [1, 0]
         }
       },
+      "flashSuitChecked": true,
       "devNote": ["Max extra run speed $2.B with spin, or $2.C with a quick aim-down."]
     },
     {

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -2210,6 +2210,7 @@
         ]},
         "h_complexToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Jump out of the sand to lure down mochtroids to freeze.",
         "It's recommended to bring a Mochtroid into the middle section of the room.",
@@ -2234,6 +2235,7 @@
         ]},
         "h_trickyToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Jump out of the sand to lure down mochtroids to freeze.",
         "It's recommended to bring a Mochtroid into the middle section of the room.",

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -1582,7 +1582,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 48,

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -29,7 +29,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedDraygon"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -56,7 +57,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedDraygon"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -694,6 +696,7 @@
         "Gravity",
         "canSpringwall"
       ],
+      "flashSuitChecked": true,
       "devNote": "The turret cannot be broken."
     },
     {
@@ -1048,7 +1051,8 @@
       "requires": [
         "HiJump",
         "canTrickyGrappleJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 56,

--- a/region/maridia/inner-pink/East Cactus Alley.json
+++ b/region/maridia/inner-pink/East Cactus Alley.json
@@ -776,7 +776,7 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "There is just enough distance for a MidAir SpringBall jump to reach without HiJump, with either a crouch jump or air ball.",
+        "There is just enough distance for a MidAir Spring Ball jump to reach without HiJump, with either a crouch jump or air ball.",
         "To do this, pause and morph early in order to get a spring fling from equipping Spring Ball."
       ],
       "devNote": "The h_maxHeightSpringBallJump is not a h_underwaterMaxHeightSpringBallJump, because Gravity is required."
@@ -819,9 +819,9 @@
       ],
       "flashSuitChecked": true,
       "note": [
-        "SpringBall jump just as Samus exits the water to reach the distant ledge.",
+        "Spring Ball jump just as Samus exits the water to reach the distant ledge.",
         "To get enough horizontal distance, either use a Stationary Lateral Mid-Air Morph with a crouch jump for extra height, or spin jump out before morphing.",
-        "Or SpringBall jump part of the way over and land on a Bomb explosion to cross the rest of the distance."
+        "Or Spring Ball jump part of the way over and land on a Bomb explosion to cross the rest of the distance."
       ],
       "devNote": [
         "The canCrouchJump is not required but makes the strat easier",
@@ -1475,7 +1475,7 @@
       "note": [
         "1) Start the jump from the raised alcove, standing on the edge facing right.",
         "2) Turn-around spin jump to get the necessary horizontal speed to reach the upper ledge.",
-        "3) SpringBall jump after breaking the water line.",
+        "3) Spring Ball jump after breaking the water line.",
         "A lateral mid-air morph or spring fling can help, but are not required.",
         "Unmorphing on a failed attempt can help avoid spike damage."
       ]
@@ -1492,7 +1492,8 @@
             "h_bombThings"
           ]}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 44,
@@ -1503,19 +1504,22 @@
         "canMidAirMorph",
         "canDisableEquipment"
       ],
+      "flashSuitChecked": true,
       "note": "This can be done by turning off Gravity and HiJump to do a mid-air morph through the morph tunnel."
     },
     {
       "id": 45,
       "link": [4, 2],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 46,
       "link": [4, 5],
       "name": "Base",
-      "requires": []
+      "requires": [],
+      "flashSuitChecked": true
     },
     {
       "id": 47,
@@ -1530,7 +1534,8 @@
           "canDiagonalBombJump",
           "h_IBJFromSpikes"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 77,
@@ -1540,6 +1545,7 @@
         "canGravityJump",
         "canTrickyJump"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Kill the Cacatac above by standing near the edge, jumping, and shooting just before hitting the ceiling.",
         "While near the edge, perform a Gravity jump out of the water. A running jump makes this significantly harder."
@@ -1548,9 +1554,10 @@
     {
       "id": 48,
       "link": [5, 4],
-      "name": "Springball Spike Boost",
+      "name": "Spring Ball Spike Boost",
       "requires": [
-        {"notable": "Springball Spike Boost"},
+        {"notable": "Spring Ball Spike Boost"},
+        "h_underwaterCrouchJump",
         "HiJump",
         "canSuitlessMaridia",
         "canTrickyJump",
@@ -1562,7 +1569,11 @@
         "canNeutralDamageBoost",
         {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 2}}
       ],
-      "note": "When the Cacatac on the ground fires a spike, perform a  springball Jump to break the waterline and then hit the spike for extra height."
+      "flashSuitChecked": true,
+      "note": "When the Cacatac on the ground fires a spike, perform a Spring Ball jump to break the waterline and then hit the spike for extra height.",
+      "devNote": [
+        "The crouch jump is not strictly necessary but it helps significantly."
+      ]
     },
     {
       "id": 49,
@@ -1571,22 +1582,24 @@
       "requires": [
         "canUnderwaterWalljump",
         "canSpaceJumpWaterBounce"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 50,
       "link": [5, 4],
-      "name": "HiJumpless Double SpringBall Jump and Bomb-Grapple-Jump",
+      "name": "HiJumpless Double Spring Ball Jump and Bomb-Grapple-Jump",
       "requires": [
-        {"notable": "HiJumpless Double SpringBall Jump and Bomb-Grapple-Jump"},
+        {"notable": "HiJumpless Double Spring Ball Jump and Bomb-Grapple-Jump"},
         "canBombGrappleJump",
         "canDoubleSpringBallJumpMidAir",
         "h_underwaterMaxHeightSpringBallJump"
       ],
+      "flashSuitChecked": false,
       "note": [
-        "1) Crouch jump and then SpringBall jump.",
+        "1) Crouch jump and then Spring Ball jump.",
         "2) Bomb-Grapple-Jump using the distant Cacatac who is above the water.",
-        "3) SpringBall jump again just as Samus exits the water."
+        "3) Spring Ball jump again just as Samus exits the water."
       ]
     },
     {
@@ -1616,6 +1629,7 @@
       "requires": [
         "canUnderwaterWalljumpBreakFree"
       ],
+      "flashSuitChecked": true,
       "note": "It is recommended to do this on the left wall to the right of the two lower Cacatacs, so that Samus can avoid the spikes on a fail."
     },
     {
@@ -1629,7 +1643,8 @@
         "h_XModeSpikeHit",
         "h_shinechargeMaxRunway",
         {"shinespark": {"frames": 17, "excessFrames": 12}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 65,
@@ -1638,7 +1653,8 @@
       "requires": [
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 20, "excessFrames": 12}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 52,
@@ -1661,7 +1677,8 @@
           "canSpringBallBombJump",
           {"spikeHits": 1}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 53,
@@ -1671,11 +1688,19 @@
         "Gravity",
         "canHorizontalDamageBoost",
         "canUseIFrames",
-        {"enemyDamage": {"enemy": "Cacatac", "type": "contact", "hits": 1}}
+        {"or": [
+          {"enemyDamage": {"enemy": "Cacatac", "type": "contact", "hits": 1}},
+          {"and": [
+            "canTrickyDodgeEnemies",
+            {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}}
+          ]}
+        ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Jump into the ceiling Cacatac and damage boost onto the platform between spike pits.",
-        "Use i-frames to cross the second set of spikes."
+        "Use i-frames to cross the second set of spikes.",
+        "With greater difficulty, a Cacatac spike projectile can be used instead."
       ]
     },
     {
@@ -1698,6 +1723,7 @@
           {"spikeHits": 1}
         ]}
       ],
+      "flashSuitChecked": true,
       "devNote": [
         "The first spike pit on the right is considered unavoidable, as if the player has Gravity and HiJump, the jump is quite tricky.",
         "In that scenario, the player will hit the spikes or need the strat with canDisableEquipment."
@@ -1718,12 +1744,13 @@
           "canSpringBallJumpMidAir"
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "This can be done by turning off Gravity and HiJump to jump over both spike pits."
     },
     {
       "id": 56,
       "link": [5, 6],
-      "name": "Suitless Springball",
+      "name": "Suitless Spring Ball",
       "requires": [
         "canSuitlessMaridia",
         "canSpringBallJumpMidAir",
@@ -1741,6 +1768,7 @@
           {"spikeHits": 1}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": "This can be done by turning off Gravity and HiJump to jump over both spike pits."
     },
     {
@@ -1751,6 +1779,7 @@
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 10, "excessFrames": 7}}
       ],
+      "flashSuitChecked": true,
       "note": "It's possible to hit the block on the right while facing left to save some Energy, but that's not expected here."
     },
     {
@@ -1759,7 +1788,8 @@
       "name": "Base",
       "requires": [
         "Morph"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 58,
@@ -1784,7 +1814,8 @@
           {"spikeHits": 1},
           "HiJump"
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 59,
@@ -1797,7 +1828,8 @@
           "canHBJ",
           {"spikeHits": 1}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 60,
@@ -1809,6 +1841,7 @@
         {"disableEquipment": "Gravity"},
         "canTrickyJump"
       ],
+      "flashSuitChecked": true,
       "note": "This can be done by turning off Gravity and HiJump to jump over both spike pits."
     }
   ],
@@ -1831,16 +1864,16 @@
     },
     {
       "id": 4,
-      "name": "Springball Spike Boost",
-      "note": "When the Cacatac on the ground fires a spike, perform a  springball Jump to break the waterline and then hit the spike for extra height."
+      "name": "Spring Ball Spike Boost",
+      "note": "When the Cacatac on the ground fires a spike, perform a  Spring Ball jump to break the waterline and then hit the spike for extra height."
     },
     {
       "id": 5,
-      "name": "HiJumpless Double SpringBall Jump and Bomb-Grapple-Jump",
+      "name": "HiJumpless Double Spring Ball Jump and Bomb-Grapple-Jump",
       "note": [
-        "1) Crouch jump and then SpringBall jump.",
+        "1) Crouch jump and then Spring Ball jump.",
         "2) Bomb-Grapple-Jump using the distant Cacatac who is above the water.",
-        "3) SpringBall jump again just as Samus exits the water."
+        "3) Spring Ball jump again just as Samus exits the water."
       ]
     },
     {

--- a/region/maridia/inner-pink/East Sand Pit.json
+++ b/region/maridia/inner-pink/East Sand Pit.json
@@ -278,6 +278,7 @@
         "canInsaneWalljump",
         "can3HighWallMidAirMorph"
       ],
+      "flashSuitChecked": true,
       "note": "Walljump up and instant morph with exact timing and positioning so as to enter the Power Bomb location through the maze's exit."
     },
     {

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -30,7 +30,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedDraygon"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -369,6 +370,7 @@
           "blockPositions": [[2, 28]]
         }
       },
+      "flashSuitChecked": true,
       "note": [
         "Get a boost from a Bomb or Power Bomb while grappled to the top Grapple block below the door.",
         "Samus will enter a 'glitched grapple hanging' state where Samus' graphics will appear corrupted while swinging with Grapple.",

--- a/region/maridia/inner-yellow/Butterfly Room.json
+++ b/region/maridia/inner-yellow/Butterfly Room.json
@@ -40,7 +40,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedDraygon"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -31,6 +31,7 @@
               "requires": [
                 {"obstaclesCleared": ["A"]}
               ],
+              "flashSuitChecked": true,
               "note": "To avoid redundant requirements, obstacle must be destroyed by going to 2->3->1."
             }
           ],

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -85,7 +85,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedDraygon"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/maridia/outer/Crab Hole.json
+++ b/region/maridia/outer/Crab Hole.json
@@ -2682,7 +2682,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 70,

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -1102,7 +1102,8 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "resetsObstacles": ["B"]
+      "resetsObstacles": ["B"],
+      "flashSuitChecked": true
     },
     {
       "id": 24,

--- a/region/maridia/outer/Maridia Tube.json
+++ b/region/maridia/outer/Maridia Tube.json
@@ -737,6 +737,7 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Only requires a runway of 7 tiles in the adjacent room, but an extra tile makes for an easier jump."
       ]
@@ -1853,7 +1854,8 @@
       "unlocksDoors": [
         {"types": ["super", "powerbomb"], "requires": []},
         {"types": ["missiles"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 145,

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -43,7 +43,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedCrocomire"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -517,6 +517,7 @@
         "canTrickyGrappleJump"
       ],
       "wallJumpAvoid": true,
+      "flashSuitChecked": true,
       "devNote": [
         "This is only useful as a way to preserve a flash suit without Hi-Jump or wall jump.",
         "FIXME: This can be possible from other rooms, with greater difficulty."

--- a/region/norfair/crocomire/Post Crocomire Farming Room.json
+++ b/region/norfair/crocomire/Post Crocomire Farming Room.json
@@ -994,6 +994,7 @@
       "requires": [
         "canJumpIntoIBJ"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Jump into an IBJ from the moving platform (Kamer).",
         "Although it is possible to do it without jumping, by starting next to the Gamet farm, it is harder and more obscure."
@@ -1038,7 +1039,8 @@
         ]},
         {"shinespark": {"frames": 25}}
       ],
-      "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 90,

--- a/region/norfair/crocomire/Post Crocomire Shaft.json
+++ b/region/norfair/crocomire/Post Crocomire Shaft.json
@@ -260,6 +260,7 @@
         "canTrickyUseFrozenEnemies"
       ],
       "bypassesDoorShell": true,
+      "flashSuitChecked": true,
       "note": [
         "Use a Super to bring a Viola down to the floor.",
         "Freeze it near or on the door, freeze the Viola on the floating platform above it, moonfall between them, and aim down.",
@@ -473,7 +474,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 15,

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -925,7 +925,8 @@
       },
       "requires": [
         "canTrickyJump"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 21,
@@ -944,7 +945,8 @@
           "ScrewAttack",
           {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -963,7 +965,8 @@
           "ScrewAttack",
           {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 1}}
         ]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 23,
@@ -980,7 +983,8 @@
         "canTrickySpringBallJump",
         "canNeutralDamageBoost",
         {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 1}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 202,
@@ -998,6 +1002,7 @@
         "canNeutralDamageBoost",
         {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 1}}
       ],
+      "flashSuitChecked": true,
       "note": "Use 7 tiles from the adjacent runway then use Spring Ball at the peak of the jump and bounce off the Waver to get up onto the top left ledge."
     },
     {
@@ -1012,7 +1017,8 @@
       },
       "requires": [
         {"shinespark": {"frames": 27, "excessFrames": 2}}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 25,

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -706,7 +706,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 60}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 23,

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -256,6 +256,7 @@
           "minExtraRunSpeed": "$2.0"
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "This uses the runway in the middle of the room but logically starts at the door, to ensure it can be opened."
       ]
@@ -276,6 +277,7 @@
           "minExtraRunSpeed": "$2.0"
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "This uses the runway in the middle of the room but logically starts at the door, to ensure it can be opened."
       ]
@@ -301,6 +303,7 @@
           "minExtraRunSpeed": "$2.0"
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "This uses the runway in the middle of the room but logically starts at the door, to ensure it can be opened."
       ]
@@ -1281,7 +1284,8 @@
             "gentleDownTiles": 3
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -1302,7 +1306,8 @@
             "openEnd": 1
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -1324,7 +1329,8 @@
           },
           "movementType": "any"
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -1342,7 +1348,8 @@
             "gentleDownTiles": 3
           }
         }
-      }
+      },
+      "flashSuitChecked": true
     },
     {
       "id": 84,
@@ -2467,6 +2474,7 @@
           "minExtraRunSpeed": "$2.0"
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "This uses the runway in the middle of the room but logically starts at the door, to ensure it can be opened."
       ]
@@ -2487,6 +2495,7 @@
           "minExtraRunSpeed": "$2.0"
         }
       },
+      "flashSuitChecked": true,
       "devNote": [
         "This uses the runway in the middle of the room but logically starts at the door, to ensure it can be opened."
       ]
@@ -2747,7 +2756,8 @@
         "canSpringBallBounce",
         "canSpringFling",
         {"heatFrames": 140}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],
@@ -2762,7 +2772,8 @@
         "canSpringBallBounce",
         "canSpringFling",
         {"heatFrames": 150}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [3, 4],
@@ -2780,6 +2791,7 @@
         "canBeVeryPatient",
         {"heatFrames": 145}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Pause immediately on room entry, and bounce just before Samus would roll off the runway.",
         "Unequip Spring Ball, then pause again as soon as possible and re-equip Spring Ball."
@@ -3441,7 +3453,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 1],
@@ -3467,7 +3480,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 2],
@@ -3753,7 +3767,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "link": [4, 3],
@@ -3779,7 +3794,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 73,

--- a/region/norfair/east/Frog Speedway.json
+++ b/region/norfair/east/Frog Speedway.json
@@ -615,7 +615,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 25,
@@ -632,7 +633,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -649,7 +651,8 @@
           "blockPositions": [[3, 13]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 27,

--- a/region/norfair/east/Lava Dive Room.json
+++ b/region/norfair/east/Lava Dive Room.json
@@ -676,6 +676,7 @@
         {"heatFrames": 425},
         {"lavaFrames": 275}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use the platform above the third Namihe to run and jump into a diagonal spark."
       ],
@@ -704,6 +705,7 @@
           ]}
         ]}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Use a flash suit to shinespark out of the lava.",
         "A diagonal spark is slightly better though Samus will barely move horizontally."

--- a/region/norfair/east/Lower Norfair Elevator.json
+++ b/region/norfair/east/Lower Norfair Elevator.json
@@ -117,7 +117,8 @@
           "types": ["powerbomb"],
           "requires": [{"heatFrames": 110}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 3,
@@ -1086,6 +1087,7 @@
       "exitCondition": {
         "leaveNormally": {}
       },
+      "flashSuitChecked": true,
       "note": "Riding the elevator without enough energy will cause a reserve trigger in the next room, reducing the total heat damage dealt.",
       "devNote": "FIXME: If the next room is also heated, the reserve won't trigger until after that elevator ride as well, but then the reserve will trigger during heat damage."
     },

--- a/region/norfair/east/Single Chamber.json
+++ b/region/norfair/east/Single Chamber.json
@@ -1382,7 +1382,8 @@
       "unlocksDoors": [
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 26,
@@ -1433,7 +1434,8 @@
           "types": ["missiles"],
           "requires": [{"heatFrames": 50}]
         }
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 88,
@@ -2384,7 +2386,8 @@
         }
       },
       "requires": [],
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 109,
@@ -2401,7 +2404,8 @@
           "blockPositions": [[3, 12]]
         }
       },
-      "bypassesDoorShell": true
+      "bypassesDoorShell": true,
+      "flashSuitChecked": true
     },
     {
       "id": 49,

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -567,7 +567,8 @@
         {"simpleHeatFrames": 310},
         {"heatFrames": 40}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 16,

--- a/region/norfair/west/Crumble Shaft.json
+++ b/region/norfair/west/Crumble Shaft.json
@@ -352,7 +352,8 @@
         "SpaceJump",
         {"heatFrames": 95}
       ],
-      "clearsObstacles": ["A"]
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true
     },
     {
       "id": 7,

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -40,7 +40,8 @@
           "unlockStrats": [
             {
               "name": "Base",
-              "requires": []
+              "requires": [],
+              "flashSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"],

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -442,7 +442,8 @@
         "canPseudoScrew",
         {"heatFrames": 540}
       ],
-      "unlocksDoors": [{"types": ["powerbomb"], "requires": []}]
+      "unlocksDoors": [{"types": ["powerbomb"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 8,
@@ -839,7 +840,8 @@
       "requires": [
         "Morph",
         {"heatFrames": 180}
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 70,
@@ -1458,6 +1460,7 @@
         }},
         {"heatFrames": 120}
       ],
+      "flashSuitChecked": true,
       "note": [
         "Smoothly jump into the morph tunnel while shooting the first Sova.",
         "Unmorph at the end of the tunnel to clear more Sovas as needed."

--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -39,7 +39,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -39,7 +39,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -27,7 +27,8 @@
               "name": "Base",
               "requires": [
                 "f_KilledMetroidRoom1"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -41,7 +41,8 @@
               "name": "Base",
               "requires": [
                 "f_KilledMetroidRoom2"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -39,7 +39,8 @@
               "name": "Base",
               "requires": [
                 "f_KilledMetroidRoom3"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -41,7 +41,8 @@
               "name": "Base",
               "requires": [
                 "f_KilledMetroidRoom4"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]
@@ -294,6 +295,7 @@
         "canMetroidAvoid"
       ],
       "setsFlags": ["f_KilledMetroidRoom4"],
+      "flashSuitChecked": true,
       "note": [
         "Group the Metroids by descending the room.",
         "Then Kill all three Metroids with Power Bombs while avoiding damage."

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -27,7 +27,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedMotherBrain"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -532,6 +533,7 @@
         ]},
         "h_complexToCarryFlashSuit"
       ],
+      "flashSuitChecked": true,
       "note": [
         "Glitch through the Mother Brain Zebetites by using a frozen Rinka and i-frames.",
         "Freeze the Rinka at its spawn location, then spin jump or down-back onto it after acquiring i-frames to clip inside of the Zebetite, then jump through.",

--- a/region/tourian/main/Tourian Escape Room 1.json
+++ b/region/tourian/main/Tourian Escape Room 1.json
@@ -29,7 +29,8 @@
               "name": "Base",
               "requires": [
                 "h_openTourianEscape1RightDoor"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -28,7 +28,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -28,7 +28,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -32,7 +32,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -28,6 +28,7 @@
               "requires": [
                 "f_DefeatedPhantoon"
               ],
+              "flashSuitChecked": true,
               "note": "The enemies are killable using Power Beam, once they actually spawn."
             }
           ],
@@ -56,6 +57,7 @@
             {
               "name": "Base",
               "requires": [],
+              "flashSuitChecked": true,
               "note": "The enemies are killable using Power Beam, once they actually spawn."
             }
           ],
@@ -85,6 +87,7 @@
               "requires": [
                 "f_DefeatedPhantoon"
               ],
+              "flashSuitChecked": true,
               "note": "The enemies are killable using Power Beam, once they actually spawn."
             }
           ],

--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -354,7 +354,8 @@
         ]},
         {"canShineCharge": {"usedTiles": 38, "openEnd": 1}},
         "h_RModeKnockbackSpark"
-      ]
+      ],
+              "flashSuitChecked": true
     },
     {
       "id": 13,
@@ -763,7 +764,8 @@
         ]},
         {"canShineCharge": {"usedTiles": 38, "openEnd": 1}},
         "h_RModeKnockbackSpark"
-      ]
+      ],
+      "flashSuitChecked": true
     },
     {
       "id": 28,
@@ -1294,7 +1296,8 @@
         "h_bombThings",
         {"canShineCharge": {"usedTiles": 38, "openEnd": 1}},
         "h_RModeKnockbackSpark"
-      ]
+      ],
+      "flashSuitChecked": true
     }
   ],
   "notables": [

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -44,7 +44,8 @@
               "name": "Base",
               "requires": [
                 "never"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -89,6 +90,7 @@
                   "h_allItemsSpawned"
                 ]}
               ],
+              "flashSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]
@@ -120,6 +122,7 @@
                   "h_allItemsSpawned"
                 ]}
               ],
+              "flashSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]
@@ -1395,6 +1398,7 @@
         "h_bombThings",
         {"obstaclesNotCleared": ["B"]}
       ],
+      "flashSuitChecked": true,
       "note": "The bomb block respawns. It must be broken on the way back too."
     },
     {

--- a/region/wreckedship/main/Electric Death Room.json
+++ b/region/wreckedship/main/Electric Death Room.json
@@ -30,7 +30,8 @@
               "name": "Base",
               "requires": [
                 "h_openRedDoor"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ],
           "note": "Somehow this door is blue, not red, before Phantoon dies."

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -54,6 +54,7 @@
                   "h_allItemsSpawned"
                 ]}
               ],
+              "flashSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]

--- a/region/wreckedship/main/Phantoon's Room.json
+++ b/region/wreckedship/main/Phantoon's Room.json
@@ -27,7 +27,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedPhantoon"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/wreckedship/main/Robot Assembly Line.json
+++ b/region/wreckedship/main/Robot Assembly Line.json
@@ -42,6 +42,7 @@
                   "h_allItemsSpawned"
                 ]}
               ],
+              "flashSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]

--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -1155,7 +1155,8 @@
           }
         }
       },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}]
+      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true
     },
     {
       "id": 52,

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -42,6 +42,7 @@
                   "h_allItemsSpawned"
                 ]}
               ],
+              "flashSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -44,6 +44,7 @@
                   "h_allItemsSpawned"
                 ]}
               ],
+              "flashSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -72,7 +72,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedPhantoon"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }
@@ -124,7 +125,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedPhantoon"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/wreckedship/main/Wrecked Ship Map Room.json
+++ b/region/wreckedship/main/Wrecked Ship Map Room.json
@@ -36,7 +36,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedPhantoon"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/wreckedship/main/Wrecked Ship Save Room.json
+++ b/region/wreckedship/main/Wrecked Ship Save Room.json
@@ -36,7 +36,8 @@
               "name": "Base",
               "requires": [
                 "f_DefeatedPhantoon"
-              ]
+              ],
+              "flashSuitChecked": true
             }
           ]
         }

--- a/region/wreckedship/main/Wrecked Ship West Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship West Super Room.json
@@ -42,6 +42,7 @@
                   "h_allItemsSpawned"
                 ]}
               ],
+              "flashSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -53,7 +53,8 @@
       "type": "object",
       "required": [
         "name",
-        "requires"
+        "requires",
+        "flashSuitChecked"
       ],
       "additionalProperties": false,
       "properties": {


### PR DESCRIPTION
This updates the schema to make `flashSuitChecked` a required field, and fixes all instances that were missing it. This includes
- A lot of updates in Green Brinstar, because flash suits were checked there a long time ago, with many strats added since.
- The last chunk of East Cactus Alley, which I apparently got sidetracked on and didn't do at all.
- Strats in the `nodes` section, including gray-door unlock strats and viewable nodes.
- Many new strats that were added recently where we forgot to put `flashSuitChecked` on them.
- Random strats which were just accidentally missed.