### PR TITLE
East Ocean R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -155,6 +155,33 @@
   ],
   "strats": [
     {
+      "link": [1, 1],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        "Gravity",
+        "canDodgeWhileShooting",
+        {"or": [
+          "h_CrystalFlash",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        {"canShineCharge": { "usedTiles": 20, "steepUpTiles": 4, "steepDownTiles": 2, "startingDownTiles": 1, "openEnd": 0 }},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm the Choots for energy. Shinecharge on the left side and get interrupted by the Skultera."
+      ]
+    },
+    {
       "id": 1,
       "link": [1, 1],
       "name": "Leave with Runway",
@@ -691,6 +718,32 @@
       "name": "Base",
       "requires": [],
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        "Gravity",
+        {"or": [
+          "h_CrystalFlash",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        {"canShineCharge": { "usedTiles": 20, "steepUpTiles": 4, "steepDownTiles": 2, "startingDownTiles": 1, "openEnd": 0 }},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm the Choots for energy. Shinecharge on the left side and get interrupted by the Skultera."
+      ]
     },
     {
       "id": 68,


### PR DESCRIPTION
Room notes:

- All runways are underwater, so Gravity required. Gravity also covers most of the movement requirements needed. (Extra requirements may be needed to get back to right door but that is covered by existing logic.)
- Five Choots to farm, and the runway is under the scaffolding, with a handy nearby Skultera for the interrupt.
- Entering from the left has `canDodgeWhileShooting` due to the very nearby Choot.