### PR TITLE
Climb R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -935,7 +935,7 @@
           {"enemyDamage": {"enemy": "Custom Climb Pirate", "type": "contact", "hits": 1}},
           {"enemyKill": {
             "enemies": [ ["Custom Climb Pirate", "Custom Climb Pirate"]],
-            "explicitWeapons": ["Charge+Plasma", "Super", "PowerBomb"]
+            "explicitWeapons": ["Plasma", "Super", "PowerBomb"]
           }}
         ]},
         "h_CrystalFlash",


### PR DESCRIPTION
Room Notes:

- Requires Zebes Awake for the standard version.
- Wall pirate drop rate is pretty good when full on Missiles.
- The bottom most pirate is best to lead towards the bottom of the room for interrupt. The player can start the windup anywhere in the line of sight to trigger a shot and jump.
- All standard strats are turned off during `f_ZebesSetAblaze` due to lack of wall pirates (and need for special attention due to the rising acid) - since this is the escape flag, it is *not* additionally flagged as permanent loss of access.
- Gaining bluesuit will logically clear the bomb wall, even if it didn't have to be cleared for the shinecharge. But this is fine since blue suit will clear it anyway.

Special Notes for `f_ZebesSetAblaze`:
- Need enemyKill requirements for the special pirates. (Plasma Beam? Ammo? Hyper Beam obviously works too.)
- Two strats are added for this condition, from each of the bottom doors. The theory of the strat is the same: clear the special pirates (they drop nothing) and then climb up the platforms for a Crystal Flash safely away from the acid.
- From there we get to use an acid-dip R-Mode Spark Interrupt. The expected reserve content after CF needed special attention due to the effects of high e-tanks. Without disableable e-tank, the auto-reserve trigger is capped at 50 (49 before CF + 1500 CF energy - 1499 energy cap = 50 reserves). With disabled e-tanks, the player can expect to get the full 400. I expect to see more use of Disable-ETank-aware CF planning when heated rooms start coming up.
- By this point, the acid has already risen considerably. Under limited reserves, the best option is to escape out the bottom right door and reset the room (and the acid) to carry the blue suit up Climb. With 400 reserves, it may be possible to get back above the acid if the goal is to carry it upwards. Either way, blue suit doesn't impede vertical movement in Climb.
- Acid frame counts need review.