### PR TITLE
Blue Brinstar Boulder Room R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -183,6 +183,7 @@
         {"autoReserveTrigger": { }},
         "canRModeSparkInterrupt"
       ],
+      "resetsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [


### PR DESCRIPTION
Video Link: https://videos.maprando.com/video/8764

Main quirks to this R-Mode Spark Interrupt:
- No energy drops in this room, so Crystal Flash is forced.
- Needs Speedy Airball strat to get to the top ledge. May need to consider alternate strats if/when we relax `SpeedBooster` hard-requirement on blue suit.
- Spikes are right there to damage down, but also maximum of two boulders can be used.
- You cannot use the entire runway for the shinecharge because you must not overshoot the third boulder by too much.
- Starting windup must be close to as immediate as possible - does this need an extra requirement?
- Auto Reserve trigger doesn't need an i-frame safeguard because the boulder doesn't come back.