### PR TITLE
bug fix r-mode standup clip wrecked ship super room

### DIFF
--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -485,7 +485,7 @@
         ]},
         {"cycleFrames": 480}
       ],
-      "clearsObstacles": ["A"],
+      "resetsObstacles": ["A"],
       "farmCycleDrops": [{"enemy": "Custom Covern (Bull)", "count": 2}],
       "flashSuitChecked": true,
       "note": "There are additional requirements for killing the Bull enemy who appears when Phantoon is defeated.",
@@ -726,6 +726,7 @@
       "requires": [
         {"notable": "R-Mode Standup Clip"},
         {"obstaclesCleared": ["A"]},
+        "canRModeStandupClip",
         "canCeilingClip",
         "canBePatient",
         {"or": [


### PR DESCRIPTION
covern farm should reset rmode obstable not clear it, or a coven farm in logic can clear the rmode flag.

https://dev.maprando.com/seed/bMTyqQJTz (step 8) expects rmode standup clip without x-ray or reserve.

also tagged the standup clip with the canrmodestandupclip tech.