### PR TITLE
Spore Spawn Farming Room R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/pink/Spore Spawn Farming Room.json
+++ b/region/brinstar/pink/Spore Spawn Farming Room.json
@@ -262,12 +262,14 @@
     {
       "id": 22,
       "link": [1, 1],
-      "name": "Gain Blue Suit (R-Mode Spark Interrupt)",
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
       "entranceCondition": {
         "comeInWithRMode": {}
       },
       "requires": [
+        {"refill": ["Energy"]},
         {"canShineCharge": {"usedTiles": 21, "steepUpTiles": 2, "openEnd": 0}},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt"
       ],
       "flashSuitChecked": true,


### PR DESCRIPTION
This one was added in the initial schema PR (#2320), so this is just to bring the energy logic in line with other "respawning enemy" rooms.