### PR TITLE
Mickey Mouse Room R-Mode Spark Interrupt

### DIFF
--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -1169,52 +1169,12 @@
                 {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "explicitWeapons": ["PowerBomb"]}},
                 {"heatFrames": 500}
               ]},
-              {"and": ["Ice", "Wave", "Spazer", {"heatFrames": 750}]},
-              {"and": [
-                {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "excludedWeapons": ["Bombs", "PseudoScrew", "PowerBomb"]}},
-                {"heatFrames": 3000}
-              ]}
+              {"and": ["Ice", "Wave", "Spazer", {"heatFrames": 750}]}
             ]}
           ]},
           {"and": [
             "h_heatProof",
-            {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "excludedWeapons": ["Bombs", "PseudoScrew", "PowerBomb"]}}
-          ]}
-        ]},
-        {"or": [
-          {"and": ["Wave", "Plasma", {"heatFrames": 450}]},
-          {"and": ["Plasma", {"heatFrames": 750}]},
-          {"and": ["Ice", "Wave", "Spazer", {"heatFrames": 750}]},
-          {"and": ["Wave", {"heatFrames": 1350}]}
-        ]},
-        {"or": [
-          {"and": [
-            {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "excludedWeapons": ["Bombs", "PseudoScrew"]}},
-            {"heatFrames": 3000}
-          ]},
-          {"and": [
-            "Plasma",
-            {"heatFrames": 250}
-          ]},
-          {"and": [
-            "Ice", "Wave", "Spazer",
-            {"heatFrames": 600}
-          ]},
-          {"and": [
-            "ScrewAttack",
-            {"heatFrames": 200}
-          ]},
-          {"and": [
-            {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "explicitWeapons": ["Missile"]}},
-            {"heatFrames": 670}
-          ]},
-          {"and": [
-            {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "explicitWeapons": ["Super"]}},
-            {"heatFrames": 400}
-          ]},
-          {"and": [
-            {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "explicitWeapons": ["PowerBomb"]}},
-            {"heatFrames": 350}
+            {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "excludedWeapons": ["Bombs", "PseudoScrew"]}}
           ]}
         ]},
         "h_heatedCrystalFlashForReserveEnergy",
@@ -1336,52 +1296,12 @@
                 {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "explicitWeapons": ["PowerBomb"]}},
                 {"heatFrames": 500}
               ]},
-              {"and": ["Ice", "Wave", "Spazer", {"heatFrames": 750}]},
-              {"and": [
-                {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "excludedWeapons": ["Bombs", "PseudoScrew", "PowerBomb"]}},
-                {"heatFrames": 3000}
-              ]}
+              {"and": ["Ice", "Wave", "Spazer", {"heatFrames": 750}]}
             ]}
           ]},
           {"and": [
             "h_heatProof",
             {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "excludedWeapons": ["Bombs", "PseudoScrew", "PowerBomb"]}}
-          ]}
-        ]},
-        {"or": [
-          {"and": ["Wave", "Plasma", {"heatFrames": 450}]},
-          {"and": ["Plasma", {"heatFrames": 750}]},
-          {"and": ["Ice", "Wave", "Spazer", {"heatFrames": 750}]},
-          {"and": ["Wave", {"heatFrames": 1350}]}
-        ]},
-        {"or": [
-          {"and": [
-            {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "excludedWeapons": ["Bombs", "PseudoScrew"]}},
-            {"heatFrames": 3000}
-          ]},
-          {"and": [
-            "Plasma",
-            {"heatFrames": 250}
-          ]},
-          {"and": [
-            "Ice", "Wave", "Spazer",
-            {"heatFrames": 600}
-          ]},
-          {"and": [
-            "ScrewAttack",
-            {"heatFrames": 200}
-          ]},
-          {"and": [
-            {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "explicitWeapons": ["Missile"]}},
-            {"heatFrames": 670}
-          ]},
-          {"and": [
-            {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "explicitWeapons": ["Super"]}},
-            {"heatFrames": 400}
-          ]},
-          {"and": [
-            {"enemyKill": {"enemies": [["Dessgeega", "Dessgeega"]], "explicitWeapons": ["PowerBomb"]}},
-            {"heatFrames": 350}
           ]}
         ]},
         {"or": [


### PR DESCRIPTION
Room Notes:

From the bottom left door:
- Screw Attack is the only way to avoid getting hit by a Multiviola by entry.
- Once you clear the first wave of Dessgeegas and the Multiviolas, you have a clear shot for blue speed for your choice of: run up to the last Dessgeegas and use them to interrupt, run through to shinecharge and hop up to the Multiviola box, or shinecharge heat interrupt.

From the top right door:
- Four different strats depending on when - or even if - you use a Crystal Flash. CF above the bomb blocks, CF while killing the Multiviolas, or CF after the Dessgeegas, and then no CF at all.
- `canBePatient` is mandated on the non-CF route due to the crumble block one-way preventing a direct reset.