### PR TITLE
Fast Rippers R-Mode Spark Interrupt

### DIFF
--- a/region/lowernorfair/west/Fast Ripper Room.json
+++ b/region/lowernorfair/west/Fast Ripper Room.json
@@ -99,6 +99,40 @@
   ],
   "strats": [
     {
+      "link": [1, 1],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit) - Timed Heated Crystal Flash",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        {"resourceAvailable": [{"type": "RegularEnergy", "count": 150}]},
+        {"resourceAtMost": [{"type": "RegularEnergy", "count": 180}]},
+        {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
+        {"disableEquipment": "HiJump"},
+        {"heatFrames": 388},
+        "h_heatedCrystalFlash",
+        {"partialRefill": {"type": "ReserveEnergy", "limit": 30}},
+        {"canShineCharge": {"usedTiles": 18, "openEnd": 0}},
+        "h_heatTriggerRModeSparkInterrupt",
+        "canTrickyJump",
+        {"heatFrames": 92}
+      ],
+      "clearsObstacles": ["B"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Requires about 150-180 Reserve at R-Mode entry to be able to correctly time the Crystal Flash.",
+        "The correct timing to place the power bomb is on taking 97 (53-83 energy left) energy worth of heat.",
+        "The Power Bomb explosion kills all six Rippers near the door, placing their",
+        "energy drops in easy reach to grab them and fill Reserve Energy.",
+        "Run to the green gate and wait until 69 energy is left and start running. Shinecharge at the end",
+        "of the runway, then use quick, speedy jumps back across the platforms towards the left door. You should",
+        "be able to make it to the left high platform (2nd from the door) before you need to windup and interrupt.",
+        "Shoot the door open and you can make it out."
+      ],
+      "devNote": "This strat makes a suitless CF with max E-Tanks viable without needing disable E-Tanks."
+    },
+    {
       "id": 43,
       "link": [1, 1],
       "name": "Open Door",
@@ -703,34 +737,6 @@
         "If any rippers remain, you can farm them with Power Bombs (or Supers at low health) but Screw Attack will no",
         "longer destroy them while you have blue suit."
       ]
-    },
-    {
-      "link": [1, 3],
-      "name": "R-Mode Spark Interrupt (Gain Blue Suit) - Timed Heated Crystal Flash",
-      "entranceCondition": {
-        "comeInWithRMode": {}
-      },
-      "requires": [
-        {"resourceAvailable": [{"type": "RegularEnergy", "count": 150}]},
-        {"resourceAtMost": [{"type": "RegularEnergy", "count": 180}]},
-        {"resourceMissingAtMost": [{"type": "Super", "count": 0}]},
-        {"heatFrames": 388},
-        "h_heatedCrystalFlash",
-        {"partialRefill": {"type": "ReserveEnergy", "limit": 30}},
-        {"canShineCharge": {"usedTiles": 18, "openEnd": 0}},
-        "h_heatTriggerRModeSparkInterrupt"
-      ],
-      "clearsObstacles": ["B"],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": [
-        "Requires about 150-180 Reserve at R-Mode entry to be able to correctly time the Crystal Flash.",
-        "The correct timing to place the power bomb is on taking 97 energy worth of heat.",
-        "The Power Bomb explosion kills all six Rippers near the door, placing their",
-        "energy drops in easy reach to grab them and fill Reserve Energy.",
-        "Heat interrupt after getting shinecharge on the green gate runway."
-      ],
-      "devNote": "This strat makes a suitless CF with max E-Tanks viable without needing disable E-Tanks."
     },
     {
       "id": 5,


### PR DESCRIPTION
Room notes:
- Six Rippers, with guaranteed Large Energy while full on Supers.
  - For clarity, I will refer to them as numbered 1 through 6, starting from the top. Their patterns are noteworthy in this strat:
  - Ripper 1 and 2 reach the left door, but don't reach the green gate.
  - Ripper 3, 4, and 5 bounce between both doors, but only 4 and 5 are low enough to interfere with the runway.
  - Ripper 6 is trapped between two platforms.
- Killing with supers just refunds your supers. Screw Attack and Power Bomb kills only. (In theory, health bias can force energy drops and allow for Super kills combined with heatProof, but they can't be grouped quickly enough to accumulate drops.)
- Special note: once blue suit is gained, Screw Attack ceases to be effective, 
- The green gate doesn't have to be opened if 18 tiles is an acceptable runway. When opened from the left, one Ripper could be sacrificed to refund the super. When opened from the right, green gate glitch leniency will determine how many Rippers must be sacrificed before you can get energy again.
- [1, 1] strat is presumed to be Super-less (can't open the gate), so no Crystal Flash option. If you can CF, you can open the gate and use the [1, 2] strat.

Farming:
- Keep Ripper 3 alive, for the best interrupt.
- Kill 4 and 5 first, to de-complicate movement.
- Interrupt close to the green gate (if you can't open it) or the right door, and with Ripper 3 approaching you from the left to then bounce of the gate/door, pass back through you while you still have i-frames. If it bounced off the gate, it'll come back in time for a second hit when you had more than 300 reserves. If it bounced off the door, a full reserve fill-up is safe.

Crystal Flash (Left Door):
- Morph quickly to avoid getting hit by Rippers. Stay by the door.
- Wait an extra second or two for Ripper 3 to start going off screen, then drop your Power Bomb.
- During the Crystal Flash, 4 and 5 will start to come back and will be destroyed by the R-Mode light orb. They are almost certain to drop Supers, which ensures you can open the gate.
- Open the gate for a longer runway.
- Interrupt near the door with Ripper 3 moving left.

Crystal Flash (Right Door):
- CF before trying to open the gate.
- Dodge Ripper 4 and 5 once they come flying through, then follow behind them and watch them explode on the light orb. Pick up the Supers they drop if you want.
- From here it's identical to [1, 2].