### PR TITLE
R-Mode Spark Interrupt - Pause Abuse tech

### DIFF
--- a/tech.json
+++ b/tech.json
@@ -2514,6 +2514,26 @@
                 "Damage down to where auto-reserves will trigger after one more enemy hit.",
                 "Use a runway to gain a shinecharge, and press jump to activate shinespark wind-up near an enemy,",
                 "in such a way that the enemy hits Samus during the wind-up, triggering an R-Mode forced stand-up."
+              ],
+              "extensionTechs": [
+                {
+                  "name": "canRModePauseAbuseSparkInterrupt",
+                  "techRequires": [
+                    "canPauseAbuse",
+                    "canRModeSparkInterrupt"
+                  ],
+                  "otherRequires": [],
+                  "note": [
+                    "The ability to gain a blue suit by triggering an R-Mode forced stand-up during a shinespark wind-up,",
+                    "combined with using pause abuse to delay the interrupt, such as when the interrupting damage must be",
+                    "received with Samus not being in a shinespark windup. Execution is similar to a standard Spark Interrupt",
+                    "except that Reserves are set to Manual, and the player must press Start to pause just before taking the",
+                    "interrupting damage to reach 00 energy. The player must then initiate windup just before the pause fadeout",
+                    "completes. Once the game is paused, switching Reserve to Auto and unpausing will complete the R-Mode",
+                    "interrupt. The screen will remain completely black during this time, which can be corrected by pausing the",
+                    "game again."
+                  ]
+                }
               ]
             },
             {

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -501,7 +501,7 @@ def process_req_speed_state(req, states, err_fn):
             if not states.issubset(["shinecharging", "shinecharged", "preshinespark"]):
                 err_fn(f"{req} while not shinecharging/shinecharged/preshinespark")
             states = {"preshinespark"}
-        elif req in ["h_CrystalSpark", "h_CrystalSparkWithoutLenience", "h_heatedCrystalSpark", "canRModeSparkInterrupt", "h_RModeKnockbackSpark"]:
+        elif req in ["h_CrystalSpark", "h_CrystalSparkWithoutLenience", "h_heatedCrystalSpark", "canRModeSparkInterrupt", "canRModePauseAbuseSparkInterrupt", "h_RModeKnockbackSpark"]:
             if not states.issubset(["shinecharging", "shinecharged", "preshinespark"]):
                 err_fn(f"{req} while not shinecharging/shinecharged/preshinespark")
             states = {"normal"}


### PR DESCRIPTION
Adds tech `canRModePauseAbuseSparkInterrupt` which combines `canRModeSparkInterrupt` and `canPauseAbuse` with a different method of execution.

The tech works like this:
1. Enter with R-Mode.
2. Set Reserves to Manual.
3. Prepare for R-Mode Spark Interrupt as usual (farm or Crystal Flash for reserve energy, get shinecharge).
4. Pause the game just before taking the interruption damage (to reach 00 energy). You will want to do this close to ground, and in a way that Samus can land quickly.
6. Right before fadeout, begin spark windup.
7. Change Reserves to Auto. Do *not* refill any energy points.
8. R-Mode Standup will interrupt the waiting shinespark as soon as the game unpauses. The screen will remain fully dark.
9. Immediately pause and unpause again to regain visibility.

This tech will likely see use for the following scenarios:
- The best interruption damage source is immobile (e.g. spikes, thorns), or for some reason can't do damage to Samus while in a windup pose.
- In heated rooms with Varia Suit, disabling the suit to drain energy will want to pause-abuse so that Varia can be re-enabled during the reserve auto-fill. This would also apply to using Lava and disabling/enabling Gravity.