### PR TITLE
Refine Green Pirates Shaft Beetom X-Ray Climb

### DIFF
--- a/region/crateria/west/Green Pirates Shaft.json
+++ b/region/crateria/west/Green Pirates Shaft.json
@@ -1862,30 +1862,47 @@
       "requires": [
         {"noBlueSuit": {}},
         {"notable": "Beetom X-Ray Climb"},
-        "canLongXRayClimb",
-        "Morph",
+        {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 6}},
+        {"or": [
+          "Morph",
+          {"and": [
+            "canTunnelCrawl",
+            {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 3}}
+          ]}
+        ]},
         "canWallIceClip",
-        "canBeVeryPatient",
-        {"enemyDamage": {"enemy": "Beetom", "type": "contact", "hits": 9}},
-        {"resetRoom": {"nodes": [2, 3, 4]}}
+        "canLongXRayClimb",
+        "canBeVeryPatient"
       ],
       "resetsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
         "Shoot out only the lower 2 shot blocks on the side Samus will be climbing.",
-        "Grab a Beetom and use Morph to pixel align the Beetom with the edge of the wall.  While facing right.",
-        "Xray stand up for height and shoot to freeze.  Angle down shot to be safe.  Continue refreezing during the next steps.",
+        "Grab a Beetom and use Morph or a tunnel crawl to pixel align the Beetom 1 pixel deep into the wall (2 or 3 pixels can also work).",
+        "If morphed, use X-Ray stand up.",
+        "Shoot to the right (horizontally or diagonally down) to freeze the Beetom.",
+        "Continue refreezing during the next steps.",
         "Grab the other Beetom and stand close, but not too close, to the first.",
-        "Do a small jump, but not too low, and do an angle down shot the frame before Samus lands.",
-        "This second beetom needs to be exactly 1 pixel below the first.  Refreeze the first before testing the positioning.",
-        "Jump onto your beetom, walk into the wall, and start xray Climbing.",
-        "Climb up 2.5 screens and then fire upwards to clear shot blocks.  Continue climbing and finish by walking away from the crumble blocks."
+        "Do a small jump, but not too low, and do an aim-up shot the frame before Samus lands.",
+        "This second Beetom needs to be exactly 1 pixel below the first.",
+        "Refreeze the first before testing the positioning.",
+        "Jump onto the second Beetom, and run into the wall to clip into it (walking can also work if the Beetom is not too deep).",
+        "X-Ray climb up 2.5 screens and then fire upwards to clear shot blocks.",
+        "Continue climbing and finish by walking away from the crumble blocks."
+      ],
+      "detailNote": [
+        "For freezing the second Beetom, only certain jump heights will work.",
+        "Otherwise the Beetom will skip over the correct position and may be frozen too low (2 pixels below the other Beetom).",
+        "From a standing position, holding jump for 5, 8, 9, or 12 frames will work;",
+        "with a crouch jump, holding jump for 5, 6, or 10 frames will work.",
+        "It is recommended to use a crouch jump, aiming for a 5 or 6 frame jump."
       ],
       "devNote": [
-        "5 hits to position the two Beetoms, 1 hit for each failed clip attempt, 4 attempts.",
-        "With Ice, Samus will be able to slowly farm the Green Pirates.",
-        "One could descend through 8 visiting one of 5 or 6 and xray climb back up to the top door using the non visited node."
+        "2 hits are assumed to position the two Beetoms (plus 3 more if tunnel crawling),",
+        "then 1 hit for each failed clip attempt, with 4 failed attempts.",
+        "With Ice, Samus would be able to slowly farm the Green Pirates.",
+        "One could descend through 8 visiting one of 5 or 6 and X-Ray climb back up to the top door using the non visited node."
       ]
     },
     {


### PR DESCRIPTION
This tightens the logic by dropping the requirement for Morph or an in-room farm. Also added some more detail to the notes. It's a very difficult strat, but the lenience here seemed more than for other strats of similar difficulty. And I think this strat has proven to be a staple of Insane logic so it can make sense to assume it will be practiced. Usually you could still moonfall down to farm and X-ray climb back up, although this is kind of terrible.