### PR TITLE
Parlor and Alcatraz R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -3152,7 +3152,7 @@
       "note": [
         "Farm Geemers and Skree for energy or else Crystal Flash.",
         "The bomb wall respawns so Crystal Flash can't be used to clear it.",
-        "Shinecharge and get interrupted by the Ripper by the save room door."
+        "Shinecharge and get interrupted by the Ripper by the save room door, or leave a Geemer alive."
       ]
     },
     {


### PR DESCRIPTION
Room notes:
- Enemies only exist when the planet is awake and not ablaze.
- Plenty of enemies to work with, there's enough Geemers to get a full reserve tank.
- The shinecharge runway can drop down the long shaft to get to the Ripper there for the spark interrupt.
- This was almost a "normal" R-Mode approach (strat on every door) until I saw the existence of multiple *notable* Alcatraz Escape strats. At that point, I made the decision to go obstacle method to avoid the possibility of hiding the Alcatraz Escape strat. If it turns out the stack of options can be simplified, reverting to door-strats can be revisited.