### PR TITLE
add 10pb cf to spongebath room

### DIFF
--- a/region/wreckedship/main/Sponge Bath.json
+++ b/region/wreckedship/main/Sponge Bath.json
@@ -242,15 +242,19 @@
       "name": "10 Power Bomb Crystal Flash",
       "requires": [
         "f_DefeatedPhantoon",
-        {"resourceAvailable": [{"type": "RegularEnergy", "count": 50}]},
-          {"or": [
-            "ScrewAttack",
-            "canPseudoScrew",
-            "Plasma",
-            "Grapple",
-            {"resetRoom": {"nodes": [2]}},
-            {"ammo": {"type": "Missile", "count": 3}},
-            {"ammo": {"type": "Super", "count": 3}}
+        {"or":[
+          {"resourceAvailable": [{"type": "RegularEnergy", "count": 50}]},
+           {"and": [
+              {"resetRoom": {"nodes": [2]}},
+              {"or": [
+                "ScrewAttack",
+                "canPseudoScrew",
+                "Plasma",
+                "Grapple",
+                {"ammo": {"type": "Missile", "count": 3}},
+                {"ammo": {"type": "Super", "count": 3}}
+              ]}
+            ]}
         ]},
         "h_10PowerBombCrystalFlash"
       ],
@@ -1337,15 +1341,19 @@
       "name": "10 Power Bomb Crystal Flash",
       "requires": [
         "f_DefeatedPhantoon",
-        {"resourceAvailable": [{"type": "RegularEnergy", "count": 50}]},
-        {"or": [
-          "ScrewAttack",
-          "canPseudoScrew",
-          "Plasma",
-          "Grapple",
-          {"resetRoom": {"nodes": [2]}},
-          {"ammo": {"type": "Missile", "count": 3}},
-          {"ammo": {"type": "Super", "count": 3}}
+        {"or":[
+          {"resourceAvailable": [{"type": "RegularEnergy", "count": 50}]},
+           {"and": [
+              {"resetRoom": {"nodes": [2]}},
+              {"or": [
+                "ScrewAttack",
+                "canPseudoScrew",
+                "Plasma",
+                "Grapple",
+                {"ammo": {"type": "Missile", "count": 3}},
+                {"ammo": {"type": "Super", "count": 3}}
+              ]}
+            ]}
         ]},
         "h_10PowerBombCrystalFlash"
       ],


### PR DESCRIPTION
this one is really easy and doesnt require tanking any damage.. let the bull get close to samus, shoot it once and morph / lay pb... they have 100% drop rate for pbs so as long as Samus isn't in healthbomb range its always a pb..

https://videos.maprando.com/video/9280
https://videos.maprando.com/video/9277

strat is a bit basic, maybe some options could be added for farming if healthbomb flag is set.