### PR TITLE
Alpha Power Bombs R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/red/Alpha Power Bomb Room.json
+++ b/region/brinstar/red/Alpha Power Bomb Room.json
@@ -129,6 +129,7 @@
         {"or": [
           "h_CrystalFlashForReserveEnergy",
           {"and": [
+            {"enemyKill": {"enemies": [["Boyon", "Boyon", "Boyon"]]}},
             "h_RModeCanRefillReserves",
             {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
             {"or": [


### PR DESCRIPTION
Room notes:

- Another Samus Eater shinecharge.
- Four Boyons are quite bad for farming.