### PR TITLE
Ceres Ridley Spark Interrupt

### DIFF
--- a/region/ceres/main/Ceres Ridley's Room.json
+++ b/region/ceres/main/Ceres Ridley's Room.json
@@ -102,7 +102,14 @@
       "requires": [
         "canRiskPermanentLossOfAccess",
         {"not": "f_DefeatedCeresRidley"},
-        {"resourceAtMost": [{"type": "RegularEnergy", "count": 29}]},
+        {"or":[
+        {
+          "resourceAtMost": [{"type": "RegularEnergy", "count": 29}]},
+          {"and":[
+            "canTrickyDodgeEnemies",
+            "canDodgeWhileShooting"
+          ]}
+        ]},
         {"or": [
           {"canShineCharge": {"usedTiles": 12, "openEnd": 0}},
           {"useFlashSuit": {}}
@@ -112,7 +119,10 @@
       "setsFlags": ["f_DefeatedCeresRidley"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note": "Very tight short charge or bring in a flash suit. Windup the shinespark during Ridley's flyby."
+      "note": "Very tight short charge or bring in a flash suit. Windup the shinespark during Ridley's flyby.",
+      "devNote": [
+        "FIXME: A 100-shot fight would allow preserving more energy for escaping afterward, but needs a more accurate scenario than just a pair of tech."
+      ]
     },
     {
       "id": 6,


### PR DESCRIPTION
Not an R-Mode strat! However, it uses `canRModeSparkInterrupt` regardless because it still requires interrupting during the windup pose.

The interrupt results from Ridley's flyby forcing Samus into a knockback pose, rather than taking damage, so no crystal flash required either.

The shinecharge is either extremely tight in-room or - since it's not R-Mode - you can bring in a flash suit!

However, it's also `canRiskPermanentLossOfAccess` because Ceres Ridley isn't respawnable. A Power Bomb can force open the door and interrupt the defeat flag from being set (doing the windup on the 2x3 shelf can gain the blue suit and also have Samus thrown out the door), but once it is set the strat can't be done anymore.