### PR TITLE
Wasteland R-Mode Spark Interrupt

### DIFF
--- a/region/lowernorfair/east/Wasteland.json
+++ b/region/lowernorfair/east/Wasteland.json
@@ -674,46 +674,31 @@
       "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
       "requires": [
         {"obstaclesCleared": ["R-Mode"]},
-        {"obstaclesNotCleared": ["C"]},
-        "h_heatProof",
+        {"obstaclesCleared": ["C", "D"]},
         {"or": [
+          "h_heatedCrystalFlashForReserveEnergy",
           {"and": [
-            "h_heatedCrystalFlash",
-            {"obstaclesCleared": ["D"]}
-          ]},
-          {"and": [
-            {"obstaclesNotCleared": ["D"]},
             "h_RModeCanRefillReserves",
             {"or": [
+              {"partialRefill": {"type": "ReserveEnergy", "limit": 5}},
               {"and": [
-                "canBePatient",
-                {"partialRefill": {"type": "ReserveEnergy", "limit": 20}},
-                {"enemyKill": {"enemies": [["Dessgeega"], ["Dessgeega", "Dessgeega", "Dessgeega"]], "excludedWeapons": ["Missile", "PseudoScrew"]}}
-              ]},
-              {"and": [
-                {"or": [
-                  {"partialRefill": {"type": "ReserveEnergy", "limit": 5}},
-                  {"and": [
-                    "canBeVeryPatient",
-                    {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
-                  ]}
-                ]},
-                {"enemyKill": {"enemies": [["Dessgeega"], ["Dessgeega", "Dessgeega", "Dessgeega"]], "excludedWeapons": ["Charge", "Bombs", "PseudoScrew"]}}
+                "canBeVeryPatient",
+                {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
               ]}
             ]}
           ]}
         ]},
+        {"heatFrames": 90},
         {"canShineCharge": {"usedTiles": 30, "openEnd": 0}},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt"
       ],
-      "clearsObstacles": ["C", "D"],
       "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Farm the three left Desgeegas, their energy rate is poor. Keep the one above the power bomb",
-        "blocks alive to use for interrupt. Or kill all four and use heat with pause abuse to interrupt."
+        "Farm the Dessgeegas, their energy rate is poor. Keep one Dessgeega alive to use for interrupt.",
+        "Or kill all four and use heat with pause abuse to interrupt."
       ],
       "devNote": [
         "FIXME: Evaluate unprotected heat option with disable E-Tank + CF for full reserves, once heated",


### PR DESCRIPTION
The first of many heated rooms!

And because the pitiful 20 energy you can get from Disgeegas is nowhere near enough to escape the room, it requires `h_heatProof`.

Possibility to evaluate:
Disable E-Tanks + CF to force full reserves -> Will this be enough to escape heated?