### PR TITLE
Green Brinstar Green Hills Zone R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/green/Green Hill Zone.json
+++ b/region/brinstar/green/Green Hill Zone.json
@@ -1516,7 +1516,6 @@
       "requires": [
         {"or": [
           "Wave",
-          {"obstaclesCleared": ["B"]},
           "h_blueGateGlitch",
           {"and": [
             {"notable": "Grapple Gate Glitch"},


### PR DESCRIPTION
Respawning enemies and a nice long runway. You can jump into the lowest bug spawner for the R-Mode Spark Interrupt.

Only the right door requires extra logic (opening the gate).