### PR TITLE
add spikesuits to etecoon e-tank room

### DIFF
--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -1076,19 +1076,18 @@
               {"ammo": {"type": "Missile", "count": 2}},
               {"ammo": {"type": "Super", "count": 2}},
               {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]},
-            {"and": [
-              "Ice",
-              "canTrickyDodgeEnemies"
             ]}
-          ]}
+          ]},
+          {"and": [
+            "Ice",
+            "canTrickyDodgeEnemies"]}
         ]},
         {"shineChargeFrames": 80},
         {"thornHits": 1},
         "canSpikeSuit",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
-      "resetsObstacles": ["B", "R-Mode"],
+      "resetsObstacles": ["A", "B", "R-Mode"],
       "flashSuitChecked": true
     },
     {
@@ -1110,18 +1109,17 @@
               {"ammo": {"type": "Missile", "count": 2}},
               {"ammo": {"type": "Super", "count": 2}},
               {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]},
-            {"and": [
-              "Ice",
-              "canTrickyDodgeEnemies"
             ]}
-          ]}
+          ]},
+          {"and": [
+            "Ice",
+            "canTrickyDodgeEnemies"]}
         ]},
         {"thornHits": 1},
         "canSpikeSuit",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
-      "resetsObstacles": ["B", "R-Mode"],
+      "resetsObstacles": ["A", "B", "R-Mode"],
       "flashSuitChecked": true
     },
     {
@@ -1752,19 +1750,18 @@
               {"ammo": {"type": "Missile", "count": 2}},
               {"ammo": {"type": "Super", "count": 2}},
               {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]},
-            {"and": [
-              "Ice",
-              "canTrickyDodgeEnemies"
             ]}
-          ]}
+          ]},
+          {"and": [
+            "Ice",
+            "canTrickyDodgeEnemies"]}
         ]},
         {"shineChargeFrames": 60},
         {"thornHits": 1},
         "canSpikeSuit",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
-      "resetsObstacles": ["B", "R-Mode"],
+      "resetsObstacles": ["A", "B", "R-Mode"],
       "flashSuitChecked": true
     },
     {
@@ -1786,18 +1783,17 @@
               {"ammo": {"type": "Missile", "count": 2}},
               {"ammo": {"type": "Super", "count": 2}},
               {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]},
-            {"and": [
-              "Ice",
-              "canTrickyDodgeEnemies"
             ]}
-          ]}
+          ]},
+          {"and": [
+            "Ice",
+            "canTrickyDodgeEnemies"]}
         ]},
         {"thornHits": 1},
         "canSpikeSuit",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
-      "resetsObstacles": ["B", "R-Mode"],
+      "resetsObstacles": ["A", "B", "R-Mode"],
       "flashSuitChecked": true
     },
     {


### PR DESCRIPTION
couple of regular spikesuits from the bottom doors were missing.. since farming may require avoiding beetoms i tried to include some options for that..

https://videos.maprando.com/video/9317
https://videos.maprando.com/video/9315