### PR TITLE
Dachora Room R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/pink/Dachora Room.json
+++ b/region/brinstar/pink/Dachora Room.json
@@ -746,7 +746,7 @@
           {"shinespark": {"frames": 110, "excessFrames": 3}}
         ]},
         {"or": [
-          {"resourceAvailable": {"type": "ReserveEnergy", "count": 1}},
+          {"resourceAvailable": [{"type": "ReserveEnergy", "count": 1}]},
           {"and": [
             "h_RModeCanRefillReserves",
             {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},


### PR DESCRIPTION
Room Notes:

- Fairly standard room with non-respawning enemies and full-length runway.
- Access from the bottom door needs a shinespark, which incurs mandatory damage before farming/CF.
- Speed block pit may trip players up in execution, but logically has no requirements to avoid. Consider lenience options?