### PR TITLE
Green Brinstar Spore Spawn Kihunters R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -103,6 +103,7 @@
         {"or": [
           "h_CrystalFlash",
           {"and": [
+            "canTrickyDodgeEnemies",
             "h_RModeCanRefillReserves",
             {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
             {"or": [


### PR DESCRIPTION
Green Kihunters have poor drop rate, so they get `canBePatient` like the Morph Room Sidehoppers do.