### PR TITLE
Shaktool Room R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-green/Shaktool Room.json
+++ b/region/maridia/inner-green/Shaktool Room.json
@@ -721,6 +721,10 @@
           ]}
         ]},
         "h_shinechargeMaxRunway",
+        {"or":[
+          "canWaterShineCharge",
+          "Gravity"
+        ]},
         {"autoReserveTrigger": {}},
         "canRModeSparkInterrupt"
       ],


### PR DESCRIPTION
Room Notes:

- Farming Shaktool normally has 1 drop if you use a beam or missile, but if you use a well-timed Shinespark, you can get as many as five. Take care not to leave the room while Shaktool is exploding, as there is a crash-the-game risk. But why would you when you want the drops anyway?
- If you can't free Shaktool from the right side, you're left with Yards. You need to clear the sand via Snail Soccer to use the runway, so you can use this to separate them for a Power Bomb kill.
- Both Shaktool and Yards hit hard, but they don't stay to bother Samus during the Reserve autofill.