### PR TITLE
refine existing shinespark strat and add xmode bluesuit to betapowerbomb room

### DIFF
--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -473,6 +473,9 @@
         "h_thornXModeBlueSuit",
         {"shinespark": {"frames": 4}}
       ],
+      "note":[
+        "Without Super Missiles or to save using a Super Missile, jump over the yapping maw to make it try to grab Samus, the Samus Eater can then be entered from the other side avoiding being grabbed."
+      ],
       "flashSuitChecked": true
     },
     {


### PR DESCRIPTION
https://videos.maprando.com/video/9368 [spikesuit] - samuseater 
https://videos.maprando.com/video/9365 [spikesuit] - destroy bridge while shinecharging on it.

https://videos.maprando.com/video/9367 [bluesuit] - samuseater
https://videos.maprando.com/video/9342 [bluesuit] - destroy bridge while shinecharging on it.

i dont think a room reset is required as if you fail the shortcharge on the bridge you can always use the samus eater?