### PR TITLE
Green Brinstar Early Supers Room R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -517,7 +517,7 @@
         "then perform a 'slow short-charge' across the speedway: you must hold run at least until you have enough speed to get under the shutters.",
         "1-tap shinecharge is used to shinecharge over the Small Sidehopper Pit, before passing the 2nd to last shutter. Fall in, take a hit for",
         "i-frames so you can land and be ready to wind up before you get hit again.",
-        "Once you have blue suit you can simply Morph and roll right through the bomb blocks to escape."
+        "Once you have blue suit you can simply Morph and roll through the bomb blocks to escape."
       ]
     },
     {


### PR DESCRIPTION
Video Link: https://videos.maprando.com/video/3024

Notable elements:
- Left Door has a respawning enemy, so no need to CF or manage energy capacity.
- Access to top shelf copies from the the other [2, 4] strats.
- Left door can run across and do the right door strat, or as an alternative: energy setup using the respawning Zeb, then run across the bottom way and shinecharge over the hopper pit. Needs only Morph to get out, since the blue suit will clear the bomb blocks.