### PR TITLE
Green Brinstar Pre-Map Room R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -185,6 +185,7 @@
             {"disableEquipment": "ETank"},
             {"resourceAvailable": [{"type": "Energy", "count": 90}]},
             {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
             {"partialRefill": {"type": "ReserveEnergy", "limit": 1}}
           ]}
         ]},
@@ -427,8 +428,9 @@
           "h_CrystalFlash",
           {"and": [
             {"disableEquipment": "ETank"},
-            {"resourceAvailable": [{"type": "Energy", "count": 90}]},
+            {"resourceAvailable": [{"type": "Energy", "count": 95}]},
             {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
             {"partialRefill": {"type": "ReserveEnergy", "limit": 1}}
           ]}
         ]},


### PR DESCRIPTION
Easy one, similar to Energy Tank Room in requirements. Left side entry needs `h_bombThings` when not using a Crystal Flash since none of the alternatives work with R-Mode Entry.

Video link: https://videos.maprando.com/video/3025