### PR TITLE
Baby Kraid R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/kraid/Baby Kraid Room.json
+++ b/region/brinstar/kraid/Baby Kraid Room.json
@@ -243,6 +243,7 @@
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -643,6 +644,7 @@
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt"
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [


### PR DESCRIPTION
Notes for this room:
- Mini-Kraid was chosen as the reserve source, partly because he spawns five drops, guaranteed large energy when full on supers, and partly to remove interference from the spikes for setting up the shinecharge.
- Only one pirate needs to be kept alive, so evasion/pacifist requirement could be dropped down from `canCarefulJump`.
- Farming the pirates instead could remove the `canCarefulJump` requirement, for the left door, but needs "dodge Mini-Kraid" logic from the right.
- Max-length runway for the shinecharge so no fancy tricks for that part.