### PR TITLE
Crateria Kihunter Room R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/east/Crateria Kihunter Room.json
+++ b/region/crateria/east/Crateria Kihunter Room.json
@@ -138,7 +138,10 @@
         "comeInWithRMode": {}
       },
       "requires": [
-        "canCameraManip",
+        {"or": [
+          "canCameraManip",
+          {"enemyDamage": {"enemy": "Sciser", "type": "contact", "hits": 1}}
+        ]},
         {"or": [
           "h_CrystalFlash",
           {"and": [
@@ -268,7 +271,10 @@
         "comeInWithRMode": {}
       },
       "requires": [
-        "canCameraManip",
+        {"or": [
+          "canCameraManip",
+          {"enemyDamage": {"enemy": "Sciser", "type": "contact", "hits": 1}}
+        ]},
         {"or": [
           "h_CrystalFlash",
           {"and": [


### PR DESCRIPTION
Room notes:

- Best farm is two scisers but requires `canCameraManip` when coming from the top doors to avoid a blind jump.
- The powerbomb option isn't suitable for R-Mode farming, since the scisers have high PB drop rate.
- The alternative is to risk a blind hit, which can be done under disable E-Tanks with a 2+3 tanks suitless, or 1+2 with any suit.
