### PR TITLE
Central Crateria check blue suits pt. 1 (Climb)

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -1040,6 +1040,15 @@
           ]
         },
         {
+          "name": "h_CrystalSparkWithoutLenience",
+          "requires": [
+            {"tech": "canCrystalSpark"},
+            "canMidAirMorph",
+            "h_CrystalFlash",
+            {"gainBlueSuit": {}}
+          ]
+        },
+        {
           "name": "h_heatedCrystalSpark",
           "requires": [
             "h_heatProof",

--- a/region/crateria/central/230 Missile Room.json
+++ b/region/crateria/central/230 Missile Room.json
@@ -84,7 +84,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -93,21 +94,40 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 9,
+          "openEnd": 0
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Blue Brinstar Elevator Room.json
+++ b/region/crateria/central/Blue Brinstar Elevator Room.json
@@ -74,7 +74,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -83,14 +84,48 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 0
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (In-Room Crystal Spark)",
+      "requires": [
+        {"or": [
+          {"canShineCharge": {"usedTiles": 13, "openEnd": 0}},
+          {"and": [
+            {"doorUnlockedAtNode": 1},
+            {"canShineCharge": {"usedTiles": 14, "openEnd": 0}}
+          ]}
+        ]},
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
@@ -109,7 +144,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 5,
@@ -129,7 +165,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -148,7 +185,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -164,7 +202,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -182,14 +221,16 @@
           "morphed": false
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
@@ -209,7 +250,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -229,7 +271,8 @@
         "leaveShinecharged": {}
       },
       "unlocksDoors": [{"nodeId": 1, "types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -247,7 +290,8 @@
           "morphed": false
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -260,6 +304,7 @@
         "leaveNormally": {}
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "In order to align and place a Power Bomb at the correct pixel, jump and hit the ceiling in the aim-down pose, then morph on the descent."
     }
   ],

--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -29,7 +29,8 @@
               "requires": [
                 "f_DefeatedBombTorizo"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "note": "If no Bombs in inventory, door stays open"
@@ -44,7 +45,8 @@
               "requires": [
                 "f_AnimalsSaved"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -108,7 +110,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 20,
@@ -128,6 +131,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": ["Max extra run speed $2.B with spin, or $2.C with a quick aim-down."]
     },
     {
@@ -146,6 +150,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": ["Max extra run speed $2.2 with spin, or $2.3 with a quick aim-down."]
     },
     {
@@ -161,7 +166,8 @@
         ]}
       ],
       "setsFlags": ["f_DefeatedBombTorizo"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -175,7 +181,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -190,7 +197,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
@@ -209,7 +217,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 5,
@@ -229,7 +238,8 @@
           "movementType": "uncontrolled"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -244,7 +254,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -261,7 +272,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -282,7 +294,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -304,7 +317,8 @@
           "movementType": "uncontrolled"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
@@ -321,7 +335,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -330,7 +345,19 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (In-Room Crystal Spark)",
+      "requires": [
+        "f_DefeatedBombTorizo",
+        {"canShineCharge": {"usedTiles": 13, "openEnd": 0}},
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 19,
@@ -341,6 +368,7 @@
       ],
       "setsFlags": ["f_AnimalsSaved"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Technically this also requires opening the wall."
     },
     {
@@ -348,14 +376,16 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 15,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -303,7 +303,8 @@
           "height": 2
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -317,7 +318,8 @@
           "rightPosition": -0.5
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -331,7 +333,8 @@
           "rightPosition": 2.5
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
@@ -351,7 +354,8 @@
         }
       },
       "bypassesDoorShell": "free",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 5,
@@ -373,7 +377,8 @@
         }
       },
       "bypassesDoorShell": "free",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -390,7 +395,8 @@
         "canXRayTurnaround"
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -405,6 +411,7 @@
       },
       "requires": [],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Overload PLMs using scroll blocks a few tiles in front of the bomb blocks."
     },
     {
@@ -427,6 +434,7 @@
         "Morph"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Diagonal shinespark up the climb to break the bomb blocks to the top right morph tunnel.",
         "A consistent place to spark from is the small platform below the bomb block, using a crouch jump and then a diagonal spark (not a crouched diagonal spark)."
@@ -452,6 +460,7 @@
         "Morph"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Diagonal shinespark up the climb to break the bomb blocks to the top right morph tunnel.",
         "A consistent place to spark from is the small platform below the bomb block, using a crouch jump and then a diagonal spark (not a crouched diagonal spark)."
@@ -472,6 +481,7 @@
         "canInsaneJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Breaking the bomb blocks is difficult because there is not enough space above them to get a neutral bounce.",
         "It is best to break them by jumping from the top platform (inside the 3-tile-high space), as this provides a 2-frame window for the morph;",
@@ -495,6 +505,7 @@
         "canInsaneJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Breaking the bomb blocks is difficult because there is not enough space above them to get a neutral bounce.",
         "It is best to break them by jumping from the top platform (inside the 3-tile-high space), as this provides a 2-frame window for the morph;",
@@ -517,6 +528,7 @@
         "h_artificialMorphMovement"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Overload PLMs using the scroll block next to the bomb blocks.",
       "devNote": "PBs cannot be used, as they will solidify the bomb blocks."
     },
@@ -534,7 +546,8 @@
         "canChainTemporaryBlue",
         "canInsaneJump"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 14,
@@ -551,7 +564,8 @@
         "canChainTemporaryBlue",
         "canInsaneJump"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 15,
@@ -566,6 +580,7 @@
       },
       "requires": [],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Overload PLMs using the scroll block next to the bomb blocks."
     },
     {
@@ -579,7 +594,8 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 105,
@@ -591,6 +607,7 @@
       "requires": [],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "When Samus enters the room from the bottom left, lava starts to rise. In the escape it is acid instead."
     },
     {
@@ -604,7 +621,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 18,
@@ -623,7 +641,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 19,
@@ -644,7 +663,8 @@
         }
       },
       "unlocksDoors": [{"nodeId": 5, "types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 20,
@@ -660,7 +680,8 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
-      "devNote": "An unheated lava crystal flash could be added instead, but that would change the strats that come after."
+      "blueSuitChecked": true,
+      "devNote": "An unprotected lava crystal flash could be added instead, but that would change the strats that come after."
     },
     {
       "id": 106,
@@ -675,7 +696,8 @@
       },
       "requires": [],
       "clearsObstacles": ["B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 23,
@@ -694,6 +716,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Starting with a crouch, diagonal shinespark to the top to break the bomb blocks to the morph tunnels on the right."
     },
     {
@@ -728,6 +751,7 @@
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll blocks next to the bomb wall",
         "After passing through, you need to go from the bottom to the top of Climb and into the bomb blocks while still in G-mode Morph.",
@@ -752,6 +776,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right."
     },
     {
@@ -793,12 +818,13 @@
         }
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right."
     },
     {
       "id": 27,
       "link": [2, 4],
-      "name": "Temporary Blue Chain Through Bomb Blocks Without XRay (Bottom Left to Bottom, Cross-Room)",
+      "name": "Temporary Blue Chain Through Bomb Blocks Without X-Ray (Bottom Left to Bottom, Cross-Room)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 14,
@@ -817,6 +843,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "A Temporary Blue Chain with movement assists to climb up and destroy the bomb blocks blocking the bottom morph tunnel."
     },
     {
@@ -846,6 +873,7 @@
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll blocks next to the bomb wall",
         "Navigate to the lower right bomb blocks while still morphed.",
@@ -856,7 +884,7 @@
     {
       "id": 29,
       "link": [2, 5],
-      "name": "Transition with Stored Fall Speed (Shortcharge)",
+      "name": "Transition with Stored Fall Speed (Blue)",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 1
@@ -868,7 +896,8 @@
           {"and": [
             {"getBlueSpeed": {"usedTiles": 15, "openEnd": 0}},
             {"doorUnlockedAtNode": 2}
-          ]}
+          ]},
+          {"haveBlueSuit": {}}
         ]}
       ],
       "exitCondition": {
@@ -882,12 +911,13 @@
         {"nodeId": 2, "types": ["missiles", "super"], "requires": []},
         {"nodeId": 2, "types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 30,
       "link": [2, 5],
-      "name": "Transition with Stored Fall Speed (Shortcharge, more speed)",
+      "name": "Transition with Stored Fall Speed (Blue, more speed)",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 2
@@ -899,7 +929,8 @@
           {"and": [
             {"getBlueSpeed": {"usedTiles": 15, "openEnd": 0}},
             {"doorUnlockedAtNode": 2}
-          ]}
+          ]},
+          {"haveBlueSuit": {}}
         ]}
       ],
       "exitCondition": {
@@ -913,7 +944,8 @@
         {"nodeId": 2, "types": ["missiles", "super"], "requires": []},
         {"nodeId": 2, "types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 31,
@@ -938,6 +970,7 @@
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Break the Bomb blocks using Screw Attack in a Moonfall, then escape the tiles with Grapple Beam."
     },
     {
@@ -951,7 +984,8 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 33,
@@ -964,7 +998,8 @@
         {"shinespark": {"frames": 43, "excessFrames": 17}}
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 34,
@@ -978,7 +1013,8 @@
       },
       "requires": [],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 35,
@@ -994,7 +1030,8 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 36,
@@ -1011,6 +1048,7 @@
       "requires": [],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "If needed, unmorph while passing through the blocks to break more than just the bottom one.",
       "devNote": [
         "If we had a comeInWithSpeedball entrance condition, it should be used instead.",
@@ -1029,7 +1067,8 @@
       },
       "requires": [],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 38,
@@ -1045,7 +1084,8 @@
         "SpaceJump"
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 39,
@@ -1056,7 +1096,18 @@
         {"shinespark": {"frames": 3, "excessFrames": 3}}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 6],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}}
+      ],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 40,
@@ -1076,6 +1127,7 @@
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Overload PLMs using the scroll blocks immediately in front of the bomb wall",
       "devNote": "This could be possible with the lava, but it would be blind and very tight."
     },
@@ -1088,6 +1140,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "These are destroyed on entry if Zebes is Ablaze."
     },
     {
@@ -1111,6 +1164,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs immediately in front of the bomb blocks.",
         "Reach the bottom and pass through the bomb blocks while still in G-mode."
@@ -1128,7 +1182,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 44,
@@ -1137,7 +1192,8 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 45,
@@ -1160,6 +1216,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs immediately in front of the bomb blocks.",
         "Fall down to the lower bomb blocks while still in G-mode Morph."
@@ -1175,6 +1232,7 @@
       },
       "requires": [],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Enter the room with a super sink, in order to clip down through several screens and reach the door below."
       ]
@@ -1191,7 +1249,18 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [3, 6],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}},
+        "Morph"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 47,
@@ -1213,6 +1282,7 @@
         "canSlowShortCharge"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Enter the room with a very specific run speed to jump from the door, and land a speedball perfectly in the tunnel to break the Bomb block.",
       "devNote": [
         "There is 1 unusable tile in this runway.",
@@ -1236,6 +1306,7 @@
         "canSpringBallBounce"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "There is 1 unusable tile in this runway."
     },
     {
@@ -1266,7 +1337,8 @@
       "requires": [
         "canInsaneJump"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 51,
@@ -1289,6 +1361,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
       "devNote": "PBs cannot be used, as they will solidify the bomb blocks."
     },
@@ -1313,6 +1386,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
         "Fall down and pass through bomb wall at the bottom while still in G-mode."
@@ -1331,6 +1405,7 @@
         "canBeVeryPatient"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Climb up 7 screens."
     },
     {
@@ -1350,6 +1425,7 @@
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Enter with G-mode direct, back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
         "Climb up 7 screens, and perform a turnaround buffered spin-jump away from the door to trigger the transition, bypassing any lock on the door."
@@ -1384,6 +1460,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
         "If Morph is not available, careful movement is needed with SpringBall to reach the top without taking a hit from a pirate or its stationary, invisible lasers."
@@ -1406,6 +1483,7 @@
         "canBeExtremelyPatient"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
         "A long series of precise bomb jumps and enemy manipulations are required to reach the top without taking a hit."
@@ -1429,6 +1507,7 @@
         {"ammo": {"type": "PowerBomb", "count": 7}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
         "Place Power Bombs as high as possible to occasionally kill multiple pirates at a time."
@@ -1451,6 +1530,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "It is sometimes possible to beat the lava, but it depends how you get here."
     },
     {
@@ -1465,7 +1545,8 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 60,
@@ -1479,7 +1560,23 @@
           {"obstaclesNotCleared": ["B"]}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [4, 6],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}},
+        "Morph",
+        {"or": [
+          "h_ClimbWithoutLava",
+          "h_lavaProof",
+          {"obstaclesNotCleared": ["B"]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 61,
@@ -1502,6 +1599,7 @@
         "canBeExtremelyPatient"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Enter the room with a very specific run speed to jump from the door, squeeze by the ceiling, and land a speedball perfectly in the tunnel to break the Bomb block.",
       "devNote": [
         "There is 1 unusable tile in this runway.",
@@ -1525,6 +1623,7 @@
         "can4HighMidAirMorph"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "There is 1 unusable tile in this runway."
     },
     {
@@ -1540,7 +1639,8 @@
         "canSpringBallBounce",
         "can4HighMidAirMorph"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 64,
@@ -1555,7 +1655,8 @@
       "requires": [
         "canInsaneJump"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 65,
@@ -1575,6 +1676,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "A Power Bomb cannot be used, as it will solidify the bomb block."
     },
     {
@@ -1590,7 +1692,8 @@
         {"shinespark": {"frames": 43, "excessFrames": 17}}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 67,
@@ -1604,7 +1707,8 @@
       },
       "requires": [],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 68,
@@ -1624,7 +1728,8 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 69,
@@ -1641,6 +1746,7 @@
       "requires": [],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "If needed, unmorph while passing through the blocks to break more than just the bottom one.",
       "devNote": [
         "If we had a comeInWithSpeedball entrance condition, it should be used instead.",
@@ -1659,7 +1765,8 @@
       },
       "requires": [],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 71,
@@ -1672,12 +1779,13 @@
         "canChainTemporaryBlue"
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 72,
       "link": [5, 2],
-      "name": "Transition with Stored Fall Speed (Shortcharge)",
+      "name": "Transition with Stored Fall Speed (Blue)",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 1
@@ -1689,7 +1797,8 @@
           {"and": [
             {"getBlueSpeed": {"usedTiles": 13, "openEnd": 0}},
             {"doorUnlockedAtNode": 5}
-          ]}
+          ]},
+          {"haveBlueSuit": {}}
         ]}
       ],
       "exitCondition": {
@@ -1703,12 +1812,13 @@
         {"nodeId": 5, "types": ["missiles", "super"], "requires": []},
         {"nodeId": 5, "types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 73,
       "link": [5, 2],
-      "name": "Transition with Stored Fall Speed (Shortcharge, more speed)",
+      "name": "Transition with Stored Fall Speed (Blue, more speed)",
       "entranceCondition": {
         "comeInWithStoredFallSpeed": {
           "fallSpeedInTiles": 2
@@ -1720,7 +1830,8 @@
           {"and": [
             {"getBlueSpeed": {"usedTiles": 13, "openEnd": 0}},
             {"doorUnlockedAtNode": 5}
-          ]}
+          ]},
+          {"haveBlueSuit": {}}
         ]}
       ],
       "exitCondition": {
@@ -1734,7 +1845,8 @@
         {"nodeId": 5, "types": ["missiles", "super"], "requires": []},
         {"nodeId": 5, "types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 74,
@@ -1759,6 +1871,7 @@
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Break the Bomb blocks using Screw Attack in a Moonfall, then escape the tiles with Grapple Beam."
     },
     {
@@ -1772,7 +1885,8 @@
         }
       },
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 76,
@@ -1791,6 +1905,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Starting with a crouch, diagonal shinespark to the top to break the bomb blocks to the morph tunnels on the right."
     },
     {
@@ -1807,6 +1922,7 @@
         "canLongXRayClimb"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Climb 8 screens and position Samus to where she is visually standing above the door.",
         "For the last X-Ray turnaround, face right then press and hold the X-ray scope input, buffer a jump then perform the X-Ray turnaround.",
@@ -1841,6 +1957,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block next to any of the bomb blocks in the room, allowing passage through the bomb blocks at the top by making them become air.",
         "If Morph is not available, careful movement is needed with SpringBall to reach the top without taking a hit from the pirates or their stationary, invisible lasers."
@@ -1863,6 +1980,7 @@
         "canBeExtremelyPatient"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "A long series of precise bomb jumps and enemy manipulations are required to reach the top without taking a hit or unmorphing.",
         "Overload PLMs using the scroll block next to the bomb blocks at the top, allowing passage through them by making them become air."
@@ -1886,6 +2004,7 @@
         {"ammo": {"type": "PowerBomb", "count": 8}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
         "Place PBs as high as possible to occasionally kill multiple pirates at a time.",
@@ -1909,6 +2028,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right."
     },
     {
@@ -1924,6 +2044,7 @@
         "canXRayClimb"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Use an X-Ray climb to position Samus to where she can break the Bomb block with Screw Attack.",
         "This is a 1 screen climb."
@@ -1965,6 +2086,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Overload PLMs using the scroll block next to the bottom right bomb blocks, allowing passage through them by making them become air.",
         "If Morph is unavailable, then careful movement will be required to get past the Pirates without taking a hit from them or their stationary, invisible lasers.",
@@ -1983,6 +2105,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "This is relatively tight when coming in from the bottom left and using a Power Bomb to break the wall.",
         "It wouldn't work if the door was Missile or Power Bomb locked."
@@ -2005,7 +2128,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 86,
@@ -2026,21 +2150,24 @@
         }
       },
       "unlocksDoors": [{"nodeId": 2, "types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 87,
       "link": [5, 6],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 88,
       "link": [6, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 89,
@@ -2058,7 +2185,8 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 90,
@@ -2069,7 +2197,18 @@
         {"shinespark": {"frames": 3, "excessFrames": 3}}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [6, 2],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}}
+      ],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 91,
@@ -2081,6 +2220,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "These are destroyed on entry if Zebes is Ablaze."
     },
     {
@@ -2090,7 +2230,18 @@
       "requires": [
         "h_bombThings"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [6, 3],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}},
+        "Morph"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 93,
@@ -2108,6 +2259,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Starting with a crouch, diagonal shinespark to the top to break the bomb blocks to the morph tunnels on the right."
     },
     {
@@ -2136,6 +2288,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Manipulate the Pirates to the right wall while climbing the room.",
         "Kill all the Pirates while moonfalling down the right side.",
@@ -2154,6 +2307,7 @@
         {"shinespark": {"frames": 18, "excessFrames": 4}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Diagonal shinespark to break the bomb blocks to the morph tunnel on the right.",
         "Spark from the highest platform that is only one tile from the right wall (the morph tunnel will be off camera, but can be seen while jumping).",
@@ -2179,6 +2333,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "This is a long temporary blue chain with X-Ray turnarounds to climb up and destroy the bomb blocks blocking the top morph tunnel.",
         "Breaking the bomb blocks is difficult because there is not enough space above them to get a neutral bounce.",
@@ -2195,7 +2350,18 @@
       "requires": [
         "h_bombThings"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [6, 4],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}},
+        "Morph"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 97,
@@ -2220,6 +2386,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right.",
         "A frozen Pirate can be used to stop the spark just above the bottom tunnel."
@@ -2245,6 +2412,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "The bomb blocks can be broken by spinjumping with Screw attack and holding right, if moonfall makes Samus clip through the platform.",
         "Use the small blue platform 2nd from the top on the right side."
@@ -2285,6 +2453,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Diagonal shinespark to break the bomb blocks to the morph tunnel on the right.",
         "Spark from the lowest platform that is only one tile from the right wall (part of the bottom right door will be on screen).",
@@ -2322,6 +2491,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "A Temporary Blue Chain with x-ray turnarounds to climb up and destroy the bomb blocks blocking the bottom morph tunnel.",
       "devNote": "The runway was reduced by 0.5 tiles, as you can't maintain Temporary Blue directly against a wall."
     },
@@ -2352,6 +2522,7 @@
       ],
       "unlocksDoors": [{"nodeId": 2, "types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "A Temporary Blue Chain with movement assists to climb up and destroy the bomb blocks blocking the bottom morph tunnel."
     },
     {
@@ -2359,7 +2530,8 @@
       "link": [6, 5],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 103,
@@ -2404,6 +2576,7 @@
       "resetsObstacles": ["A", "B"],
       "farmCycleDrops": [{"enemy": "Grey Space Pirate (wall)", "count": 11}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "FIXME: Shinesparking can also be a viable option, in case it is patched to not cost energy."
       ]
@@ -2421,7 +2594,23 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [6, 6],
+      "name": "Gain Blue Suit (Crystal Spark)",
+      "requires": [
+        {"obstaclesCleared": ["A"]},
+        {"or": [
+          "h_ClimbWithoutLava",
+          {"obstaclesNotCleared": ["B"]}
+        ]},
+        {"canShineCharge": {"usedTiles": 28, "openEnd": 0}},
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [

--- a/region/crateria/central/Crateria Map Room.json
+++ b/region/crateria/central/Crateria Map Room.json
@@ -61,7 +61,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -70,21 +71,40 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Crateria Power Bomb Room.json
+++ b/region/crateria/central/Crateria Power Bomb Room.json
@@ -70,7 +70,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -86,6 +87,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Wait for the Alcoon to walk off and reach the bottom of the slope.",
         "Dodge it's fireballs with Morph or Screw, or simply freeze it and wait while standing behind it.",
@@ -128,6 +130,7 @@
       ],
       "farmCycleDrops": [{"enemy": "Alcoon", "count": 3}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "The Alcoons have a 99.5% Power Bomb drop rate, after which they only drop small energy."
       ]
@@ -139,7 +142,27 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSparkWithoutLenience"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "No lenience, because Power Bombs can be farmed from the Alcoons."
+      ]
     },
     {
       "id": 5,
@@ -156,6 +179,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Duck under the first two Alcoon shots, or retreat back a platform to fight them with Power Beam.",
       "devNote": "All the Alcoons are assumed killed in each case."
     },
@@ -164,7 +188,8 @@
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Crateria Save Room.json
+++ b/region/crateria/central/Crateria Save Room.json
@@ -61,7 +61,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -70,21 +71,43 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 1
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSparkWithoutLenience"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "No lenience, because reloading from the save is possible."
+      ]
     },
     {
       "id": 3,
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Crateria Tube.json
+++ b/region/crateria/central/Crateria Tube.json
@@ -64,7 +64,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -73,7 +74,34 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 0
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (In-Room Crystal Spark)",
+      "requires": [
+        {"canShineCharge": {"usedTiles": 14, "openEnd": 0}},
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -92,7 +120,8 @@
         }
       },
       "bypassesDoorShell": "free",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
@@ -111,14 +140,16 @@
         }
       },
       "bypassesDoorShell": "free",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 5,
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -137,6 +168,7 @@
         "leaveShinecharged": {}
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "FIXME: Add 3 room shinecharges."
     },
     {
@@ -153,7 +185,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -168,7 +201,8 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -184,7 +218,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
@@ -201,7 +236,8 @@
           "fallSpeedInTiles": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -218,7 +254,8 @@
           "fallSpeedInTiles": 2
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -236,7 +273,8 @@
           "morphed": false
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -254,7 +292,8 @@
           "morphed": true
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 14,
@@ -268,6 +307,7 @@
       "requires": [],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "Though there is no door shell here, this strat is included for completeness in case a randomizer adds a door shell where bypassing it could be useful.",
         "FIXME: add strat(s) entering with a grapple teleport and leaving with a grapple swing."
@@ -289,7 +329,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 16,
@@ -307,14 +348,16 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 17,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 18,
@@ -333,6 +376,7 @@
         "leaveShinecharged": {}
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "FIXME: Add 3 room shinecharges."
     },
     {
@@ -349,7 +393,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 20,
@@ -364,7 +409,8 @@
       "exitCondition": {
         "leaveWithSpark": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 21,
@@ -380,7 +426,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 22,
@@ -397,7 +444,8 @@
           "fallSpeedInTiles": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 23,
@@ -414,7 +462,8 @@
           "fallSpeedInTiles": 2
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 24,
@@ -432,7 +481,8 @@
           "morphed": false
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 25,
@@ -450,7 +500,8 @@
           "morphed": true
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 26,
@@ -464,6 +515,7 @@
       "requires": [],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "Though there is no door shell here, this strat is included for completeness in case a randomizer adds a door shell where bypassing it could be useful.",
         "FIXME: add strat(s) entering with a grapple teleport and leaving with a grapple swing."
@@ -485,7 +537,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 28,
@@ -503,7 +556,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 29,
@@ -516,7 +570,24 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 0
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 30,
@@ -535,7 +606,8 @@
         }
       },
       "bypassesDoorShell": "free",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 31,
@@ -554,7 +626,8 @@
         }
       },
       "bypassesDoorShell": "free",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/central/Final Missile Bombway.json
+++ b/region/crateria/central/Final Missile Bombway.json
@@ -80,12 +80,13 @@
     {
       "id": 22,
       "link": [1, 1],
-      "name": "Gain Blue Suit (Crystal Spark)",
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
           "openEnd": 0
-        }
+        },
+        "comesInHeated": "no"
       },
       "requires": [
         "h_CrystalSpark"
@@ -497,12 +498,13 @@
     {
       "id": 26,
       "link": [2, 2],
-      "name": "Gain Blue Suit (Crystal Spark)",
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
           "openEnd": 0
-        }
+        },
+        "comesInHeated": "no"
       },
       "requires": [
         "h_CrystalSpark"

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -92,7 +92,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 24,
@@ -116,6 +117,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Leaving with upward momentum is possible in three ways:",
         "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
@@ -146,7 +148,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -161,7 +164,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
@@ -180,7 +184,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 5,
@@ -200,7 +205,8 @@
           "movementType": "uncontrolled"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -215,7 +221,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -228,7 +235,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -265,7 +273,8 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Mellow", "count": 12}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -274,7 +283,18 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Crystal Spark)",
+      "requires": [
+        {"canShineCharge": {"usedTiles": 36, "openEnd": 1}},
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
@@ -284,21 +304,24 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -311,7 +334,8 @@
       },
       "requires": [],
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 14,
@@ -329,7 +353,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 15,
@@ -347,7 +372,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 16,
@@ -360,7 +386,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 25,
@@ -384,6 +411,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Leaving with upward momentum is possible in three ways:",
         "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
@@ -416,7 +444,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 18,
@@ -431,7 +460,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 19,
@@ -450,7 +480,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 20,
@@ -470,7 +501,8 @@
           "movementType": "uncontrolled"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 21,
@@ -485,7 +517,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 22,
@@ -498,7 +531,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 23,
@@ -508,7 +542,8 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -206,12 +206,13 @@
     {
       "id": 43,
       "link": [1, 1],
-      "name": "Gain Blue Suit (Crystal Spark)",
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
           "openEnd": 0
-        }
+        },
+        "comesInHeated": "no"
       },
       "requires": [
         "h_heatedCrystalSpark"
@@ -1025,12 +1026,13 @@
     {
       "id": 49,
       "link": [2, 2],
-      "name": "Gain Blue Suit (Crystal Spark)",
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
       "entranceCondition": {
         "comeInShinecharging": {
           "length": 3,
           "openEnd": 0
-        }
+        },
+        "comesInHeated": "no"
       },
       "requires": [
         "h_heatedCrystalSpark"

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -914,6 +914,16 @@
                 "any"
               ]
             },
+            "comesInHeated": {
+              "type": "string",
+              "description": "Indicates whether the strat is applicable if entering from a heat environment without heat protection.",
+              "default": "any",
+              "enum": [
+                "no",
+                "yes",
+                "any"
+              ]
+            },
             "devNote": {
               "$ref" : "m3-note.schema.json#/definitions/devNote"
             }

--- a/tech.json
+++ b/tech.json
@@ -2350,6 +2350,10 @@
                 "While standing, press the crystal flash inputs, where the down press is not pressed until the last frame, where the inputs are checked.",
                 "This occurs approximately 13 frames after the Power Bomb explosion is completely gone.",
                 "Instead of crystal flashing, Samus will go down the elevator. If it was done properly, Samus' beam will be grey in color."
+              ],
+              "devNote": [
+                "It is possible to retain a blue suit while performing an elevator Crystal Flash,",
+                "ending with both a blue suit and a flash suit."
               ]
             },
             {
@@ -2801,8 +2805,12 @@
                   "note": [
                     "Getting stuck in a right side (left facing) door.",
                     "Starting from the room to the right, perform a dashing stationary spinjump into a doorcheck.",
-                    "Then,  as Samus arrives in the desired room, hold down to automatically fall forward into the closing door.",
+                    "Then, as Samus arrives in the desired room, hold down to automatically fall forward into the closing door.",
                     "This requires the doorway in the room to the right to not be underwater. This is typically used to start an X-Ray Climb."
+                  ],
+                  "devNote": [
+                    "This normally comes with a canDash requirement, which rather than being included it as a tech dependence,",
+                    "is included as part of the comeInWithDoorStuck entrance condition requirements."
                   ],
                   "extensionTechs": [
                     {
@@ -2816,9 +2824,37 @@
                       "note": [
                         "When the adjacent room is underwater it is not possible to gain dash state for the stationary spinjump.",
                         "Instead, an extremely precise jump is required followed by aiming down to shrink Samus' hitbox.",
-                        "From a full height jump, there are two frames which can touch the transition at the correct height.",
-                        "After entering the next room, hold forward then one frame later aim down.",
-                        "Turning off HiJump may help as it changes which frames work for the trick."
+                        "From a full height jump, there is a 2-frame window which can touch the transition at the correct height,",
+                        "when Samus is slightly below the center of the doorway.",
+                        "With HiJump unequipped, the start of the frame window is just as Samus rotates to become horizontal.",
+                        "Hold forward through the transition.",
+                        "One frame after the transition completes, hold diagonally down-forward."
+                      ],
+                      "detailNote": [
+                        "The vertical positions that work are $83.2800 and $84.6000.",
+                        "The same positions work with HiJump equipped, but Samus' animation will be different."
+                      ],
+                      "extensionTechs": [
+                        {
+                          "name": "canRightSideDashlessDoorStuck",
+                          "techRequires": [
+                            "canRightSideDoorStuckFromWater"
+                          ],
+                          "otherRequires": [],
+                          "note": [
+                            "Performing a dashless right-side door-stuck setup from an air environment,",
+                            "for example in order to carry a blue suit.",
+                            "From a full height jump, the transition must be touched frame-perfectly at the correct height,",
+                            "when Samus is in the center of the doorway.",
+                            "With HiJump unequipped, this is on the frame just before Samus would rotate to horizontal.",
+                            "Hold forward through the transition.",
+                            "One frame after the transition completes, hold diagonally down-forward."
+                          ],
+                          "detailNote": [
+                            "The vertical position that works is $80.C800.",
+                            "The same position works with HiJump equipped, but Samus' animation will be different."
+                          ]
+                        }
                       ]
                     }
                   ]

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -140,6 +140,7 @@ def process_keyvalue(k, v, metadata):
         "speedBooster", # validated by schema
         "framesRemaining",  # validated by schema
         "comesThroughToilet",  # validated by schema
+        "comesInHeated",  # validated by schema
         "direction",  # validated by schema
         "blue",  # validated by schema
         "movementType",  # validated by schema
@@ -496,7 +497,7 @@ def process_req_speed_state(req, states, err_fn):
             states = {"blue"}
         elif req in ["h_flashSuitIceClip", "h_SpikeXModeSpikeSuit", "h_ThornXModeSpikeSuit"]:
             states = {"preshinespark"}
-        elif req in ["h_CrystalSpark", "h_heatedCrystalSpark", "canRModeSparkInterrupt", "h_RModeKnockbackSpark"]:
+        elif req in ["h_CrystalSpark", "h_CrystalSparkWithoutLenience", "h_heatedCrystalSpark", "canRModeSparkInterrupt", "h_RModeKnockbackSpark"]:
             if not states.issubset(["shinecharging", "shinecharged"]):
                 err_fn(f"{req} while not shinecharging/shinecharged")            
             states = {"normal"}


### PR DESCRIPTION
- Added `comesInHeated` property of entrance conditions. This is necessary for cross-room Crystal Spark strats, since a heated neighboring room (without heat protection) would generally make it impossible to retry, which seems too unreasonable.
- Added `canRightSideDashlessDoorStuck`, as an air-environment extension of `canRightSideDoorStuckFromWater`. The vertical position required is different and more precise (frame-perfect from a full height jump), so I'm guessing this will go in Insane.
- Added helper `h_CrystalSparkWithoutLenience` for cases where you can farm Power Bombs or reload from a save. In the latter case, we're kind of relying on the quick reload QoL to make it reasonable, though without it I'm not sure if it's quite bad enough to be worth modeling differently.