### PR TITLE
add spikesuits / bluesuits to spiky platforms room

### DIFF
--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -701,7 +701,7 @@
         {"lavaFrames": 40}
       ],
       "devNote": [
-        "Heatframes / spikehits assume two attemps"
+        "Heatframes / spikehits assume two attempts"
       ],
       "flashSuitChecked": true
     },


### PR DESCRIPTION
https://videos.maprando.com/video/9037 [rightdoor suitless]

https://videos.maprando.com/video/9036 [leftdoor suitless]

https://videos.maprando.com/video/9032 [double xmode bluesuit]

https://videos.maprando.com/video/9031 [spikexmode spikesuit]

maybe the heatframes leniancy can be written into a helper or something so the randomizer can take it away?