### PR TITLE
add tricky upper gmode setup to mickey mouse room.

### DIFF
--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -1965,6 +1965,7 @@
               "Bombs",
               "ScrewAttack",
               {"ammo": { "type": "PowerBomb", "count": 1}},
+              {"obstaclesCleared": ["A"]},
               {"obstaclesCleared": ["B"]}
             ]}
           ]}


### PR DESCRIPTION
sorry for the re-do.. had to delete the fork.

Where were we on this? Loptr mentioned if you don't get the viola through the crumbles on the first opportunity it goes into a pattern where it will still go through but never go through the top shot block..  I tried letting it cycle in the clip area and it wouldnt go through the shot blocks.

I think Osse had some success with bombs instead of screw attack? (can add an or for those if so)

https://videos.maprando.com/video/7611
https://videos.maprando.com/video/7610