### PR TITLE
Green Brinstar Main Shaft R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -604,6 +604,7 @@
       "to": [
         {"id": 7},
         {"id": 8},
+        {"id": 9},
         {"id": 12},
         {"id": 13},
         {"id": 14}
@@ -4464,68 +4465,6 @@
       "clearsObstacles": ["R-Mode"]
     },
     {
-      "link": [9, 9],
-      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
-      "requires": [
-        {"obstaclesCleared": ["R-Mode"]},
-        {"or": [
-          "h_CrystalFlash",
-          {"and": [
-            {"obstaclesCleared": ["A"]},
-            {"disableEquipment": "ETank"},
-            {"or": [
-              {"resourceAvailable": [{"type": "Energy", "count": 80}]},
-              {"and": [
-                {"enemyKill": {
-                  "enemies": [["Ripper 2 (red)"], ["Ripper 2 (red)"]],
-                  "excludedWeapons": ["Super"]
-                }},
-                {"resourceAvailable": [{"type": "Energy", "count": 40}]}
-              ]}
-            ]},
-            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
-            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
-            {"partialRefill": {"type": "ReserveEnergy", "limit": 1}}
-          ]}
-        ]},
-        {"notable": "Bottom Ice Clip"},
-        "h_bombThings",
-        "h_additionalBomb",
-        "canTrickyJump",
-        {"or": [
-          "h_XRayMorphIceClip",
-          {"and": [
-            "h_highPixelIceClip",
-            "canInsaneJump",
-            "canBeVeryPatient"
-          ]}
-        ]},
-        {"or": [
-          "h_useSpringBall",
-          {"and": [
-            "can4HighMidAirMorph",
-            "canInsaneJump"
-          ]}
-        ]},
-        {"or": [
-          {"canShineCharge": {"usedTiles": 17, "openEnd": 1}},
-          {"and": [
-            "h_frozenEnemyRunway",
-            {"canShineCharge": {"usedTiles": 18, "openEnd": 1}}
-          ]}
-        ]},
-        {"autoReserveTrigger": {}},
-        "canRModeSparkInterrupt"
-      ],
-      "resetsObstacles": ["R-Mode"],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": [
-        "Enter R-Mode using any door. Crystal Flash or farm the upper section enemies. Use 'Bottom Ice Clip' strat to regain access to the Etecoons Shaft, then",
-        "wait on top of the crumble block to get the Zeela to follow you in. Shinecharge on top of the Etecoon Shaft and get hit by the Zeela to interrupt."
-      ]
-    },
-    {
       "id": 188,
       "link": [9, 9],
       "name": "Leave With Runway",
@@ -5430,6 +5369,52 @@
       "name": "Base",
       "requires": [],
       "flashSuitChecked": true
+    },
+    {
+      "link": [13, 9],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "requires": [
+        {"obstaclesCleared": ["R-Mode"]},
+        {"notable": "Bottom Ice Clip"},
+        {"or": [
+          "h_CrystalFlash",
+          {"and": [
+            {"obstaclesCleared": ["A"]},
+            "h_RModeCanRefillReserves",
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        "h_bombThings",
+        "h_additionalBomb",
+        "canTrickyJump",
+        "h_XRayMorphIceClip",
+        {"or": [
+          "h_useSpringBall",
+          {"and": [
+            "can4HighMidAirMorph",
+            "canInsaneJump"
+          ]}
+        ]},
+        "canBeVeryPatient",
+        {"or": [
+          {"canShineCharge": {"usedTiles": 17, "openEnd": 1}},
+          {"and": [
+            "h_frozenEnemyRunway",
+            {"canShineCharge": {"usedTiles": 18, "openEnd": 1}}
+          ]}
+        ]},
+        {"autoReserveTrigger": {}},
+        "canRModeSparkInterrupt"
+      ],
+      "resetsObstacles": ["R-Mode"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Enter R-Mode using any door. Crystal Flash or farm the upper section enemies. Use 'Bottom Ice Clip' strat to regain access to the Etecoons Shaft, then",
+        "wait on top of the crumble block to get the Zeela to follow you in. Shinecharge on top of the Etecoon Shaft and get hit by the Zeela to interrupt."
+      ]
     },
     {
       "id": 235,


### PR DESCRIPTION
Notes on this room:
- A lot of doors, so the obstacle approach seemed obvious.
- Access between shinecharge location and enemies for farming separated by a PB barrier.
- Needs a notable strat ("Bottom Ice Clip") to get the Zeela in position to interrupt. Also needed to regain access to the Etecoon shaft after farming.
- Note that getting *to* the strat from anywhere other than Etecoons means you already did the Bottom Ice Clip, and the strat will (logically) have you do it again. In practice you only need to do it once, which is relevant for bomb usage. Better way to track this?
- The internal door has a valid G-Mode setup, so this entire strat could be done internally if the internal door is or can be unlocked.

