### PR TITLE
Aqueduct R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-pink/Aqueduct.json
+++ b/region/maridia/inner-pink/Aqueduct.json
@@ -1554,7 +1554,6 @@
       "link": [2, 5],
       "name": "Gravity Jump",
       "requires": [
-        "Gravity",
         "canGravityJump"
       ],
       "flashSuitChecked": true,


### PR DESCRIPTION
Room Notes:
- Five Yards, three of which are global.
- The bottom runway is full-length, and you can free and anger the bottom Yard to interrupt.
- For the walljumpless, [5, 5] has an alternative with a shorter runway (and fewer Yards usable) that doesn't need to get back up from 2.