### PR TITLE
Green Brinstar Fireflea Room R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/green/Green Brinstar Fireflea Room.json
+++ b/region/brinstar/green/Green Brinstar Fireflea Room.json
@@ -187,6 +187,43 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 1],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        {"or": [
+          "h_CrystalFlash",
+          {"and": [
+            {"disableEquipment": "ETank"},
+            {"resourceAvailable": [{"type": "Energy", "count": 20}]},
+            {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 0}]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 1}}
+          ]}
+        ]},
+        {"or": [
+          {"canShineCharge": {"usedTiles": 16, "openEnd": 0}},
+          {"and": [
+            {"doorUnlockedAtNode": 2},
+            {"canShineCharge": {"usedTiles": 17, "openEnd": 0}}
+          ]}
+        ]},
+        {"autoReserveTrigger": {}},
+        "canRModeSparkInterrupt"
+      ],
+      "unlocksDoors": [{"nodeId": 2, "types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm Firefleas for Reserves or else Crystal Flash. Damage down on the thorns (6 hits suitless).",
+        "Get shinecharge on the top-right ledge and use the last fireflea to interrupt."
+      ],
+      "devNote": [
+        "FIXME: The last fireflea self-destructs and will drop a Large Energy right on top of Samus if full on PBs."
+      ]
+    },
+    {
       "id": 6,
       "link": [1, 1],
       "name": "Crystal Flash",
@@ -257,6 +294,43 @@
       },
       "bypassesDoorShell": true,
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        {"or": [
+          "h_CrystalFlash",
+          {"and": [
+            {"disableEquipment": "ETank"},
+            {"resourceAvailable": [{"type": "Energy", "count": 20}]},
+            {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 0}]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 1}}
+          ]}
+        ]},
+        {"or": [
+          {"canShineCharge": {"usedTiles": 16, "openEnd": 0}},
+          {"and": [
+            {"doorUnlockedAtNode": 2},
+            {"canShineCharge": {"usedTiles": 17, "openEnd": 0}}
+          ]}
+        ]},
+        {"autoReserveTrigger": {}},
+        "canRModeSparkInterrupt"
+      ],
+      "unlocksDoors": [{"nodeId": 2, "types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm Firefleas for Reserves or else Crystal Flash. Damage down on the thorns (6 hits suitless).",
+        "Get shinecharge on the top-right ledge and use the last fireflea to interrupt."
+      ],
+      "devNote": [
+        "FIXME: The last fireflea self-destructs and will drop a Large Energy right on top of Samus if full on PBs."
+      ]
     },
     {
       "id": 11,


### PR DESCRIPTION
Reserve farming is very good here due to Firefleas guaranteeing Large Energy when full on PBs, but four is still not enough to completely fill an E-Tank.

If the runway is too tight, the thorns could be used for Spike X-Mode (will want a separate strat).

Not sure how to accurately reflect the correct energy state in the event of autoReserveTrigger, with the fireflea self-destructing and dropping a Large Energy right on top of Samus. This can only happen on the firefleam farm route, since in the CF route they will (except for a very very low chance) drop PBs instead.

Note that you should only farm one Fireflea. If you farm all four the room becomes very dark, and Samus's sprite is affected by the darkness in R-Mode, which can make it extremely difficult to see position or the magic frame when short-charging.