### PR TITLE
Plowerhouse R-Mode Spark Interrupt

### DIFF
--- a/region/lowernorfair/east/Plowerhouse Room.json
+++ b/region/lowernorfair/east/Plowerhouse Room.json
@@ -428,7 +428,8 @@
         {"heatFrames": 390},
         {"acidFrames": 133},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-        "canRModeSparkInterrupt"
+        "canRModeSparkInterrupt",
+        {"heatFrames": 80}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -598,7 +599,8 @@
         {"heatFrames": 390},
         {"acidFrames": 133},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-        "canRModeSparkInterrupt"
+        "canRModeSparkInterrupt",
+        {"heatFrames": 80}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,


### PR DESCRIPTION
Room notes:
- The heated shinecharge is possible with 2+2 tanks (197 energy before lenience).
- Two Holtzes mandatory to kill upon entry, whichever side you come from.
- Holtzes guarantee large energy if full on ammo.
- Zebbo farm only works with heatproof.
- Farming Holtzes in heat seems unlikely to be able to get ahead of the heat damage. Possible candidate to evaluate is a Space Jump + Screw Attack sweep, but the existing strat models it at 340 heatFrames (out of the 480 that can be afforded) and this likely is not stopping to pick up drops.

As such, for now farming path requires heatproof and assumes you will top off at a Zebbo pipe (although Holtz farming may be faster in practice, farming the remaining four is free with blue suit).