### PR TITLE
Hellway R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/red/Hellway.json
+++ b/region/brinstar/red/Hellway.json
@@ -185,10 +185,10 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Fill up on the respawning Zebs. Drain energy down to 20/10/5 and jump into the",
-        "floor plant with forward momentum to shinecharge while getting eaten. At 8/4/2 energy",
-        "left, shinecharge and get ready to jump out. Get hit by the Zeb to complete the",
-        "interrupt."
+        "Fill up on the respawning Zebbos. Drain energy down to 20/10/5. Trigger a Zebbo from the",
+        "first plant and kill it but leave its drop hanging. Jump (not fall) into the second floor plant",
+        "with forward momentum to shinecharge while getting eaten. At 8/4/2 energy left, shinecharge",
+        "and get ready to jump out. Get hit by the Zebbo to complete the interrupt."
       ]
     },
     {
@@ -462,7 +462,7 @@
       "flashSuitChecked": true
     },
     {
-      "link": [2, 2],
+      "link": [2, 1],
       "name": "R-Mode Spark Interrupt (Gain Blue Suit) - Samus Eater Shinecharge",
       "entranceCondition": {
         "comeInWithRMode": {}
@@ -478,10 +478,11 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Fill up on the respawning Zebs. Drain energy down to 20/10/5 and jump into the",
-        "floor plant with forward momentum to shinecharge while getting eaten. At 8/4/2 energy",
-        "left, shinecharge and get ready to jump out. Get hit by the Zeb to complete the",
-        "interrupt."
+        "Cross to the left door, and fill up on respawning Zebbos as you go.",
+        "Drain energy down to 20/10/5. Trigger a Zebbo from the leftmost plant and kill it but leave",
+        "its drop hanging. Jump (not fall) into the second floor plant with forward momentum to shinecharge",
+        "while getting eaten. At 8/4/2 energy left, shinecharge and get ready to jump out. Get hit by the",
+        "Zebbo to complete the interrupt."
       ]
     },
     {


### PR DESCRIPTION
Room Notes:

- Respawning Zebs provide energy.
- Samus Eater Shinecharge. The best energy value is 20/10/5 to enter the plant and leave with just enough to get hit by a Zeb and interrupt.