### PR TITLE
Add tricky jump req to underwater max height SBJ

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -784,7 +784,8 @@
           "name": "h_underwaterMaxHeightSpringBallJump",
           "requires": [
             "h_underwaterCrouchJump",
-            "canTrickySpringBallJump"
+            "canTrickySpringBallJump",
+            "canTrickyJump"
           ]
         },
         {


### PR DESCRIPTION
This brings the underwater helper into consistency with `h_maxHeightSpringBallJump`. I assume that the lack of `canTrickyJump` requirement was unintentional. I think it's only recently that the underwater helper has been used much.