### PR TITLE
Main Hall R-Mode Spark Interrupt

### DIFF
--- a/region/lowernorfair/east/Main Hall.json
+++ b/region/lowernorfair/east/Main Hall.json
@@ -139,25 +139,7 @@
         "comeInWithRMode": {}
       },
       "requires": [
-        "h_navigateHeatRooms",
         {"or": [
-          {"and": [
-            {"or": [
-              {"enemyDamage": {"enemy": "Dragon", "type": "fireball", "hits": 3}},
-              {"and": ["Ice", "Wave"]},
-              {"enemyKill": {"enemies": [["Dragon", "Dragon"]], "explicitWeapons": ["Wave+Plasma"]}}
-            ]},
-            {"heatFrames": 900}
-          ]},
-          {"and": [
-            "canCarefulJump",
-            {"or": [
-              {"enemyDamage": {"enemy": "Dragon", "type": "fireball", "hits": 2}},
-              "Ice",
-              {"enemyKill": {"enemies": [["Dragon", "Dragon"]], "explicitWeapons": ["Super", "Plasma"]}}
-            ]},
-            {"heatFrames": 700}
-          ]},
           {"and": [
             "canTrickyJump",
             {"heatFrames": 570}
@@ -198,7 +180,7 @@
         {"canShineCharge": {"usedTiles": 24, "openEnd": 1}},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt",
-        {"heatFrames": 240}
+        {"heatFrames": 80}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -499,15 +481,14 @@
         {"canShineCharge": {"usedTiles": 24, "openEnd": 1}},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt",
-        {"heatFrames": 240}
+        {"heatFrames": 80}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Cross to the center platform to get to the shinecharge runway. Any Dragons you kill",
-        "along the way, you can try to collect their drops with Grapple Beam instead of risking",
-        "the acid. Keep one Dragon to the left of the elevator to use their fireball for interrupt.",
-        "Or you can also use a heat interrupt."
+        "Cross to the center platform to get to the shinecharge runway. Of the two Dragons left",
+        "of the elevator, farm the left one and to use the right one's fireball to interrupt while",
+        "at the leftmost side of the of the center runway. Or you can also use a heat interrupt."
       ]
     },
     {


### PR DESCRIPTION
Room notes:

- Left door entry can potentially farm five Dragons. For coming in from the right, you're only expected to farm what Dragons can be reached without having to deal with Hibachis.
- Grapple Beam is required to farm Dragons for collecting the drop without acid dips.