### PR TITLE
Terminator Room R-Mode Spark Interrupt

### DIFF
--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -107,7 +107,7 @@
           "h_CrystalFlash",
           {"and": [
             "h_RModeCanRefillReserves",
-            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 10}]},
             {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
           ]}
         ]},
@@ -115,7 +115,6 @@
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt"
       ],
-      "collectsItems": [3],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -374,7 +373,7 @@
           "h_CrystalFlash",
           {"and": [
             "h_RModeCanRefillReserves",
-            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 10}]},
             {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
           ]}
         ]},
@@ -382,7 +381,6 @@
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt"
       ],
-      "collectsItems": [3],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [


### PR DESCRIPTION
Room notes:

- Perhaps the simplest room in West Crateria: just six Geemers and a full-length runway. Wavers make for better interrupting than farming.

Oh also there's an item in the way, so it gets collected.