### PR TITLE
Golden Torizo Room R-Mode Spark Interrupt

### DIFF
--- a/region/lowernorfair/west/Golden Torizo's Room.json
+++ b/region/lowernorfair/west/Golden Torizo's Room.json
@@ -574,10 +574,6 @@
         {"not": "f_DefeatedGoldenTorizo"},
         "canRiskPermanentLossOfAccess",
         {"notable": "Crystal Flash During Fight"},
-        {"or": [
-          {"ammo": {"type": "Super", "count": 30}},
-          {"and": ["Charge", "Ice", "Wave", "Plasma"]}
-        ]},
         "h_heatedCrystalFlashForReserveEnergy",
         {"enemyDamage": {"enemy": "Golden Torizo", "type": "contact", "hits": 1}},
         "canUseIFrames",


### PR DESCRIPTION
Room Notes:
- Another boss room, so another permanent loss of access strat. GT has two: one that farms, the other a Crystal Flash. Both use notable strats (safe spot or CF during fight). The CF forces a kill there and then (to prevent logic trying to use the standard Crystal Flash kill strat and require a *second* Crystal Flash).
  - Safe Spot energy farming requires heat-proof generally, but if you can't exceed 30 missiles, you can be full on ammo - forcing energy drops - and be able to stay ahead of heat damage that way.
  - Because CF Fight needs an "i-frame safe" reserve cap, it has to be heatProof, based on the standard CF kill wanting 800 heat frames after CF. A possible alternative approach to explore is to instead use the time (and enough energy) after CF while damaging down to get GT to nearly destroyed, interrupt, then finish it with a maximum of 300 heat frames. (Killing GT and then using a heat interrupt is instead essentially killing GT normally, then re-entering the room and using the GT Dead CF strat).
- In addition, a third strat can be done with GT defeated, by using a heat interrupt.