### PR TITLE
Gauntlet Entrance R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/west/Gauntlet Entrance.json
+++ b/region/crateria/west/Gauntlet Entrance.json
@@ -123,7 +123,13 @@
           ]}
         ]},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-        "canRModeSparkInterrupt"
+        {"or": [
+          {"and": [
+            "canInsaneJump",
+            "canRModeSparkInterrupt"
+          ]},
+          "canRModePauseAbuseSparkInterrupt"
+        ]}
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -133,49 +139,6 @@
         "The two side wavers are local and easier to position for the R-Mode Spark Interrupt.",
         "It can help to pause abuse in the acid either to damage down or as part of the R-Mode Spark Interrupt.",
         "If grabbed by a Yapping Maw during a Shinespark, keep at least any button held to prevent a crash."
-      ]
-    },
-    {
-      "link": [1, 1],
-      "name": "R-Mode Spark Interrupt (Gain Blue Suit) - Yapping Maw Kill",
-      "entranceCondition": {
-        "comeInWithRMode": {}
-      },
-      "requires": [
-        "canTrickyJump",
-        "canDodgeWhileShooting",
-        {"or": [
-          "ScrewAttack",
-          "h_useMorphBombs",
-          {"and": [
-            "Morph",
-            {"or": [
-              {"ammo": {"type": "PowerBomb", "count": 3}},
-              {"and":[
-                "h_CrystalFlash",
-                {"ammo": {"type": "PowerBomb", "count": 2}}
-              ]}
-            ]}
-          ]}
-        ]},
-        {"ammo": {"type": "Super", "count": 4}},
-        {"or": [
-          {"resourceAvailable": [{"type": "ReserveEnergy", "count": 1}]},
-          {"and": [
-            "h_RModeCanRefillReserves",
-            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
-            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
-          ]}
-        ]},
-        {"canShineCharge": {"usedTiles": 21, "steepUpTiles": 2, "steepDownTiles": 2, "startingDownTiles": 1, "openEnd": 0}},
-        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-        "canRModeSparkInterrupt"
-      ],
-      "clearsObstacles": ["A"],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": [
-        "Clear the bomb barriers and farm four Yapping Maws. Keep one Waver alive to interrupt."
       ]
     },
     {
@@ -772,7 +735,13 @@
           ]}
         ]},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-        "canRModeSparkInterrupt"
+        {"or": [
+          {"and": [
+            "canInsaneJump",
+            "canRModeSparkInterrupt"
+          ]},
+          "canRModePauseAbuseSparkInterrupt"
+        ]}
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -782,49 +751,6 @@
         "The two side wavers are local and easier to position for the R-Mode Spark Interrupt.",
         "It can help to pause abuse in the acid either to damage down or as part of the R-Mode Spark Interrupt.",
         "If grabbed by a Yapping Maw during a Shinespark, keep at least any button held to prevent a crash."
-      ]
-    },
-    {
-      "link": [2, 1],
-      "name": "R-Mode Spark Interrupt (Gain Blue Suit) - Yapping Maw Kill",
-      "entranceCondition": {
-        "comeInWithRMode": {}
-      },
-      "requires": [
-        "canTrickyJump",
-        "canDodgeWhileShooting",
-        {"or": [
-          "ScrewAttack",
-          "h_useMorphBombs",
-          {"and": [
-            "Morph",
-            {"or": [
-              {"ammo": {"type": "PowerBomb", "count": 3}},
-              {"and":[
-                "h_CrystalFlash",
-                {"ammo": {"type": "PowerBomb", "count": 2}}
-              ]}
-            ]}
-          ]}
-        ]},
-        {"ammo": {"type": "Super", "count": 4}},
-        {"or": [
-          {"resourceAvailable": [{"type": "ReserveEnergy", "count": 1}]},
-          {"and": [
-            "h_RModeCanRefillReserves",
-            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
-            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
-          ]}
-        ]},
-        {"canShineCharge": {"usedTiles": 21, "steepUpTiles": 2, "steepDownTiles": 2, "startingDownTiles": 1, "openEnd": 0}},
-        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-        "canRModeSparkInterrupt"
-      ],
-      "clearsObstacles": ["A"],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": [
-        "Clear the bomb barriers and farm four Yapping Maws. Keep one Waver to interrupt."
       ]
     },
     {


### PR DESCRIPTION
Room Notes:

- Bomb barriers block access to the runway. Traversal strats for Screw Attack, Bombs, and Power Bombs (with the Crystal Flash option mixed in - the Crystal Flash should be used *last*) were incorporated with a slight adjustment to account for farming strategies.
- Specifically: options involving killing Yapping Maws was split into a separate strat, that in turn assumes you will just kill all four Yapping Maws. Doing so already provides likely enough energy without having to farm Wavers too.
- The runway may need to be double-checked for acid constraints.