### PR TITLE
Climb Supers Room R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/central/Climb Supers Room.json
+++ b/region/crateria/central/Climb Supers Room.json
@@ -245,34 +245,6 @@
       "flashSuitChecked": true
     },
     {
-      "link": [1, 1],
-      "name": "X-Mode - R-Mode Spark Pause Abuse Interrupt (Gain Blue Suit)",
-      "entranceCondition": {
-        "comeInWithRMode": {}
-      },
-      "requires": [
-        "h_CrystalFlash",
-        "canXMode",
-        "h_XModeSpikeHit",
-        "h_XModeSpikeHit",
-        "canUseIFrames",
-        "h_shinechargeMaxRunway",
-        {"autoReserveTrigger": {}},
-        "canRModePauseAbuseSparkInterrupt",
-        {"spikeHits": 1}
-      ],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": [
-        "Crystal Flash, set reserves to manual, then damage down on the spikes. Perform Spike X-Mode and gain shinecharge.",
-        "Pause abuse on a spike hit. Enter spark windup at the last moment before the game pauses and set auto reserve.",
-        "Quickly pause and unpause again to regain visibility."
-      ],
-      "devNote": [
-        "Assumes one extra spike hit after gaining blue suit due to loss of visibility."
-      ]
-    },
-    {
       "id": 75,
       "link": [1, 1],
       "name": "Leave With Grapple Swing",


### PR DESCRIPTION
Room notes:

- Top door requires Spike X-Mode and Pause Abuse. I also wrote in an extra spike hit after the auto reserve trigger to account for the temporary loss of visibility due to auto-reserve on 1st frame of unpause.
- Bottom door is fairly normal. There's an option for acid dip if all four Boyons must be farmed.