### PR TITLE
Crateria Flyway R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -150,16 +150,7 @@
             {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
             {"or": [
               {"and": [
-                {"resourceAvailable": [{"type": "RegularEnergy", "count": 99}]},
-                {"disableEquipment": "ETank"},
-                {"partialRefill": {"type": "ReserveEnergy", "limit": 100}}
-              ]},
-              {"and": [
                 {"resourceAvailable": [{"type": "RegularEnergy", "count": 19}]},
-                {"or": [
-                  "Plasma",
-                  "h_usePowerBomb"
-                ]},
                 {"disableEquipment": "ETank"},
                 {"partialRefill": {"type": "ReserveEnergy", "limit": 100}}
               ]},


### PR DESCRIPTION
Room notes:

- Nothing special to say about this quite long runway. Manipulation of the one Mellow you keep to get it out of the way seems relatively trivial.
- Twelve Mellows available to farm (before and after spark) with a drop rate of 28:12:28. This required breaking the helper out to raise the post-farming reserves to 100. (Though one might more likely just get 20, spark, then farm the rest.)
- With this many Mellows, the odds of getting to a full Reserve tank from low energy were very good, so an additional option was added to farm from as low as 19 energy. The player is recommended to damage down to 29 to activate healthbomb (eliminating the Nothing drop) in this scenario: the rate of small/large favors reaching enough total energy drops to still manage a full reserve tank (about 71% chance - and *slightly better odds* than doing so from 99 energy).

This room has forced me to think about the possibility of abusing healthbomb state. MapRando (for example) doesn't currently track this condition, and logic has no way to check for it. But in this scenario, a player might consider doing the following, to further increase the odds of completing the strat with a large amount of energy available:

1. Damage down to 29 energy + 0 reserves. Cause an enemy to spawn a drop, thereby activating the health bias flag.
2. Crystal Flash.
3. Damage back down for R-Mode entry, with a maximum reserve supply of 50, taking care to do so in a way that does not cause any more drops to spawn (as this will deactivate health bias).
4. Enter Flyway in R-Mode.
5. Farm the Mellows and wait to collect the many energy drops until you've farmed all but one. With 2/3 dropping large energy this would yield 160 energy, enough to bring the 50 at entry to 210: full e-tank and one full reserve, plus some more.