### PR TITLE
Green Pirate Shaft R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -199,6 +199,7 @@
       "from": 1,
       "to": [
         {"id": 1},
+        {"id": 4},
         {"id": 8}
       ]
     },
@@ -350,6 +351,75 @@
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true
+    },
+    {
+      "link": [1, 4],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        "Morph",
+        "canUseIFrames",
+        {"or": [
+          "h_CrystalFlash",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"or": [
+              {"and": [
+                {"enemyKill": 
+                  {
+                    "enemies": [ ["Green Space Pirate (standing)", "Green Space Pirate (standing)"], ["Green Space Pirate (standing)", "Green Space Pirate (standing)"] ],
+                    "excludedWeapons": ["Missile"]
+                  }
+                },
+                {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+                {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+              ]},
+              {"and": [
+                {"enemyKill": 
+                  {
+                    "enemies": [ ["Beetom", "Beetom"] ],
+                    "excludedWeapons": ["PowerBomb"]
+                  }
+                },
+                {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 0}]},
+                {"partialRefill": {"type": "ReserveEnergy", "limit": 10}}
+              ]}
+            ]}
+          ]}
+        ]},
+        {"or": [
+          {"canShineCharge": {"usedTiles": 12, "openEnd": 0}},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 3},
+              {"doorUnlockedAtNode": 4}
+            ]},
+            {"canShineCharge": {"usedTiles": 13, "openEnd": 0}}
+          ]},
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"doorUnlockedAtNode": 4},
+            {"canShineCharge": {"usedTiles": 14, "openEnd": 0}}
+          ]}
+        ]},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"nodeId": 4, "types": ["ammo"], "requires": []}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm four of the pirates for drops. If you have full power bombs and can do so without using one",
+        "you can also kill two Beetoms for guaranteed two small energy drops.",
+        "Keep the bottom pirate alive: stun it with a Power Beam shot or i-frame past it.",
+        "Once you have the reserves, perform a 1-screen shortcharge between the bottom doors, then hop",
+        "back up to the bottom pirate's ledge and get shot at."
+      ]
     },
     {
       "id": 5,
@@ -606,6 +676,59 @@
       "blueSuitChecked": true
     },
     {
+      "link": [2, 4],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        "canUseIFrames",
+        {"or": [
+          "h_CrystalFlash",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"enemyKill": 
+              {
+                "enemies": [ ["Green Space Pirate (standing)", "Green Space Pirate (standing)"], ["Green Space Pirate (standing)", "Green Space Pirate (standing)"] ],
+                "excludedWeapons": ["Missile"]
+              }
+            },
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        {"or": [
+          {"canShineCharge": {"usedTiles": 12, "openEnd": 0}},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 3},
+              {"doorUnlockedAtNode": 4}
+            ]},
+            {"canShineCharge": {"usedTiles": 13, "openEnd": 0}}
+          ]},
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"doorUnlockedAtNode": 4},
+            {"canShineCharge": {"usedTiles": 14, "openEnd": 0}}
+          ]}
+        ]},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"nodeId": 4, "types": ["ammo"], "requires": []}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm four of the pirates for drops, leaving the bottom pirate alive.",
+        "Stun it with a Power Beam shot or i-frame past it.",
+        "Perform a 1-screen shortcharge between the bottom doors, then hop",
+        "back up to the bottom pirate's ledge and get shot at."
+      ]
+    },
+    {
       "id": 83,
       "link": [2, 4],
       "name": "Blue Suit",
@@ -856,6 +979,61 @@
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true
+    },
+    {
+      "link": [3, 4],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        "canUseIFrames",
+        {"or": [
+          "h_CrystalFlash",
+          {"and": [
+            {"enemyDamage": {"enemy": "Green Space Pirate (standing)", "type": "contact", "hits": 1}},
+            "h_RModeCanRefillReserves",
+            {"enemyKill": 
+              {
+                "enemies": [ ["Green Space Pirate (standing)", "Green Space Pirate (standing)"], ["Green Space Pirate (standing)", "Green Space Pirate (standing)"] ],
+                "excludedWeapons": ["Missile"]
+              }
+            },
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        {"or": [
+          {"canShineCharge": {"usedTiles": 12, "openEnd": 0}},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 3},
+              {"doorUnlockedAtNode": 4}
+            ]},
+            {"canShineCharge": {"usedTiles": 13, "openEnd": 0}}
+          ]},
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"doorUnlockedAtNode": 4},
+            {"canShineCharge": {"usedTiles": 14, "openEnd": 0}}
+          ]}
+        ]},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"nodeId": 4, "types": ["ammo"], "requires": []}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Stun the bottom pirate with a Power Beam shot, or i-frame past it.",
+        "Farm the four pirates above for drops, then get back through the bottom pirate.",
+        "Stun it with a Power Beam shot or i-frame past it a second time.",
+        "Perform a 1-screen shortcharge between the bottom doors, then hop",
+        "back up to the bottom pirate's ledge and get shot at."
+      ]
     },
     {
       "id": 25,
@@ -1410,6 +1588,61 @@
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true
+    },
+    {
+      "link": [4, 4],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        "canUseIFrames",
+        {"or": [
+          "h_CrystalFlash",
+          {"and": [
+            {"enemyDamage": {"enemy": "Green Space Pirate (standing)", "type": "contact", "hits": 1}},
+            "h_RModeCanRefillReserves",
+            {"enemyKill": 
+              {
+                "enemies": [ ["Green Space Pirate (standing)", "Green Space Pirate (standing)"], ["Green Space Pirate (standing)", "Green Space Pirate (standing)"] ],
+                "excludedWeapons": ["Missile"]
+              }
+            },
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        {"or": [
+          {"canShineCharge": {"usedTiles": 12, "openEnd": 0}},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 3},
+              {"doorUnlockedAtNode": 4}
+            ]},
+            {"canShineCharge": {"usedTiles": 13, "openEnd": 0}}
+          ]},
+          {"and": [
+            {"doorUnlockedAtNode": 3},
+            {"doorUnlockedAtNode": 4},
+            {"canShineCharge": {"usedTiles": 14, "openEnd": 0}}
+          ]}
+        ]},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "unlocksDoors": [
+        {"nodeId": 3, "types": ["ammo"], "requires": []},
+        {"nodeId": 4, "types": ["ammo"], "requires": []}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Stun the bottom pirate with a Power Beam shot, or i-frame past it.",
+        "Farm the four pirates above for drops, then get back through the bottom pirate.",
+        "Stun it with a Power Beam shot or i-frame past it a second time.",
+        "Perform a 1-screen shortcharge between the bottom doors, then hop",
+        "back up to the bottom pirate's ledge and get shot at."
+      ]
     },
     {
       "id": 49,


### PR DESCRIPTION
Room Notes:
- Four pirates and two Beetoms, but both have non-trivial kill requirements. Missiles were excluded from the pirates and Power Bombs from the Beetoms. Beetom farm guarantees 10 energy, Pirate farm has a good chance of getting 20.
  - Possible combined farm for 30 energy? Would need to use bombs for Beetom kill, use a Super, be willing to sacrifice one Pirate for a Missile drop, or something like Screw Attack.
- Due to Power Bomb block, Beetom farm is only available when coming from the top door.
- One-tile runway at the bottom between doors 3 and 4.