### PR TITLE
Blue Brin E-Tank - Rename G-mode strat

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -1423,7 +1423,7 @@
     {
       "id": 70,
       "link": [5, 2],
-      "name": "G-Mode Morph Shoot the Ceiling Block Item",
+      "name": "G-Mode Shoot the Ceiling Block Item",
       "requires": [
         "canGMode",
         "Morph",


### PR DESCRIPTION
Sam noticed this strat probably shouldnt say "G-Mode Morph", that is used in strats where morph or artificial morph work, but this one requires real morph.