### PR TITLE
Blue Brinstar Energy Tank Room R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -164,6 +164,7 @@
     {
       "from": 2,
       "to": [
+        {"id": 1},
         {"id": 2},
         {"id": 4}
       ]
@@ -854,6 +855,36 @@
       "note": "Regain mobility with the first Geemer then roll through the second to avoid a second hit."
     },
     {
+      "link": [2, 1],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        "h_ZebesIsAwake",
+        {"or": [
+          "h_CrystalFlash",
+          {"and":[
+            "Morph",
+            "h_destroyBombWalls",
+            {"disableEquipment": "ETank"},
+            {"resourceAvailable": [{"type": "Energy", "count": 90}]},
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 1}}
+          ]}
+        ]},
+        {"canShineCharge": { "usedTiles": 30, "openEnd": 0 } },
+        {"autoReserveTrigger": { "maxReserveEnergy": 95 }},
+        "canRModeSparkInterrupt"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "clearsObstacles": ["A", "B"],
+      "devNote": [
+        "Kill the Geemers for Reserves, or else Crystal Flash. Damage down and use the Reo to interrupt a shinespark wind-up."
+      ]
+    },
+    {
       "id": 34,
       "link": [2, 2],
       "name": "Leave with Runway",
@@ -983,36 +1014,6 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true
-    },
-    {
-      "link": [2, 1],
-      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
-      "entranceCondition": {
-        "comeInWithRMode": {}
-      },
-      "requires": [
-        "h_ZebesIsAwake",
-        {"or": [
-          "h_CrystalFlash",
-          {"and":[
-            "Morph",
-            "h_destroyBombWalls",
-            {"disableEquipment": "ETank"},
-            {"resourceAvailable": [{"type": "Energy", "count": 90}]},
-            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
-            {"partialRefill": {"type": "ReserveEnergy", "limit": 1}}
-          ]}
-        ]},
-        {"canShineCharge": { "usedTiles": 30, "openEnd": 0 } },
-        {"autoReserveTrigger": { "maxReserveEnergy": 95 }},
-        "canRModeSparkInterrupt"
-      ],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "clearsObstacles": ["A", "B"],
-      "devNote": [
-        "Kill the Geemers for Reserves, or else Crystal Flash. Damage down and use the Reo to interrupt a shinespark wind-up."
-      ]
     },
     {
       "id": 39,


### PR DESCRIPTION
Video link: https://videos.maprando.com/video/8739

Overall, probably the simplest form of this technique one can get. No in-room obstacles that need to be cleared: just get some reserve, damage down to prep for R-Mode standup, get a shinecharge, and get it done. Aside from needing the ZebesAwake requirement this probably can work as a basic template for any other simple Spark Interrupt appearance.