### PR TITLE
add spikesuits to noob bridge

### DIFF
--- a/region/brinstar/green/Noob Bridge.json
+++ b/region/brinstar/green/Noob Bridge.json
@@ -292,7 +292,7 @@
           ]},
           {"and": [
             "HiJump",
-            "canBeVeryPatient"
+            "canQuickDrop"
           ]}
         ]},
         {"spikeHits": 1},


### PR DESCRIPTION
I saw "noob bridge" in the issues thread of add more spikesuits..

I stuck a canbeverypatient on the springball / hijump ones as they are kind of sucky, especially the springball one.. but i can always take it off if it's not needed?

https://videos.maprando.com/video/8873 [hjb / quickdrop]

https://videos.maprando.com/video/8874 [with bombs]

https://videos.maprando.com/video/8875 [with peebs]

https://videos.maprando.com/video/8876 [with springball]