### PR TITLE
Bomb Torizo Room R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -164,7 +164,7 @@
           {"and": [
             "canBePatient",
             {"or": [
-              {"resourcesAtMost": [{"type": "ReserveEnergy", "count": 50}]},
+              {"resourceAtMost": [{"type": "ReserveEnergy", "count": 50}]},
               "canRiskPermanentLossOfAccess"
             ]}
           ]}


### PR DESCRIPTION
Yup, it's another boss room R-Mode strat, so hello again `canRiskPermanentLossOfAccess`.

Bomb Torizo's eggs are freely farmable, so it gets a full-refill strat. The shinecharge is 13 tiles and I imagine it will be a challenge to manage with Bomb Torizo stomping all over the place in the process.

Also, since there's rising acid (it stops at about 1 tile up) when you save the animals, there's a pause abuse blue suit strat there too.