### PR TITLE
Kraid's Room R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -288,7 +288,10 @@
       "requires": [
         {"not": "f_DefeatedKraid"},
         "canRiskPermanentLossOfAccess",
-        "canBeVeryPatient",
+        {"or": [
+          "canBeVeryPatient",
+          {"disableEquipment": "ETank"}
+        ]},
         {"refill": ["Energy"]},
         {"or": [
           "Charge",
@@ -519,7 +522,10 @@
         {"or": [
           "h_CrystalFlash",
           {"and": [
-            "canBeVeryPatient",
+            {"or": [
+              "canBeVeryPatient",
+              {"disableEquipment": "ETank"}
+            ]},
             {"refill": ["Energy"]},
             {"or": [
               "Charge",


### PR DESCRIPTION
Room Notes:
- Only possible while Kraid is alive, so hard `canRiskPermanentLossOfAccess`.
- Requires X-Mode for shinecharge.
- Crystal Flash can be used to gain energy without causing Kraid to rise (allowing for KQK after).
- Otherwise, farming nails requires Kraid standup.
- There's a supposed case where the one (and only) nail that can yield drops can be despawned, thereby preventing any further drops from being farmed. Details about what can cause this, and what kind of tech may be needed to avoid it, may need research.
  - If nothing else, it may be necessary to treat the nail like a non-respawning enemy.
