### PR TITLE
Lower Norfair Spring Ball Maze R-Mode Spark Interrupt

### DIFF
--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze.json
@@ -629,33 +629,16 @@
         {"heatFrames": 100},
         "h_heatedCrystalFlashForReserveEnergy",
         "canCeilingClip",
-        {"or": [
-          "canTrivialMidAirMorph",
-          {"and": ["h_useSpringBall", "HiJump"]}
-        ]},
+        "canTrivialMidAirMorph",
         {"heatFrames": 240},
         {"or": [
           {"enemyKill": {"enemies": [["Alcoon"]], "explicitWeapons": ["Missile", "Super", "Charge+Plasma", "Wave+Plasma"]}},
-          {"and": [
-            {"enemyKill": {"enemies": [["Alcoon"]], "explicitWeapons": ["Wave", "Ice+Spazer", "Plasma", "ScrewAttack", "PseudoScrew"]}},
-            {"heatFrames": 180}
-          ]},
-          {"and": [
-            {"heatFrames": 200},
-            {"or": [
-              "canDodgeWhileShooting",
-              "Morph"
-            ]}
-          ]},
-          {"and": [
-            {"heatFrames": 160},
-            {"enemyDamage": {"enemy": "Alcoon", "type": "fireball", "hits": 1}}
-          ]}
+          {"heatFrames": 200}
         ]},
         {"canShineCharge": {"usedTiles": 27, "gentleUpTiles": 2, "openEnd": 0}},
         {"or": [
           "canDownBack",
-          "canCarefulJump"
+          "canTrickyJump"
         ]},
         {"heatFrames": 120},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
@@ -1230,13 +1213,15 @@
           {"and": ["canSpringBallBombJump", {"heatFrames": 60}]},
           {"and": [
             "canIBJ",
+            "canBombHorizontally",
+            "canJumpIntoIBJ",
+            {"heatFrames": 110},
             {"or": [
-              {"and": ["canBombHorizontally", {"heatFrames": 660}]},
-              {"and": ["canJumpIntoIBJ", "canDoubleBombJump", {"heatFrames": 110}]},
-              {"and": ["canJumpIntoIBJ", {"heatFrames": 300}]}
+              "canDoubleBombJump",
+              {"heatFrames": 190}
             ]}
           ]},
-          {"and": ["canTrickyDashJump", {"heatFrames": 20}]},
+          {"and": ["canTrickyDashJump", "canInsaneJump", {"heatFrames": 20}]},
           {"and": ["canUseFrozenEnemies", "canInsaneJump", {"heatFrames": 150}]}
         ]},
         {"or": [
@@ -1246,20 +1231,10 @@
             {"heatFrames": 120}
           ]},
           {"and": [
-            {"enemyKill": {"enemies": [["Alcoon"]], "explicitWeapons": ["Missile", "Super", "Wave", "Ice+Spazer", "Plasma", "ScrewAttack", "PseudoScrew", "PowerBomb"]}},
+            {"enemyKill": {"enemies": [["Alcoon"]], "explicitWeapons": ["Wave", "Ice+Spazer", "Plasma", "ScrewAttack", "PseudoScrew", "PowerBomb"]}},
             {"heatFrames": 180}
           ]},
-          {"and": [
-            {"heatFrames": 200},
-            {"or": [
-              "canDodgeWhileShooting",
-              "Morph"
-            ]}
-          ]},
-          {"and": [
-            {"heatFrames": 160},
-            {"enemyDamage": {"enemy": "Alcoon", "type": "fireball", "hits": 1}}
-          ]}
+          {"heatFrames": 200}
         ]},
         {"or": [
           {"resourceAvailable": [{"type": "ReserveEnergy", "count": 1}]},
@@ -1281,7 +1256,7 @@
         {"canShineCharge": {"usedTiles": 27, "gentleUpTiles": 2, "openEnd": 0}},
         {"or": [
           "canDownBack",
-          "canCarefulJump"
+          "canTrickyJump"
         ]},
         {"heatFrames": 120},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},


### PR DESCRIPTION
Room notes:
- Four Alcoons to farm. Alcoons guarantee small energy if full on Power Bombs, so 20 energy is viable.
- One Alcoon must be cleared for runway access. This can be done quickly with any ammo or a good Plasma beam. If the drop is needed, it must be allowed to pop out of the ground, however.
- The bottom left Alcoon is the interrupt source. There's just barely enough shine frames to get from the upper ledge down there by weaving through the vertical section.
- [2, 7] requires the Crystal Flash Clip notable.

Backup strats not included:
- If all four Alcoons are dead, there's still enough shineframes to roll into the spike pit. There's not enough for a pause abuse spark interrupt straight away, but you can perform a spikesuit, then take a second spike hit to do a pause abuse interrupt.
- Of course, heat interrupt is always an option.