### PR TITLE
Waterway Energy Tank Room R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -141,8 +141,10 @@
           ]}
         ]},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-        "canRModeSparkInterrupt"
+        "canRModeSparkInterrupt",
+        {"partialRefill": {"type": "Energy", "limit": 25}}
       ],
+      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [


### PR DESCRIPTION
Room Notes:

- Two long runways: one needs some logic to get to, the other needs Gravity to use.
- Zeros are easily accessed for energy setup. The rest of the enemies can only be accessed for farming with Gravity (water physics speed means not all of the energy that drops could be collected). Alternatively they can be farmed after blue suit.