### PR TITLE
Rename to canComplexRModeCrystalFlashInterrupt

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -1656,9 +1656,9 @@
           ]
         },
         {
-          "name": "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+          "name": "h_artificialMorphComplexRModeCrystalFlashInterrupt",
           "requires": [
-            {"tech": "canTrickyRModeCrystalFlashInterrupt"},
+            {"tech": "canComplexRModeCrystalFlashInterrupt"},
             "h_artificialMorphRModeCrystalFlashInterrupt"
           ]
         },

--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -295,7 +295,7 @@
           ]},
           {"and": [
             {"ammo": {"type": "Missile", "count": 2}},
-            "canTrickyRModeCrystalFlashInterrupt"
+            "canComplexRModeCrystalFlashInterrupt"
           ]}
         ]}
       ],
@@ -330,7 +330,7 @@
           ]},
           {"and": [
             {"ammo": {"type": "Missile", "count": 2}},
-            "h_artificialMorphTrickyRModeCrystalFlashInterrupt"
+            "h_artificialMorphComplexRModeCrystalFlashInterrupt"
           ]}
         ]},
         {"or": [
@@ -930,7 +930,7 @@
           ]},
           {"and": [
             {"ammo": {"type": "Missile", "count": 2}},
-            "canTrickyRModeCrystalFlashInterrupt"
+            "canComplexRModeCrystalFlashInterrupt"
           ]}
         ]}
       ],
@@ -966,7 +966,7 @@
           ]},
           {"and": [
             {"ammo": {"type": "Missile", "count": 2}},
-            "h_artificialMorphTrickyRModeCrystalFlashInterrupt"
+            "h_artificialMorphComplexRModeCrystalFlashInterrupt"
           ]}
         ]}
       ],

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -419,7 +419,7 @@
           "h_artificialMorphBombThings",
           "h_artificialMorphSpringBall"
         ]},
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -1162,7 +1162,7 @@
       "name": "R-Mode Crystal Flash Interrupt",
       "requires": [
         {"obstaclesCleared": ["R-Mode"]},
-        "canTrickyRModeCrystalFlashInterrupt",
+        "canComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -1207,7 +1207,7 @@
           ]},
           "h_artificialMorphSpringBall"
         ]},
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -1543,7 +1543,7 @@
         }
       },
       "requires": [
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -2323,7 +2323,7 @@
         }
       },
       "requires": [
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [

--- a/region/maridia/inner-yellow/The Beach.json
+++ b/region/maridia/inner-yellow/The Beach.json
@@ -418,7 +418,7 @@
         "comeInWithRMode": {}
       },
       "requires": [
-        "canTrickyRModeCrystalFlashInterrupt",
+        "canComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -455,7 +455,7 @@
         }
       },
       "requires": [
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -859,7 +859,7 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        "canTrickyRModeCrystalFlashInterrupt",
+        "canComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -897,7 +897,7 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -466,7 +466,7 @@
       "name": "R-Mode Crystal Flash Interrupt (Skultera)",
       "requires": [
         {"obstaclesCleared": ["R-Mode"]},
-        "canTrickyRModeCrystalFlashInterrupt",
+        "canComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -506,7 +506,7 @@
         }
       },
       "requires": [
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -2602,7 +2602,7 @@
             ]}
           ]}
         ]},
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -2922,7 +2922,7 @@
         "comesThroughToilet": "no"
       },
       "requires": [
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -4109,7 +4109,7 @@
         {"obstaclesCleared": ["R-Mode"]},
         "canCameraManip",
         "canMoonwalk",
-        "canTrickyRModeCrystalFlashInterrupt",
+        "canComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -4156,7 +4156,7 @@
       },
       "requires": [
         "canCameraManip",
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"ammo": {"type": "PowerBomb", "count": 3}},
@@ -4299,7 +4299,7 @@
         {"obstaclesCleared": ["R-Mode"]},
         "canCameraManip",
         "canMoonwalk",
-        "canTrickyRModeCrystalFlashInterrupt",
+        "canComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"or": [
@@ -4341,7 +4341,7 @@
       },
       "requires": [
         "canCameraManip",
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"ammo": {"type": "PowerBomb", "count": 3}},
@@ -5499,7 +5499,7 @@
           "h_artificialMorphDoubleSpringBallJump"
         ]},
         "canCameraManip",
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 10}},
         {"ammo": {"type": "Super", "count": 10}},
         {"ammo": {"type": "PowerBomb", "count": 3}},

--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -550,7 +550,7 @@
           ]},
           {"and": [
             {"ammo": {"type": "Missile", "count": 2}},
-            "canTrickyRModeCrystalFlashInterrupt"
+            "canComplexRModeCrystalFlashInterrupt"
           ]}
         ]}
       ],
@@ -591,7 +591,7 @@
           ]},
           {"and": [
             {"ammo": {"type": "Missile", "count": 2}},
-            "canTrickyRModeCrystalFlashInterrupt"
+            "canComplexRModeCrystalFlashInterrupt"
           ]}
         ]}
       ],

--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -223,7 +223,7 @@
         "comeInWithRMode": {}
       },
       "requires": [
-        "canTrickyRModeCrystalFlashInterrupt",
+        "canComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 2}}
       ],
       "flashSuitChecked": true,
@@ -249,7 +249,7 @@
         }
       },
       "requires": [
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 2}}
       ],
       "flashSuitChecked": true,
@@ -1013,7 +1013,7 @@
         "comeInWithRMode": {}
       },
       "requires": [
-        "canTrickyRModeCrystalFlashInterrupt",
+        "canComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 2}}
       ],
       "flashSuitChecked": true,
@@ -1039,7 +1039,7 @@
         }
       },
       "requires": [
-        "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+        "h_artificialMorphComplexRModeCrystalFlashInterrupt",
         {"ammo": {"type": "Missile", "count": 2}}
       ],
       "flashSuitChecked": true,

--- a/tech.json
+++ b/tech.json
@@ -2434,7 +2434,7 @@
               "extensionTechs": [
                 {
                   "id": 226,
-                  "name": "canTrickyRModeCrystalFlashInterrupt",
+                  "name": "canComplexRModeCrystalFlashInterrupt",
                   "techRequires": [
                     "canRModeCrystalFlashInterrupt"
                   ],


### PR DESCRIPTION
This is to parallel 
`canCarryFlashSuit` -> `canComplexCarryFlashSuit` -> `canTrickyCarryFlashSuit`
`canGMode` -> `canComplexGMode` -> `canTrickyGMode`

I was originally not thinking there would be a need for an insane variant `canTrickyRModeCrystalFlashInterrupt`, but I'm starting to think it might be worth making.