### PR TITLE
Lower Norfair Fireflea Room R-Mode Spark Interrupt

### DIFF
--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -784,7 +784,7 @@
       "flashSuitChecked": true
     },
     {
-      "link": [2, 3],
+      "link": [2, 2],
       "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
       "entranceCondition": {
         "comeInWithRMode": {}
@@ -804,8 +804,7 @@
         ]},
         {"canShineCharge": {"usedTiles": 20, "gentleDownTiles": 2, "openEnd": 1}},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-        "canRModeSparkInterrupt",
-        {"spikeHits": 1}
+        "canRModeSparkInterrupt"
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,


### PR DESCRIPTION
Room Notes:

- The only R-Mode Spark in Lower Norfair to not be heated, so no heat interrupt option.
- Power Bombs are safely usable after Crystal Flash in this room, as long as Firefleas haven't been killed yet.
- Two different runways. One requires killing the Fune in the way, the other (longer) requires being able to traverse the vertical section.
- Crystal Flash strats from the upper doors don't require going down at all.
- Spike Pause Abuse strat from the lower door doesn't require going up, but does need to farm ~~all five Firefleas~~ one Fireflea and have full damage reduction to avoid a Crystal Flash.
- All other farming strats go for the Firefleas and farm for one energy drop (always large). ~~Missing power bomb lenience based on how many firefleas can be accessed.~~
- Farming Funes wasn't included because Firefleas are way better for it.