### PR TITLE
Refine Red Tower hero shot shinespark

### DIFF
--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -1066,15 +1066,24 @@
         {"shineChargeFrames": 100},
         {"notable": "Hero Shot Shinespark"},
         "canHeroShot",
-        {"shinespark": {"frames": 77, "excessFrames": 3}},
+        {"shinespark": {"frames": 77, "excessFrames": 7}},
         {"ammo": {"type": "Missile", "count": 1}}
       ],
       "wallJumpAvoid": true,
       "flashSuitChecked": true,
       "note": [
-        "Come in shinecharged from the top left door. With missiles selected, position Samus roughly in the horizontal center of the room.",
-        "Crouch, aim up, then in very quick succession, shoot a missile upwards then spark up.",
-        "If done correctly, Samus will pass the Missile, break the bomb block platforms, then be passed by the Missile which will break the shot blocks at the top."
+        "Come in shinecharged from the top left door.",
+        "With missiles selected, position Samus roughly in the horizontal center of the room.",
+        "Crouch, hold angle up and angle down simultaneously to aim up,",
+        "then in very quick succession, shoot a Missile upwards, release angle up and angle down,",
+        "press and hold jump to initiate the shinespark wind-up from a crouch,",
+        "then quickly press up to spark upwards.",
+        "If done correctly, Samus will pass the Missile, break the bomb block platforms,",
+        "then be passed by the Missile which will break the shot blocks at the top."
+      ],
+      "detailNote": [
+        "Initiating the shinespark from a stand can also work, but if no tanks are available,",
+        "Samus will not get high enough reach the ledge normally and would have to down-back. "
       ]
     },
     {
@@ -1090,15 +1099,24 @@
       "requires": [
         {"notable": "Hero Shot Shinespark"},
         "canHeroShot",
-        {"shinespark": {"frames": 77, "excessFrames": 3}},
+        {"shinespark": {"frames": 77, "excessFrames": 7}},
         {"ammo": {"type": "Missile", "count": 1}}
       ],
       "wallJumpAvoid": true,
       "flashSuitChecked": true,
       "note": [
-        "Come in shinecharging from the top left door. With missiles selected, position Samus roughly in the horizontal center of the room.",
-        "Crouch, aim up, then in very quick succession, shoot a missile upwards then spark up.",
-        "If done correctly, Samus will pass the Missile, break the bomb block platforms, then be passed by the Missile which will break the shot blocks at the top."
+        "Come in shinecharged from the top left door.",
+        "With missiles selected, position Samus roughly in the horizontal center of the room.",
+        "Crouch, hold angle up and angle down simultaneously to aim up,",
+        "then in very quick succession, shoot a Missile upwards, release angle up and angle down,",
+        "press and hold jump to initiate the shinespark wind-up from a crouch,",
+        "then quickly press up to spark upwards.",
+        "If done correctly, Samus will pass the Missile, break the bomb block platforms,",
+        "then be passed by the Missile which will break the shot blocks at the top."
+      ],
+      "detailNote": [
+        "Initiating the shinespark from a stand can also work, but if no tanks are available,",
+        "Samus will not get high enough reach the ledge normally and would have to down-back. "
       ]
     },
     {
@@ -1109,15 +1127,24 @@
         {"notable": "Hero Shot Shinespark"},
         "canHeroShot",
         {"useFlashSuit": {}},
-        {"shinespark": {"frames": 77, "excessFrames": 3}},
+        {"shinespark": {"frames": 77, "excessFrames": 7}},
         {"ammo": {"type": "Missile", "count": 1}}
       ],
       "wallJumpAvoid": true,
       "flashSuitChecked": true,
       "note": [
+        "Come in shinecharged from the top left door.",
         "With missiles selected, position Samus roughly in the horizontal center of the room.",
-        "Crouch, aim up, then in very quick succession, shoot a missile upwards then spark up.",
-        "If done correctly, Samus will pass the Missile, break the bomb block platforms, then be passed by the Missile which will break the shot blocks at the top."
+        "Crouch, hold angle up and angle down simultaneously to aim up,",
+        "then in very quick succession, shoot a Missile upwards, release angle up and angle down,",
+        "press and hold jump to initiate the shinespark wind-up from a crouch,",
+        "then quickly press up to spark upwards.",
+        "If done correctly, Samus will pass the Missile, break the bomb block platforms,",
+        "then be passed by the Missile which will break the shot blocks at the top."
+      ],
+      "detailNote": [
+        "Initiating the shinespark from a stand can also work, but if no tanks are available,",
+        "Samus will not get high enough reach the ledge normally and would have to down-back. "
       ]
     },
     {


### PR DESCRIPTION
This is to reflect that it is possible to do tankless. The tankless version seems only slightly more difficult, so I thought it's probably not enough to justify adding more logical requirements for it. Updated the note to describe the inputs for the crouch-jump method, since this seems to be the easiest way to do it tankless.