### PR TITLE
Below Botwoon Energy Tank R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -118,7 +118,7 @@
       "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
       "requires": [
         "Gravity",
-        {"obstaclesCleared": ["A", "R-Mode"],
+        {"obstaclesCleared": ["A", "R-Mode"]},
         {"refill": ["Energy"]},
         {"canShineCharge": {"usedTiles": 23, "gentleUpTiles": 2, "gentleDownTiles": 2, "steepUpTiles": 1, "openEnd": 1}},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},


### PR DESCRIPTION
Room Notes:
- Multiple respawning Zoa points.
- An Owtch that has to be removed for runway access.
- Take the interrupt away from sand, ideally.