### PR TITLE
Beta Power Bombs R-Mode Spark Interrupt

### DIFF
--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -150,22 +150,18 @@
         {"samusEaterFrames": 160},
         "h_shinechargeMaxRunway",
         {"autoReserveTrigger": {}},
+        "canHorizontalDamageBoost",
         "canRModePauseAbuseSparkInterrupt"
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "While Morphed, the Sidehoppers cannot hit you.",
-        "If you have no suits and between 51-80 energy and need to take damage to Crystal Flash,",
-        "lead the Sidehoppers to the right, then roll left quickly to trap them offscreen so you can",
-        "safely jump into the thorns until you're below 50.",
-        "Lead the Sidehoppers to the left, press against the left wall and lay the Power Bomb",
-        "to Crystal Flash. Roll slightly away while waiting for the PB to explode to avoid getting",
-        "bomb-jumped into the Sidehoppers. Roll back during the explosion so you can complete the",
-        "Crystal Flash. Now you can damage down on the thorns until you're between 17-32 energy.",
-        "Jump into the center plant with forward momentum to gain shinecharge. Once it releases",
-        "you, jump into the thorns with pause abuse to interrupt the windup."
+        "While morphed the sidehoppers cannot hit you.",
+        "Crystal Flash to add Energy into Reserve Tanks, avoiding the bomb bounce.",
+        "Damage down to between 17-32 Energy.",
+        "Jump into the center plant with forward momentum to gain shinecharge.",
+        "Jump into the thorns with a pause abuse and hold a damage boost into the pause to interrupt the windup."
       ]
     },
     {


### PR DESCRIPTION
Room Notes:

- Sidehoppers again. Three is not great for farming.
- Two runway options: Power Bomb to clear the blocks (which can also be used to kill hoppers) and jump into a Samus Eater, or avoid clearing the blocks and have a normal runway.