### PR TITLE
Lower Mushrooms R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/west/Lower Mushrooms.json
+++ b/region/crateria/west/Lower Mushrooms.json
@@ -69,6 +69,42 @@
   ],
   "strats": [
     {
+      "link": [1, 1],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        {"or": [
+          "h_CrystalFlash",
+          {"and": [
+            {"or": [
+              {"and": [
+                {"resourceAvailable": [{"type": "RegularEnergy", "count": 4}]},
+                {"disableEquipment": "ETank"},
+                {"partialRefill": {"type": "ReserveEnergy", "limit": 200}}
+              ]},
+              {"and": [
+                {"resourceMissingAtMost": [{"type": "RegularEnergy", "count": 0}]},
+                "canRiskPermanentLossOfAccess",
+                {"partialRefill": {"type": "ReserveEnergy", "limit": 200}}
+              ]}
+            ]},
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]}
+          ]}
+        ]},
+        "h_shinechargeMaxRunway",
+        {"autoReserveTrigger": {}},
+        "canRModeSparkInterrupt"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "The Kagos can provide a lot of energy. Run across the room and then jump into the",
+        "Gray Geemer's path to interrupt."
+      ]
+    },
+    {
       "id": 1,
       "link": [1, 1],
       "name": "Leave with Runway",
@@ -200,6 +236,42 @@
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        {"or": [
+          "h_CrystalFlash",
+          {"and": [
+            {"or": [
+              {"and": [
+                {"resourceAvailable": [{"type": "RegularEnergy", "count": 4}]},
+                {"disableEquipment": "ETank"},
+                {"partialRefill": {"type": "ReserveEnergy", "limit": 200}}
+              ]},
+              {"and": [
+                {"resourceMissingAtMost": [{"type": "RegularEnergy", "count": 0}]},
+                "canRiskPermanentLossOfAccess",
+                {"partialRefill": {"type": "ReserveEnergy", "limit": 200}}
+              ]}
+            ]},
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]}
+          ]}
+        ]},
+        "h_shinechargeMaxRunway",
+        {"autoReserveTrigger": {}},
+        "canRModeSparkInterrupt"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "The Kagos can provide a lot of energy. Run across the room and then jump into the",
+        "Gray Geemer's path to interrupt."
+      ]
     },
     {
       "id": 8,


### PR DESCRIPTION
Room notes:

- Two Kagos = two full reserve tanks, even from low energy.
- The Gray Geemers aren't worth farming, and you need one to interrupt anyway.