### PR TITLE
West Crateria blue suit logic

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -1421,8 +1421,16 @@
               "canInsaneJump"
             ]}
           ]
+        },
+        {
+          "name": "h_storedSpark",
+          "requires": [
+            {"or": [
+              {"useFlashSuit": {}},
+              {"blueSuitShinecharge": {}}
+            ]}
+          ]
         }
-
       ]
     },
     {

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -76,12 +76,6 @@
       "note": "The left half of the leftmost thick wall that can be broken to extend the runway. Only useful in G-Mode."
     },
     {
-      "id": "D",
-      "name": "Blue Suit",
-      "obstacleType": "abstract",
-      "note": "Samus has obtained a blue suit from R-Mode."
-    },
-    {
       "id": "E",
       "name": "Respawning Block",
       "obstacleType": "abstract",
@@ -151,7 +145,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 1,
@@ -169,6 +164,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Involves leaving some drops hanging after killing the enemies so they don't respawn."
     },
     {
@@ -191,6 +187,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Involves leaving some drops hanging after killing the enemies so they don't respawn."
     },
     {
@@ -210,6 +207,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Involves leaving some drops hanging after killing the enemies so they don't respawn.",
       "devNote": "This situation can only be usefully created with G-Mode."
     },
@@ -222,6 +220,7 @@
       ],
       "farmCycleDrops": [{"enemy": "Zebbo", "count": 1}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "We use cycleFrames here rather than simpleCycleFrames because of how the acid (and Yapping Maw) complicates the farm."
       ]
@@ -240,7 +239,8 @@
       },
       "requires": [],
       "clearsObstacles": ["B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -264,6 +264,7 @@
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "To use the full runway, kill the Zebbo with Wave.",
       "devNote": [
         "FIXME: Running through acid doesn't stop a shinecharge, but does inhibit tapping without gravity.",
@@ -313,7 +314,35 @@
         ]}
       ],
       "clearsObstacles": ["B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Crystal Spark)",
+      "requires": [
+        {"obstaclesCleared": ["B"]},
+        {"or": [
+          {"canShineCharge": {
+            "usedTiles": 18,
+            "steepUpTiles": 1,
+            "steepDownTiles": 1,
+            "openEnd": 1
+          }},
+          {"and": [
+            {"canShineCharge": {
+              "usedTiles": 19,
+              "steepUpTiles": 1,
+              "steepDownTiles": 1,
+              "openEnd": 1
+            }},
+            {"doorUnlockedAtNode": 1}
+          ]}
+        ]},
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -323,7 +352,8 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -340,6 +370,7 @@
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Place a Power Bomb to the left of the Zebbo, then exit G-Mode, to break the bomb wall to the right."
     },
     {
@@ -357,18 +388,18 @@
       ],
       "clearsObstacles": ["C"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Carefully kill the Zebbo, then place two bombs against the right wall to break the left half of the wall to slightly increase the length of the runway."
     },
     {
       "id": 11,
       "link": [1, 1],
-      "name": "R-Mode Blue Suit",
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
       "entranceCondition": {
         "comeInWithRMode": {}
       },
       "requires": [
-        {"notable": "R-Mode Blue Suit"},
-        "canBePatient",
+        {"refill": ["Energy"]},
         {"or": [
           {"canShineCharge": {
             "usedTiles": 14,
@@ -405,17 +436,17 @@
             {"doorUnlockedAtNode": 1}
           ]}
         ]},
-        {"shinespark": {"frames": 0, "excessFrames": 0}}
+        {"autoReserveTrigger": {}},
+        "canRModeSparkInterrupt"
       ],
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "clearsObstacles": ["B", "D"],
+      "clearsObstacles": ["B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
-        "Use R-Mode to get a blue suit to cross the room and get the item, or to leave the right shinecharged.",
         "In R-Mode, fill your Reserves at the farm. Damage down again so that Samus is within 1 Zebbo hit from triggering Reserves.",
         "Gain a shinecharge in-room without gaining more energy. It is possible to time the despawn of a drop with the acid if no ammo is owned.",
-        "Shinespark vertically, such that a Zebbo can hit Samus in the wind-up to cause a reserve trigger, giving a blue suit.",
-        "It is then fine to farm the Zebbos again."
+        "Shinespark vertically, such that a Zebbo can hit Samus in the wind-up to cause a reserve trigger, giving a blue suit."
       ]
     },
     {
@@ -447,6 +478,7 @@
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Gain a spike suit and shinespark vertically into the spikes,",
         "being careful not to turn around or move forward until Samus falls far enough, to avoid additional spike hits.",
@@ -462,14 +494,14 @@
       "requires": [
         {"obstaclesCleared": ["B"]},
         {"or": [
-          {"canShineCharge": {
+          {"getBlueSpeed": {
             "usedTiles": 18,
             "steepUpTiles": 1,
             "steepDownTiles": 1,
             "openEnd": 1
           }},
           {"and": [
-            {"canShineCharge": {
+            {"getBlueSpeed": {
               "usedTiles": 19,
               "steepUpTiles": 1,
               "steepDownTiles": 1,
@@ -482,33 +514,15 @@
         "canChainTemporaryBlue"
       ],
       "clearsObstacles": ["A", "E"],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 12,
-      "link": [1, 3],
-      "name": "Blue Suit",
-      "requires": [
-        {"notable": "R-Mode Blue Suit"},
-        {"obstaclesCleared": ["D"]},
-        "Morph",
-        {"or": [
-          "canTrickyJump",
-          {"acidFrames": 20}
-        ]}
-      ],
-      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
-      "note": [
-        "Carefully walk through the room. It is possible but tricky to do so damageless, but it is always possible to go back and farm if needed.",
-        "While in the morph tunnel, simply unmorph to break the bomb blocks overhead."
-      ]
+      "blueSuitChecked": true
     },
     {
       "id": 13,
       "link": [1, 4],
       "name": "Base",
       "requires": [
+        "canDash",
         {"or": [
           "canCarefulJump",
           {"acidFrames": 35}
@@ -519,7 +533,26 @@
         ]}
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "id": 12,
+      "link": [1, 4],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}},
+        {"or": [
+          "canTrickyJump",
+          {"acidFrames": 20}
+        ]}
+      ],
+      "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Carefully walk through the room. It is possible but tricky to do so damageless, but it is always possible to go back and farm if needed."
+      ]
     },
     {
       "id": 14,
@@ -534,6 +567,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Enter through the top of the door to reach all the way to the shot block wall."
     },
     {
@@ -555,6 +589,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Charge the Shinespark just before getting to the bug, then Midair Shinespark to make it all the way to the shot blocks."
     },
     {
@@ -582,6 +617,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "To use the full runway, kill the Zebbo with Wave, then Midair Shinespark to make it all the way to the shot blocks.",
       "devNote": [
         "FIXME: Running through acid doesn't stop a shinecharge, but does inhibit tapping without gravity.",
@@ -591,7 +627,7 @@
     {
       "id": 17,
       "link": [1, 4],
-      "name": "Blue SpaceJump",
+      "name": "Blue Space Jump",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 5,
@@ -606,12 +642,13 @@
         "h_complexToCarryFlashSuit"
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 18,
       "link": [1, 4],
-      "name": "Blue SpaceJump, Kill Zebo on Entry",
+      "name": "Blue Space Jump, Kill Zebo on Entry",
       "entranceCondition": {
         "comeInGettingBlueSpeed": {
           "length": 14,
@@ -632,6 +669,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "To use the full runway, kill the Zebbo with Wave.",
       "devNote": [
         "FIXME: Running through acid doesn't stop a shinecharge, but does inhibit tapping without gravity.",
@@ -643,6 +681,7 @@
       "link": [1, 4],
       "name": "Bombs",
       "requires": [
+        "canDash",
         {"or": [
           "canCarefulJump",
           {"acidFrames": 35}
@@ -651,6 +690,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "When taking too much acid damage, it is always possible to return to the left and farm."
     },
     {
@@ -658,6 +698,7 @@
       "link": [1, 4],
       "name": "Power Bombs",
       "requires": [
+        "canDash",
         {"or": [
           "canCarefulJump",
           {"acidFrames": 35}
@@ -676,6 +717,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "When taking too much acid damage, it is always possible to return to the left and farm."
     },
     {
@@ -706,6 +748,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "It is possible to return to the farm after sparking to regain Energy."
     },
     {
@@ -718,7 +761,8 @@
         {"shinespark": {"frames": 49, "excessFrames": 0}}
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 23,
@@ -726,6 +770,7 @@
       "name": "Use Flash Suit and Power Bombs",
       "requires": [
         "h_usePowerBomb",
+        "canDash",
         {"useFlashSuit": {}},
         {"or": [
           {"and": [
@@ -739,7 +784,8 @@
         ]}
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 24,
@@ -751,7 +797,8 @@
         }
       },
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 56,
@@ -769,7 +816,8 @@
         ]}
       ],
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 25,
@@ -782,7 +830,8 @@
       },
       "requires": [],
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 26,
@@ -800,7 +849,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 27,
@@ -818,7 +868,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 28,
@@ -842,6 +893,7 @@
         {"shinespark": {"frames": 93, "excessFrames": 15}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Use SpeedBooster to break the runway Bomb block and then to shinespark across the room, saving Power Bombs.",
         "One Power Bomb is still needed to break the tunnel block.",
@@ -870,6 +922,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Carry temporary blue across the room, breaking the bomb blocks along the way.",
         "Use Spring Ball to bounce through the morph tunnel at the beginning, and across the final stretch at the end."
@@ -901,11 +954,16 @@
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "collectsItems": [3],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Roll through the item to overload PLMs then quickly fall into the morph tunnel, unmorph at the correct spot and jump out before the acid touches Samus.",
         "With a careful, blind, Space Jump with Screw Attack, move through the bomb walls while avoiding the spikes."
       ],
-      "devNote": "This strat leaves the room, as it would be unreasonable and may not be possible to do anything at 1 with the broken camera movement."
+      "devNote": [
+        "This strat leaves the room, as it would be unreasonable and may not be possible to do anything at 1 with the broken camera movement.",
+        "With a blue suit, there is no need to overload PLMs, so the camera will not be broken and the requirements could be relaxed;",
+        "but it is covered by a 2->4 strat."
+      ]
     },
     {
       "id": 29,
@@ -919,7 +977,8 @@
           "steepUpTiles": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 30,
@@ -928,14 +987,16 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 31,
       "link": [2, 3],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 32,
@@ -954,6 +1015,7 @@
         {"acidFrames": 60}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "There are 9 unusable tiles in this runway."
     },
     {
@@ -972,6 +1034,7 @@
         {"acidFrames": 200}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "There are 5 unusable tiles in this runway."
     },
     {
@@ -993,6 +1056,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "A quick jump morph from the top of the slope will bounce into the tunnel and avoid acid damage.",
       "devNote": "There are 6 unusable tiles in this runway."
     },
@@ -1012,6 +1076,7 @@
         {"acidFrames": 27}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "There is 1 unusable tile in this runway."
     },
     {
@@ -1024,12 +1089,18 @@
         }
       },
       "requires": [
+        {"noBlueSuit": {}},
         "Morph",
         "canMoonfall"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Moonfall against the Chozo statue to clip into the Morph Tunnel, past the Bomb block."
+      ],
+      "devNote": [
+        "The fact that this doesn't work with a blue suit is irrelevant, since reaching node 4 is free with a blue suit and Morph.",
+        "But we include a `noBlueSuit` requirement anyway, to be correct."
       ]
     },
     {
@@ -1052,6 +1123,7 @@
       ],
       "collectsItems": [3],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Roll through the item to overload PLMs then fall into the morph tunnel, unmorph at the correct spot and quickly jump out before the acid touches Samus.",
         "Exit G-mode and roll back into the tunnel to fix the camera and return avoiding the acid again."
@@ -1062,45 +1134,33 @@
       ]
     },
     {
-      "id": 37,
-      "link": [3, 1],
-      "name": "Blue Suit",
+      "link": [2, 4],
+      "name": "G-Mode Morph with Blue Suit",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
       "requires": [
-        {"notable": "R-Mode Blue Suit"},
-        {"obstaclesCleared": ["D"]},
-        "Morph",
-        {"or": [
-          "canTrickyJump",
-          {"acidFrames": 10}
-        ]}
+        {"haveBlueSuit": {}},
+        "canOffScreenMovement"
       ],
-      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
-      "note": "Carefully walk through the room. It is possible but tricky to do so damageless."
+      "blueSuitChecked": true,
+      "note": [
+        "Enter with artificial morph, and use a blue suit to fall into the morph tunnel,",
+        "unmorph at the correct spot and quickly jump out before the acid touches Samus.",
+        "Exit G-mode to fix the camera."
+      ]
     },
     {
       "id": 38,
       "link": [3, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
-    },
-    {
-      "id": 39,
-      "link": [3, 2],
-      "name": "Leave Shinecharged, Blue Suit",
-      "requires": [
-        {"notable": "R-Mode Blue Suit"},
-        {"obstaclesCleared": ["D"]},
-        "h_shinechargeMaxRunway",
-        {"shineChargeFrames": 0}
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {}
-      },
-      "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
-      "devNote": "FIXME: Add a way to leave with blue suit."
+      "blueSuitChecked": true
     },
     {
       "id": 40,
@@ -1109,7 +1169,18 @@
       "requires": [
         "h_usePowerBomb"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [3, 4],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}},
+        "Morph"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 41,
@@ -1123,6 +1194,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Delay breaking the runway block so that it will not respawn too quickly.",
         "Wait for the acid to be rising to break the tunnel block, and then go through the tunnel on the next cycle."
@@ -1138,6 +1210,7 @@
       ],
       "resetsObstacles": ["E"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Grab the item and quickly return through the blocks before they respawn.",
       "devNote": "This does not require the item to be there, but there is no reason to go through the tunnel twice if it's not."
     },
@@ -1146,6 +1219,7 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [
+        "canDash",
         {"or": [
           "canCarefulJump",
           {"acidFrames": 35}
@@ -1160,13 +1234,30 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
-      "devNote": "A Back-of-Gauntlet-Spark strat would require at least Screw Attack and acid Frames to be reasonable."
+      "blueSuitChecked": true
+    },
+    {
+      "id": 37,
+      "link": [4, 1],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}},
+        {"or": [
+          "canTrickyJump",
+          {"acidFrames": 10}
+        ]}
+      ],
+      "clearsObstacles": ["A", "B"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": "Carefully walk through the room. It is possible but tricky to do so damageless."
     },
     {
       "id": 44,
       "link": [4, 1],
       "name": "Bombs",
       "requires": [
+        "canDash",
         {"or": [
           "canCarefulJump",
           {"acidFrames": 35}
@@ -1196,6 +1287,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "After destroying a single bomb block, Samus can spin jump into its spot to quickly escape the acid.",
         "To avoid the acid completely, morph quickly at the right height and place a bomb."
@@ -1206,6 +1298,7 @@
       "link": [4, 1],
       "name": "Power Bombs",
       "requires": [
+        "canDash",
         {"or": [
           "canCarefulJump",
           {"acidFrames": 35}
@@ -1214,7 +1307,8 @@
         {"ammo": {"type": "PowerBomb", "count": 3}}
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 46,
@@ -1226,7 +1320,8 @@
         {"shinespark": {"frames": 76, "excessFrames": 18}}
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 47,
@@ -1240,12 +1335,27 @@
           {"shinespark": {"frames": 58, "excessFrames": 21}},
           {"and": [
             "h_additionalBomb",
+            "canDash",
             {"shinespark": {"frames": 30, "excessFrames": 27}}
           ]}
         ]}
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [4, 3],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}},
+        "Morph"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "While in the morph tunnel, simply unmorph to break the bomb blocks overhead."
+      ]
     },
     {
       "id": 48,
@@ -1260,7 +1370,8 @@
         ]}
       ],
       "clearsObstacles": ["E"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 49,
@@ -1286,6 +1397,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Break the tunnel block with a Bomb and then return to safety.",
         "Break the runway block on the next cycle.",
@@ -1296,17 +1408,6 @@
     }
   ],
   "notables": [
-    {
-      "id": 1,
-      "name": "R-Mode Blue Suit",
-      "note": [
-        "Use R-Mode to get a blue suit to cross the room and get the item, or to leave the right shinecharged.",
-        "In R-Mode, fill your Reserves at the farm. Damage down again so that Samus is within 1 Zebbo hit from triggering Reserves.",
-        "Gain a shinecharge in-room without gaining more energy. It is possible to time the despawn of a drop with the acid if no ammo is owned.",
-        "Shinespark vertically, such that a Zebbo can hit Samus in the wind-up to cause a reserve trigger, giving a blue suit.",
-        "It is then fine to farm the Zebbos again."
-      ]
-    },
     {
       "id": 2,
       "name": "Spark Master",
@@ -1319,5 +1420,7 @@
   ],
   "nextStratId": 57,
   "nextNotableId": 3,
-  "devNote": ["FIXME: Add canLongChainTemporaryBlue left-to-right strats."]
+  "devNote": [
+    "FIXME: Add canLongChainTemporaryBlue left-to-right strats."
+  ]
 }

--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -88,20 +88,27 @@
         {"resetRoom": {"nodes": [1]}},
         {"or": [
           {"and": [
+            "canDash",
             "ScrewAttack",
             "canDodgeWhileShooting",
             {"cycleFrames": 600}
           ]},
           {"and": [
+            "canDash",
             "h_bombThings",
             "canTrickyDodgeEnemies",
             {"cycleFrames": 850}
+          ]},
+          {"and": [
+            {"haveBlueSuit": {}},
+            {"cycleFrames": 660}
           ]}
         ]}
       ],
       "resetsObstacles": ["A"],
       "farmCycleDrops": [{"enemy": "Waver", "count": 2}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "There is a third Waver on the right side of the room,",
         "but generally it would not be worthwhile to cross the room for it."
@@ -120,7 +127,8 @@
           "steepDownTiles": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -145,6 +153,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "It is possible to run through the Yapping Maw while it is attacking a different direction.",
         "But that likely requires acid damage and isn't entirely reliable."
@@ -174,7 +183,8 @@
           "position": "top"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
@@ -199,6 +209,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Freeze the Yapping Maw while it is in the air, extended."
     },
     {
@@ -208,7 +219,26 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 6,
+          "openEnd": 0,
+          "steepUpTiles": 1,
+          "steepDownTiles": 1
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -217,13 +247,15 @@
       "requires": [
         {"or": [
           "h_useMorphBombs",
-          "ScrewAttack"
+          "ScrewAttack",
+          {"haveBlueSuit": {}}
         ]}
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -240,6 +272,7 @@
         {"types": ["powerbomb"], "requires": [], "useImplicitRequires": false}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Place a Power Bomb near the door, then wait for the Waver to get into position to hit Samus through the transition.",
         "The Waver only moves while on camera, and needs to move around the region several times before being set up properly."
@@ -263,6 +296,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "Freeing the Waver with a shinespark is not reliable, and depends on when and where the shinespark starts.",
         "Most of these strats kill the Wavers or set up situations where they can't reach the door."
@@ -280,7 +314,18 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}}
+      ],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
@@ -315,6 +360,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Yapping maw / Wavers / Center bomb blockade"
     },
     {
@@ -335,7 +381,8 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -347,7 +394,8 @@
       "requires": [
         {"shinespark": {"frames": 95, "excessFrames": 20}}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -363,6 +411,7 @@
         {"shinespark": {"frames": 85, "excessFrames": 20}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Shinespark below the top block or Samus will crash into a solid wall."
     },
     {
@@ -388,6 +437,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Shinespark from the end of the entry runway, just past the down slope.",
         "Samus will crash into the last set of blocks preventing access to the opposite door."
@@ -413,6 +463,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "This is a series of precise jumps to fit between the solid walls while clearing a path through the room.",
         "Breaking the center blocks opens up a runway that can be used to charge a new spark in room."
@@ -435,6 +486,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "This is a series of precise jumps to fit between the solid walls while clearing a path through the room.",
         "Breaking the center blocks opens up a runway that can be used to charge a new spark in room."
@@ -456,6 +508,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "FIXME: Larger speeds (as high as max speed $7.0) can also work but require greater precision",
         "It would also be possible to stop in the middle of the room and then gain blue speed in-room to continue."
@@ -483,6 +536,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "FIXME: Larger speeds (as high as max speed $7.0) can also work but require greater precision",
         "It would also be possible to stop in the middle of the room and then gain blue speed in-room to continue."
@@ -510,6 +564,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Come in gaining blue speed, and chain temporary blue across the room, carefully avoiding the Yapping Maws and minimizing acid damage.",
         "After breaking the center bomb blocks, perform staggered walljumps (if available) on the wall to right, to wait for the acid to lower.",
@@ -529,7 +584,8 @@
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 86, "excessFrames": 21}}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 20,
@@ -549,7 +605,8 @@
           ]}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 21,
@@ -564,6 +621,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "This is harder when crossing the room and easier if the right door can be used to reset the room, but it will cost one extra Power Bomb.",
         "One method is to place a Power Bomb near the first bomb wall, killing the first Waver, but keeping the second, global Waver.",
@@ -589,7 +647,18 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}}
+      ],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 23,
@@ -615,6 +684,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Yapping Maw / Waver / Left of Blockade Bomb Wall"
     },
     {
@@ -637,7 +707,8 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 25,
@@ -649,7 +720,8 @@
       "requires": [
         {"shinespark": {"frames": 95, "excessFrames": 13}}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 26,
@@ -669,6 +741,7 @@
         {"shinespark": {"frames": 80, "excessFrames": 13}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Wait for the acid to clear before moving to shinespark on the other side of the bomb blocks."
     },
     {
@@ -691,6 +764,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "This is a series of precise jumps to fit between the solid walls while clearing a path through the room.",
         "Breaking the center blocks opens up a runway that can be used to charge a new spark in room."
@@ -713,6 +787,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "This is a series of precise jumps to fit between the solid walls while clearing a path through the room.",
         "Breaking the center blocks opens up a runway that can be used to charge a new spark in room."
@@ -734,6 +809,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "FIXME: Larger speeds (as high as max speed $7.0) can also work but require greater precision",
         "It would also be possible to stop in the middle of the room and then gain blue speed in-room to continue."
@@ -760,6 +836,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "FIXME: Larger speeds (as high as max speed $7.0) can also work but require greater precision",
         "It would also be possible to stop in the middle of the room and then gain blue speed in-room to continue."
@@ -782,6 +859,7 @@
         "canChainTemporaryBlue"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Come in gaining blue speed, and chain temporary blue across the room, carefully avoiding the Yapping Maws and acid.",
         "After breaking the center bomb blocks, run back to the right and wait for the acid to lower.",
@@ -800,7 +878,8 @@
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 79, "excessFrames": 14}}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 32,
@@ -819,6 +898,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "If using two Power Bombs, shinespark after the Yapping Maw starts to retreat to prevent a game crash."
     },
     {
@@ -831,7 +911,8 @@
         }
       },
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 50,
@@ -849,7 +930,8 @@
         ]}
       ],
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 34,
@@ -862,7 +944,8 @@
       },
       "requires": [],
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 35,
@@ -880,7 +963,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 36,
@@ -898,7 +982,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 37,
@@ -914,6 +999,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "This is harder when crossing the room and easier if the left door can be used to reset the room, but it will cost one extra Power Bomb.",
         "Place a Power Bomb near the first and third bomb walls. One Waver will be alive by the fifth wall, which will only move while on camera.",
@@ -929,19 +1015,26 @@
         "canDodgeWhileShooting",
         {"or": [
           {"and": [
+            "canDash",
             "ScrewAttack",
             {"cycleFrames": 420}
           ]},
           {"and": [
+            "canDash",
             "h_bombThings",
             "canTrickyDodgeEnemies",
             {"cycleFrames": 630}
+          ]},
+          {"and": [
+            {"haveBlueSuit": {}},
+            {"cycleFrames": 620}
           ]}
         ]}
       ],
       "resetsObstacles": ["A"],
       "farmCycleDrops": [{"enemy": "Waver", "count": 1}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 38,
@@ -956,7 +1049,8 @@
           "steepDownTiles": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 39,
@@ -980,6 +1074,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "The yapping maw prevents use of an extra runway tile because it will move to grab Samus"
     },
     {
@@ -1006,7 +1101,8 @@
           "position": "top"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 41,
@@ -1033,6 +1129,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Jump towards the Yapping Maw before it is on screen so it moves up.",
         "Quickly move it off camera so it will be `frozen` in place.",
@@ -1046,7 +1143,26 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 6,
+          "openEnd": 0,
+          "steepUpTiles": 1,
+          "steepDownTiles": 1
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 43,
@@ -1055,13 +1171,15 @@
       "requires": [
         {"or": [
           "h_useMorphBombs",
-          "ScrewAttack"
+          "ScrewAttack",
+          {"haveBlueSuit": {}}
         ]}
       ],
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 44,
@@ -1074,6 +1192,7 @@
         "leaveWithGModeSetup": {}
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Place a Power Bomb near the door, then wait for the Waver to get into position to hit Samus through the transition.",
         "The Waver only moves while on camera, and needs to move around the region several times before being set up properly."
@@ -1097,6 +1216,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "Freeing the Waver with a shinespark is not reliable, and depends on when and where the shinespark starts.",
         "Most of these strats kill the Wavers or set up situations where they can't reach the door."

--- a/region/crateria/west/Green Brinstar Elevator Room.json
+++ b/region/crateria/west/Green Brinstar Elevator Room.json
@@ -74,7 +74,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -83,14 +84,48 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 13,
+          "openEnd": 0
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (In-Room Crystal Spark)",
+      "requires": [
+        {"or": [
+          {"canShineCharge": {"usedTiles": 13, "openEnd": 0}},
+          {"and": [
+            {"doorUnlockedAtNode": 1},
+            {"canShineCharge": {"usedTiles": 14, "openEnd": 0}}
+          ]}
+        ]},
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
@@ -108,7 +143,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 5,
@@ -127,7 +163,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -146,7 +183,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -162,7 +200,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -180,14 +219,16 @@
           "morphed": false
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
@@ -207,7 +248,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -227,7 +269,8 @@
         "leaveShinecharged": {}
       },
       "unlocksDoors": [{"nodeId": 1, "types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -245,7 +288,8 @@
           "morphed": false
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -258,6 +302,7 @@
         "leaveNormally": {}
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "In order to align and place a Power Bomb at the correct pixel, jump and hit the ceiling in the aim-down pose, then morph on the descent."
     }
   ],

--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -283,7 +283,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -303,6 +304,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Create a runway by destroying all but the bottom row of shot blocks."
     },
     {
@@ -319,6 +321,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Create a runway by destroying all but the bottom row of shot blocks."
     },
     {
@@ -328,14 +331,32 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 3,
+          "openEnd": 0
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 5,
       "link": [1, 8],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -351,6 +372,7 @@
         "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "In Red Brinstar Firefleas, instead of simply grappling and moonwalking into the transition, perform a setup like in the Moat:",
         "Angle-up, jump, bonk the ceiling, then use Grapple just before landing and moonwalk back as it attaches.",
@@ -376,6 +398,7 @@
         "canOffScreenMovement"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "After teleporting, press down while still grappling, to move Samus up and right by retracting the grapple.",
         "Release Grapple, angle-down, and shoot the blocks to the left and right of Samus.",
@@ -394,7 +417,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -404,6 +428,7 @@
         {"resetRoom": {"nodes": [2, 3, 4]}},
         {"cycleFrames": 850},
         {"or": [
+          {"haveBlueSuit": {}},
           "ScrewAttack",
           "Wave",
           "Spazer",
@@ -426,6 +451,7 @@
       "resetsObstacles": ["A"],
       "farmCycleDrops": [{"enemy": "Green Space Pirate (standing)", "count": 5}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "A two-way farm strat could be added for if the room can be reset at both the top and bottom."
       ]
@@ -449,6 +475,7 @@
         {"enemy": "Green Space Pirate (standing)", "count": 2}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Jump to lay a Power Bomb above ground height, to both break the Power Bomb blocks and kill the Beetoms.",
         "The top two Space Pirates will also be killed."
@@ -470,6 +497,7 @@
           ]}
         ]},
         {"or": [
+          {"haveBlueSuit": {}},
           "ScrewAttack",
           "Wave",
           "Spazer",
@@ -496,6 +524,7 @@
         {"enemy": "Beetom", "count": 2}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "This strat mainly exists as a way to farm Beetoms in case the room cannot be reset at node 2;",
         "in this case, the Pirates along the way come almost for free, and it also works at node 2."
@@ -508,7 +537,8 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -521,6 +551,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Lay a Power Bomb on the floor to destroy the Power Bomb blocks.",
         "Go up and to either the left or right ledge with the Beetoms, and lay another Power Bomb.",
@@ -529,14 +560,32 @@
         "Stand and collect two Power Bomb drops, one from each Beetom, then remorph in time to press the Crystal Flash inputs."
       ],
       "devNote": [
-        "The resetRoom requirement is in case you need to farm a bit to get above health-bomb energy."
+        "The resetRoom requirement is in case you need to farm a bit to get above health-bomb energy.",
+        "With a blue suit, this strat has to be done a little differently but still works."
       ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 8,
+          "openEnd": 0
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
       "link": [2, 2],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
+        {"noBlueSuit": {}},
         "h_usePowerBomb",
         {"or": [
           {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}},
@@ -551,7 +600,17 @@
           "knockback": false
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 4],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 78,
@@ -564,7 +623,8 @@
           "hits": 5
         }}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -578,7 +638,8 @@
           "hits": 3
         }}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 14,
@@ -596,7 +657,8 @@
           ]
         }}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 15,
@@ -612,7 +674,8 @@
         {"shinespark": {"frames": 1, "excessFrames": 1}},
         "canUseSpeedEchoes"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 16,
@@ -621,7 +684,8 @@
       "requires": [
         "h_usePowerBomb"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 17,
@@ -634,6 +698,7 @@
         "canXRayClimb"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Climb until the camera fully shows Samus on the bottom of the screen.",
         "Shoot up to clear the shot blocks and resume climbing until you can walk out to the left.",
@@ -667,6 +732,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Crystal Flash then damage down on the Pirates to Reserve trigger to exit G-Mode.",
         "To prevent freeing the Beetoms, the Power Bomb needs to be placed on the left platform just below the door.",
@@ -685,7 +751,8 @@
         }
       },
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 20,
@@ -698,7 +765,8 @@
       },
       "requires": [],
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 21,
@@ -716,7 +784,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 22,
@@ -734,7 +803,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 23,
@@ -747,7 +817,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 24,
@@ -763,14 +834,32 @@
         }
       },
       "unlocksDoors": [{"nodeId": 4, "types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [3, 3],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 25,
       "link": [3, 4],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 26,
@@ -792,7 +881,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 27,
@@ -812,7 +902,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 28,
@@ -831,7 +922,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 29,
@@ -848,7 +940,8 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 30,
@@ -869,7 +962,8 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 31,
@@ -890,7 +984,8 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 32,
@@ -915,11 +1010,15 @@
         "canBePatient"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "X-Ray climb about 2.5 screen lengths, until the camera shows Samus' helmet on the bottom of the screen.",
         "Shoot up to clear the shot blocks and resume climbing until you can walk out to the right.",
         "Fix the camera by shooting the floor shot block and jumping down.",
         "The pirate will attack while climbing past it."
+      ],
+      "devNote": [
+        "With a blue suit, Samus' i-frames still last a normal amount of time."
       ]
     },
     {
@@ -953,10 +1052,19 @@
               "type": "contact",
               "hits": 5
             }}
+          ]},
+          {"and": [
+            "h_artificialMorphSpringBall",
+            {"or": [
+              "HiJump",
+              "h_artificialMorphSpringBallBombJump"
+            ]},
+            {"haveBlueSuit": {}}
           ]}
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "With Spring Ball, it is possible to save a Power Bomb by placing it on the descent of the first jump by the bottom corner of the overhang,",
         "then bouncing on it on the ascent of the second.",
@@ -979,6 +1087,7 @@
         "h_CrystalFlash"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "In Red Brinstar Firefleas, instead of simply grappling and moonwalking into the transition, perform a setup like in the Moat:",
         "Angle-up, jump, bonk the ceiling, then use Grapple just before landing and moonwalk back as it attaches.",
@@ -1001,11 +1110,21 @@
         "canOffScreenMovement"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "After teleporting, press down while still grappling, to move Samus up and right by retracting the grapple.",
         "Release Grapple, angle-down, and shoot the blocks to the left and right of Samus.",
         "Morph and roll to the right; then Samus will be able to unmorph and stand."
       ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Blue Suit",
+      "requires": [
+        {"haveBlueSuit": {}}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 36,
@@ -1018,13 +1137,15 @@
           "hits": 5
         }}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 37,
       "link": [4, 2],
       "name": "Tank the Damage (Use I-Frames to Reduce Damage)",
       "requires": [
+        "canDash",
         "canUseIFrames",
         "canTrickyJump",
         {"enemyDamage": {
@@ -1034,6 +1155,7 @@
         }}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "FIXME: This could use a ledge grab tech to avoid the 4th pirate hit.",
       "devNote": "A shinespark could be used to kill the bottom two pirates."
     },
@@ -1053,7 +1175,8 @@
           ]
         }}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 39,
@@ -1068,13 +1191,16 @@
       "requires": [
         "canComplexGMode",
         "canLongXRayClimb",
-        {"enemyKill": {
-          "enemies": [["Green Space Pirate (standing)"]],
-          "explicitWeapons": ["Charge", "Ice", "Wave", "Spazer", "Plasma", "Missile", "Super"]
-        }}
+        {"or": [
+          {"enemyKill": {
+            "enemies": [["Green Space Pirate (standing)"]]
+          }},
+          {"haveBlueSuit": {}}
+        ]}
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Enter with G-mode direct and kill the bottom Pirate.",
         "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
@@ -1101,6 +1227,7 @@
       ],
       "bypassesDoorShell": true,
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Enter with G-mode direct and kill the bottom Pirate with Bombs or a Power Bomb.",
         "Back up to between 1 and 6 pixels from the door transition, and activate X-ray to get very deep stuck in the door.",
@@ -1121,7 +1248,8 @@
         {"shinespark": {"frames": 1, "excessFrames": 1}},
         "canUseSpeedEchoes"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 41,
@@ -1139,6 +1267,7 @@
         "canUseSpeedEchoes"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "It is possible to damage once to get through the first two pirates, then shinespark to kill the three above.",
         "Diagonal shinespark into the corner on the floor below the pirate above. This requires fairly precise positioning of the pirates.",
@@ -1150,7 +1279,8 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 43,
@@ -1172,7 +1302,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 44,
@@ -1192,7 +1323,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 45,
@@ -1211,7 +1343,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 46,
@@ -1228,7 +1361,8 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 47,
@@ -1249,7 +1383,8 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 48,
@@ -1270,7 +1405,8 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 49,
@@ -1283,7 +1419,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 50,
@@ -1299,7 +1436,49 @@
         }
       },
       "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [4, 4],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 12,
+          "openEnd": 0
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [4, 4],
+      "name": "Gain Blue Suit (In-Room Crystal Spark)",
+      "requires": [
+        {"or": [
+          {"canShineCharge": {"usedTiles": 12, "openEnd": 0}},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 3},
+              {"doorUnlockedAtNode": 4}
+            ]},
+            {"canShineCharge": {"usedTiles": 13, "openEnd": 0}}
+          ]},
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"doorUnlockedAtNode": 4},
+            {"canShineCharge": {"usedTiles": 14, "openEnd": 0}}
+          ]}
+        ]},
+        "h_CrystalSpark"
+      ],
+      "unlocksDoors": [{"nodeId": 3, "types": ["ammo"], "requires": []}],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 51,
@@ -1324,6 +1503,7 @@
         "canBePatient"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "X-Ray climb about 2.5 screen lengths, until the camera shows Samus' helmet on the bottom of the screen.",
         "Shoot up to clear the shot blocks and resume climbing until you can walk out to the left.",
@@ -1362,10 +1542,19 @@
               "type": "contact",
               "hits": 5
             }}
+          ]},
+          {"and": [
+            "h_artificialMorphSpringBall",
+            {"or": [
+              "HiJump",
+              "h_artificialMorphSpringBallBombJump"
+            ]},
+            {"haveBlueSuit": {}}
           ]}
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "With Spring Ball, it is possible to save a Power Bomb by placing it on the descent of the first jump by the bottom corner of the overhang,",
         "then bouncing on it on the ascent of the second.",
@@ -1379,41 +1568,47 @@
       "link": [5, 8],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 54,
       "link": [6, 8],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 55,
       "link": [8, 5],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 56,
       "link": [8, 6],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 57,
       "link": [8, 9],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 58,
       "link": [9, 1],
       "name": "Beetom X-Ray Climb",
       "requires": [
+        {"noBlueSuit": {}},
         {"notable": "Beetom X-Ray Climb"},
         "canLongXRayClimb",
         "Morph",
@@ -1424,6 +1619,7 @@
       ],
       "resetsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Shoot out only the lower 2 shot blocks on the side Samus will be climbing.",
         "Grab a Beetom and use Morph to pixel align the Beetom with the edge of the wall.  While facing right.",
@@ -1450,13 +1646,15 @@
           {"obstaclesCleared": ["A"]}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 60,
       "link": [9, 2],
       "name": "Leave With Runway - Single Frozen Beetom",
       "requires": [
+        {"noBlueSuit": {}},
         "h_frozenEnemyRunway",
         {"or": [
           "Morph",
@@ -1472,6 +1670,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Bring a Beetom down from above and freeze it in position to extend the runway.",
         "Keep a half-tile gap between the Beetom and the runway in order to extend it as much as possible."
@@ -1482,6 +1681,7 @@
       "link": [9, 2],
       "name": "Leave With Runway - Double Frozen Beetom",
       "requires": [
+        {"noBlueSuit": {}},
         "h_trickyFrozenEnemyRunway",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 9}},
         {"or": [
@@ -1501,6 +1701,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Bring a Beetom down from above and freeze it in position to extend the runway.",
         "Shoot it again then quickly go back up and grab the second Beetom.",
@@ -1514,12 +1715,14 @@
       "link": [9, 2],
       "name": "Beetom Moondance",
       "requires": [
+        {"noBlueSuit": {}},
         {"notable": "Beetom Moondance"},
         "canMoondance",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 4}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Pick up a Beetom and bring it up to the centered platform below the crumble blocks.",
         "Freeze it at about head height where Samus can move around inside its sprite, and use it to Moondance.",
@@ -1533,12 +1736,14 @@
       "link": [9, 2],
       "name": "Beetom Stuck Moonfall",
       "requires": [
+        {"noBlueSuit": {}},
         {"notable": "Beetom Stuck Moonfall"},
         "canEnemyStuckMoonfall",
         "canTrickyUseFrozenEnemies",
         {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 2}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Position both Beetoms above the shot block for an 'Enemy Stuck Moonfall' to clip through the floor below, bypassing the morph tunnel.",
         "1) Attach a Beetom and freeze it off of Samus while standing on the shot block.",
@@ -1546,6 +1751,9 @@
         "3) Let the bottom Beetom unfreeze and then refreeze it once it touches the ground.",
         "4) Destroy the shot block and refresh Ice on both Beetoms.",
         "5) Moonfall between the Beetoms until Samus clips downward, while holding a button to automatically change animation pose (Angle-aim or Up)"
+      ],
+      "detailNote": [
+        "This can be done with a blue suit, by being careful not to move while a Beetom is attached."
       ]
     },
     {
@@ -1553,6 +1761,7 @@
       "link": [9, 2],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
+        {"noBlueSuit": {}},
         {"or": [
           "Morph",
           {"obstaclesCleared": ["A"]}
@@ -1565,13 +1774,15 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 65,
       "link": [9, 2],
       "name": "Leave with Moondance",
       "requires": [
+        {"noBlueSuit": {}},
         {"or": [
           "Morph",
           {"obstaclesCleared": ["A"]}
@@ -1586,13 +1797,15 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 66,
       "link": [9, 2],
       "name": "Leave with Extended Moondance",
       "requires": [
+        {"noBlueSuit": {}},
         {"or": [
           "Morph",
           {"obstaclesCleared": ["A"]}
@@ -1608,13 +1821,15 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 67,
       "link": [9, 3],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
+        {"noBlueSuit": {}},
         {"or": [
           "Morph",
           {"obstaclesCleared": ["A"]}
@@ -1657,6 +1872,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "It is possible to shake the Beetom off near the right door while facing left, then lure it down to the bottom without taking more hits (or to kill the Pirates with Bombs).",
       "devNote": [
         "FIXME: If starting the room at the bottom, the way it is written requires killing the pirates twice.",
@@ -1668,6 +1884,7 @@
       "link": [9, 3],
       "name": "Leave with Moondance",
       "requires": [
+        {"noBlueSuit": {}},
         {"or": [
           "Morph",
           {"obstaclesCleared": ["A"]}
@@ -1682,13 +1899,15 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 69,
       "link": [9, 3],
       "name": "Leave with Extended Moondance",
       "requires": [
+        {"noBlueSuit": {}},
         {"or": [
           "Morph",
           {"obstaclesCleared": ["A"]}
@@ -1705,6 +1924,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Carefully Moondance where the floor is supported by more tiles."
     },
     {
@@ -1712,6 +1932,7 @@
       "link": [9, 4],
       "name": "G-Mode Setup - Get Hit By Beetom",
       "requires": [
+        {"noBlueSuit": {}},
         {"or": [
           "Morph",
           {"obstaclesCleared": ["A"]}
@@ -1754,6 +1975,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "It is possible to shake the Beetom off near the right door while facing left, then lure it down to the bottom without taking more hits (or to kill the Pirates with Bombs).",
       "devNote": [
         "FIXME: If starting the room at the bottom, the way it is written requires killing the pirates twice.",
@@ -1765,6 +1987,7 @@
       "link": [9, 4],
       "name": "Leave with Moondance",
       "requires": [
+        {"noBlueSuit": {}},
         {"or": [
           "Morph",
           {"obstaclesCleared": ["A"]}
@@ -1779,13 +2002,15 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 72,
       "link": [9, 4],
       "name": "Leave with Extended Moondance",
       "requires": [
+        {"noBlueSuit": {}},
         {"or": [
           "Morph",
           {"obstaclesCleared": ["A"]}
@@ -1802,6 +2027,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Carefully Moondance where the floor is supported by more tiles."
     },
     {
@@ -1811,7 +2037,8 @@
       "requires": [
         "canGMode"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 74,
@@ -1822,7 +2049,8 @@
         "h_artificialMorphBombThings",
         "h_additionalBomb"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 75,
@@ -1834,6 +2062,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Place a Power Bomb and exit G-Mode. To prevent freeing the Beetoms, the Power Bomb needs to be placed on the left platform just below the door."
     },
     {
@@ -1855,6 +2084,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Place bombs against the bottom of the crumble blocks to overload PLMs."
     }
   ],

--- a/region/crateria/west/Lower Mushrooms.json
+++ b/region/crateria/west/Lower Mushrooms.json
@@ -90,7 +90,8 @@
         {"cycleFrames": 1200}
       ],
       "farmCycleDrops": [{"enemy": "Kago", "count": 2}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -99,7 +100,21 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Crystal Spark)",
+      "requires": [
+        "h_shinechargeMaxRunway",
+        "h_CrystalSparkWithoutLenience"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "No lenience, since the Kagos are a reasonable enough Power Bomb farm."
+      ]
     },
     {
       "id": 4,
@@ -111,7 +126,8 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 17,
@@ -131,14 +147,16 @@
         "h_shinechargeMaxRunway",
         "h_RModeKnockbackSpark"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 5,
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -159,7 +177,8 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -180,14 +199,16 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -208,7 +229,8 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
@@ -229,7 +251,8 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -242,7 +265,8 @@
       },
       "requires": [],
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -260,7 +284,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -278,7 +303,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 14,
@@ -291,7 +317,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 15,
@@ -303,7 +330,8 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 18,
@@ -323,7 +351,8 @@
         "h_shinechargeMaxRunway",
         "h_RModeKnockbackSpark"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/west/Statues Hallway.json
+++ b/region/crateria/west/Statues Hallway.json
@@ -64,7 +64,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 21,
@@ -88,6 +89,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Leaving with upward momentum is possible in three ways:",
         "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
@@ -120,7 +122,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -136,7 +139,8 @@
           "minExtraRunSpeed": "$1.3"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
@@ -155,7 +159,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 5,
@@ -175,7 +180,8 @@
           "movementType": "uncontrolled"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -190,7 +196,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -203,7 +210,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -212,21 +220,34 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Crystal Spark)",
+      "requires": [
+        "h_shinechargeMaxRunway",
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -239,7 +260,8 @@
       },
       "requires": [],
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -257,7 +279,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -275,7 +298,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 14,
@@ -288,7 +312,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 22,
@@ -312,6 +337,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Leaving with upward momentum is possible in three ways:",
         "1) Most easily, with a momentum-conserving morph against the ceiling through the transition,",
@@ -341,7 +367,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 16,
@@ -357,7 +384,8 @@
           "minExtraRunSpeed": "$1.3"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 17,
@@ -376,7 +404,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 18,
@@ -396,7 +425,8 @@
           "movementType": "uncontrolled"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 19,
@@ -411,7 +441,8 @@
           }
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 20,
@@ -424,7 +455,8 @@
       "exitCondition": {
         "leaveWithTemporaryBlue": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/crateria/west/Statues Room.json
+++ b/region/crateria/west/Statues Room.json
@@ -90,7 +90,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 25,
@@ -104,6 +105,7 @@
       ],
       "setsFlags": ["f_TourianOpen"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Represents the statues sinking and opening up the path to Tourian"
     },
     {
@@ -113,7 +115,24 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Come in Shinecharging, Crystal Spark)",
+      "entranceCondition": {
+        "comeInShinecharging": {
+          "length": 2,
+          "openEnd": 0
+        },
+        "comesInHeated": "no"
+      },
+      "requires": [
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 18,
@@ -122,7 +141,8 @@
       "requires": [
         "f_TourianOpen"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -140,7 +160,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
@@ -158,7 +179,8 @@
       "exitCondition": {
         "leaveShinecharged": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 5,
@@ -178,7 +200,8 @@
           "morphed": false
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 20,
@@ -196,7 +219,8 @@
           "canGravityJump"
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 21,
@@ -208,7 +232,8 @@
         "HiJump",
         "canSpringBallJumpMidAir"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 22,
@@ -220,17 +245,19 @@
         "canUnderwaterWalljump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Walljump up the elevator room walls without Gravity suit.  Space Jump helps once the waterline is reached."
     },
     {
       "id": 23,
       "link": [2, 1],
-      "name": "Underwater Bomb into SpringBall Jump",
+      "name": "Underwater Bomb into Spring Ball Jump",
       "requires": [
         "f_TourianOpen",
         "canUnderwaterBombIntoSpringBallJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Perform a double Spring Ball jump without Hi-Jump,",
         "using a Bomb to propel Samus upward just long enough to get the second mid-air Spring Ball jump."
@@ -251,10 +278,10 @@
     {
       "id": 24,
       "link": [2, 1],
-      "name": "Use Flash Suit",
+      "name": "Use Stored Spark",
       "requires": [
         "f_TourianOpen",
-        {"useFlashSuit": {}},
+        "h_storedSpark",
         {"or": [
           {"shinespark": {"frames": 14, "excessFrames": 8}},
           {"and": [
@@ -263,7 +290,8 @@
           ]}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 14,
@@ -280,6 +308,7 @@
         {"shinespark": {"frames": 21, "excessFrames": 8}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Jump to the right side and diagonal spark left to escape the water.",
         "To spark as quickly as possible, buffer a spin jump by holding left (or right) and jump while riding the elevator."
@@ -300,6 +329,7 @@
         {"shinespark": {"frames": 24, "excessFrames": 9}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Jump to either side and vertically spark out.",
         "To spark as quickly as possible, buffer a spin jump by holding left (or right) and jump while riding the elevator."
@@ -327,7 +357,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -352,7 +383,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -376,7 +408,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
@@ -400,7 +433,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 26,
@@ -414,6 +448,7 @@
       ],
       "setsFlags": ["f_TourianOpen"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Represents the statues sinking and opening up the path to Tourian, but coming from below.",
       "devNote": [
         "If Tourian is locked, coming in from below results in glitched graphics.",
@@ -427,7 +462,8 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -445,7 +481,8 @@
           "morphed": false
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -465,6 +502,7 @@
         "leaveNormally": {}
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "In order to align and place a Power Bomb at the correct pixel, perform a suitless stationary spin jump and hit the ceiling before starting to morph."
     }
   ],

--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -108,7 +108,8 @@
         }
       },
       "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 19,
@@ -122,7 +123,8 @@
           "gentleUpTiles": 2
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -146,13 +148,18 @@
             {"cycleFrames": 960}
           ]},
           {"cycleFrames": 1110}
+        ]},
+        {"or": [
+          "canDash",
+          {"cycleFrames": 400}
         ]}
       ],
       "farmCycleDrops": [
         {"enemy": "Geemer (blue)", "count": 6},
         {"enemy": "Waver", "count": 3}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -161,7 +168,18 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 1],
+      "name": "Gain Blue Suit (Crystal Spark)",
+      "requires": [
+        "h_shinechargeMaxRunway",
+        "h_CrystalSpark"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
@@ -171,7 +189,8 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 5,
@@ -181,7 +200,8 @@
         {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 1}}
       ],
       "gModeRegainMobility": {},
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -203,7 +223,8 @@
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
       "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -225,14 +246,16 @@
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
       "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
       "link": [1, 3],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -254,7 +277,8 @@
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
       "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
@@ -276,7 +300,8 @@
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
       "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -289,7 +314,8 @@
       },
       "requires": [],
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -307,7 +333,8 @@
         }
       },
       "bypassesDoorShell": true,
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -320,7 +347,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 14,
@@ -340,7 +368,8 @@
         {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 1}}
       ],
       "gModeRegainMobility": {},
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 20,
@@ -354,6 +383,7 @@
         {"shinespark": {"frames": 9, "excessFrames": 9}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "The Geemer and Samus both need to be in a position relative to the slope where the initial damage boost will allow Samus to land on the slope and perform a slopespark.",
         "A normalized setup can be achieved by entering from the right door, shinecharging down the slope and stopping before the Geemer is on screen (just before the second mushroom).",
@@ -378,6 +408,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Walk the Geemer up the slope, killing any wavers on the way. Once the Geemer reaches the top of the second slope walk left to move it off screen.",
         "Go back down the slope to gain enough runway and build a shinecharge up the slope. Jump over the Geemer and perform a slopespark on the slope close to the door."
@@ -391,21 +422,24 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 17,
       "link": [3, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 18,
       "link": [3, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -495,7 +495,7 @@ def process_req_speed_state(req, states, err_fn):
             # Note: "canSpeedKeep" can be used for other purposes than obtaining blue, but its presence should be
             # enough to satisfy the test as a way that blue may be obtained.
             states = {"blue"}
-        elif req in ["h_flashSuitIceClip", "h_SpikeXModeSpikeSuit", "h_ThornXModeSpikeSuit"]:
+        elif req in ["h_flashSuitIceClip", "h_SpikeXModeSpikeSuit", "h_ThornXModeSpikeSuit", "h_storedSpark"]:
             states = {"preshinespark"}
         elif req in ["h_CrystalSpark", "h_CrystalSparkWithoutLenience", "h_heatedCrystalSpark", "canRModeSparkInterrupt", "h_RModeKnockbackSpark"]:
             if not states.issubset(["shinecharging", "shinecharged"]):


### PR DESCRIPTION
This adds a helper `h_storedSpark` for cases where shinesparking using either a flash suit or blue suit works equivalently.

In Green Pirates Shaft, most things involving Beetoms seem not feasible with a blue suit (e.g., G-mode setups, moondances). It wouldn't surprise me if some of these turn out to be possible with a trickier setup; I just left them as `noBlueSuit` for now.

The only setups for gaining blue suit that I'm adding here are Crystal Spark strats, which exist at every in-room and cross-room runway. Methods of gaining blue suit using R-mode or X-mode will be added separately (currently being worked on by aquanight and nn). I did rework the existing R-mode spark interrupt strat in Gauntlet Energy Tank Room: there was no longer a need for it to have an obstacle or a notable strat; instead it's like the other R-mode spark interrupt strats being added.