### PR TITLE
Ridley Tank Room R-Mode Spark Interrupt

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -1666,7 +1666,7 @@
           ]
         },
         {
-          "name": "h_HeatedCrystalFlashForReserveEnergy",
+          "name": "h_heatedCrystalFlashForReserveEnergy",
           "requires": [
             {"or": [
               {"and": [

--- a/region/lowernorfair/east/Ridley Tank Room.json
+++ b/region/lowernorfair/east/Ridley Tank Room.json
@@ -74,7 +74,7 @@
       },
       "requires": [
         "h_heatProof",
-        "h_HeatedCrystalFlashForReserveEnergy",
+        "h_heatedCrystalFlashForReserveEnergy",
         {"disableEquipment": "Varia"},
         {"disableEquipment": "Gravity"},
         {"canShineCharge": {"usedTiles": 12, "openEnd": 0}},

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -334,7 +334,7 @@ def check_shinecharge_req(req):
 def check_heat_req(req):
     if isinstance(req, str):
         if req in ["h_heatProof", "h_heatedCrystalFlash", "h_heatedLavaCrystalFlash", "h_heatedAcidCrystalFlash",
-                   "h_HeatedCrystalFlashForReserveEnergy",
+                   "h_heatedCrystalFlashForReserveEnergy",
                    "h_heatedCrystalSpark", "h_LowerNorfairElevatorDownwardFrames",
                    "h_LowerNorfairElevatorUpwardFrames", "h_MainHallElevatorFrames", "h_heatedGreenGateGlitch",
                    "h_heatedDirectGModeLeaveSameDoor", "h_heatedIndirectGModeOpenSameDoor",


### PR DESCRIPTION
It had to be done.

This is one of the hardest, if not ***the*** hardest, shinecharge in the game.

With the lack of any other damage source than heat, I decided to use this opportunity to create a new helper, `h_RModeHeatedCrystalFlashForReserves`. This is intended to be used in heated rooms where there is a need to try to maximize available Reserve Energy to support heat-runs following R-Mode standup, which requires special attention once the player has more than 9 E-Tanks.

Heated rooms with Crystal Flash paths will eventually want to use this helper in order to correctly maximize available energy after the spark interrupt.

