### PR TITLE
add spikesuits to spiky death room

### DIFF
--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -902,8 +902,6 @@
       },
       "requires": [
         {"shineChargeFrames": 35},
-        "canTrickyJump",
-        "canComplexCarryFlashSuit",
         "f_DefeatedPhantoon",
         "h_spikeSuitSpikeHitLeniency",
         {"spikeHits": 1},


### PR DESCRIPTION
also tidied up the xmode shinecharge strat by using the helper.

https://videos.maprando.com/video/9010 [right door] https://videos.maprando.com/video/9009 [left door]

I tried to come in normally shinecharged and fall to the ground but unless you come in jumping the kzan hits you before you have time to gain flashsuit,