### PR TITLE
Crab Maze R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -339,14 +339,9 @@
             ]}
           ]}
         ]},
-        {"or":[
-          {"resourceAvailable": [{"type": "Energy", "count": 121}]},
-          "canPauseAbuse",
-          "h_partialEnemyDamageReduction"
-        ]},
         "canWaterShineCharge",
         {"canShineCharge": {"usedTiles": 20, "openEnd": 0}},
-        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        {"autoReserveTrigger": {}},
         "canRModeSparkInterrupt"
       ],
       "flashSuitChecked": true,
@@ -577,14 +572,9 @@
             ]}
           ]}
         ]},
-        {"or":[
-          {"resourceAvailable": [{"type": "Energy", "count": 121}]},
-          "canPauseAbuse",
-          "h_partialEnemyDamageReduction"
-        ]},
         "canWaterShineCharge",
         {"canShineCharge": {"usedTiles": 20, "openEnd": 0}},
-        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        {"autoReserveTrigger": {}},
         "canRModeSparkInterrupt"
       ],
       "flashSuitChecked": true,


### PR DESCRIPTION
Room notes:

- Left door has the only runway in the room, and it's an air-into-water shinecharge.
- There are eight Scisers to farm and with their drop rate, just seven (all the ones on the left side) are good enough for a full tank. One Sciser is on the right side and needs Morph to access from the left.

Scisers hit for 120 against suitless Samus, so for the reserve management step, I chose to require either pause abuse (not a pause abuse spark interrupt), or at least a suit (reducing the damage to 60), so that the player has the ability to control the reserve amount for the spark interrupt.