### PR TITLE
West Ocean R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -3097,7 +3097,7 @@
                   "canBeExtremelyPatient",
                   {"and": [
                     {"enemyKill": {"enemies": [["Ripper 2 (green)"]], "excludedWeapons": ["Super"]}},
-                    {"resourceMissingAtMost": [{"type": "Super", "count": 1}]}
+                    {"resourceMissingAtMost": [{"type": "Super", "count": 0}]}
                   ]}
                 ]},
                 {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}


### PR DESCRIPTION
Room Notes:

Two different locations for R-Mode Spark:
- Upper location has easy access to a respawning Zeb. This requires a frozen Zeb lure to bring it above the path, freeze it again and get shinecharge.
- Lower location can use the underwater runway (requires Gravity) and a Skultera. Suit-less runway (left door) is too far away from the left Skultera to get there in time.
  - Only one Skultera can be farmed and its baseline rate of any energy is 60% (same as two Sidehoppers). 20-energy is extreme patience at 16% chance per attempt.
  - The "resourceMissingAtMost" on ReserveEnergy option in the lower section Spark is intended to be satisfied by routing through the Zeb farm in-room strat after entering from above (or getting above through an X-Ray Climb). It could also be satisified by a G-Mode Crystal Flash (see next item).
- Several existing Direct G-Mode (mostly X-Ray Climbs) and Direct G-Mode Morph strats were flagged as satisfying R-Mode entry. The Very Deep Stuck climbs were not flagged under the assumption they get the player stuck behind a (possibly locked) door shell, and thus don't allow access to the actual room.