### PR TITLE
fast ripper room super fix.

### DIFF
--- a/region/lowernorfair/west/Fast Ripper Room.json
+++ b/region/lowernorfair/west/Fast Ripper Room.json
@@ -1531,6 +1531,7 @@
           ]},
           {"and": [
             {"heatFrames": 50},
+            {"ammo": {"type": "Super", "count": 1}},
             "canHeroShot"
           ]},
           {"and": [


### PR DESCRIPTION
the base  strat wasn't requiring any supers for "hero shot" to open the gate

as from "Words" in logic discord.

https://dev.maprando.com/seed/rtRL5xjz7/data/visualizer/index.html
[Expert Challenge]
Think I found some broken logic on this one. Step 5 expects you to get spring ball in main street, listing a return route through fast ripper room, except Supers aren't available yet. I ended up doing the cac alley spike boost to get back, but that's extreme difficulty and also uses spring ball.