### PR TITLE
Pink Brinstar Wave Gate Room R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
+++ b/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
@@ -190,10 +190,16 @@
       "entranceCondition": {
         "comeInWithRMode": {}
       },
-      "requires": [],
+      "requires": [
+        {"enemyDamage": {"enemy": "Sm. Sidehopper", "type": "contact", "hits": 1}}
+      ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "clearsObstacles": ["R-Mode"]
+      "clearsObstacles": ["R-Mode"],
+      "devNote": [
+        "FIXME: It is possible to avoid a forced Small Sidehopper hit by buffering an aim down as you release X-Ray.",
+        "Evading further hits from that position would require more logic."
+      ]
     },
     {
       "link": [1, 1],


### PR DESCRIPTION
Room notes:
- Another room with Sidehoppers that are bad for drops, and spikes so we can just use all of them by using the spike R-Mode method.
- No runway, so we *also* need the spikes for X-Mode Shinecharge.
- R-Mode Obstacle used to incorporate Sidehopper kill strats, and movement for getting there from the right side.