### PR TITLE
Botwoon Energy Tank Room R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1866,9 +1866,14 @@
       "requires": [
         "Gravity",
         {"refill": ["Energy"]},
-        "canSuitlessMaridia",
-        "canMidAirMorph",
-        {"disableEquipment": "Gravity"},
+        {"or": [
+          {"and": [
+            "canSuitlessMaridia",
+            "canMidAirMorph",
+            {"disableEquipment": "Gravity"}
+          ]},
+          {"canShineCharge": {"usedTiles": 23, "openEnd": 1, "gentleUpTiles": 4}}
+        ]},
         "h_shinechargeMaxRunway",
         {"autoReserveTrigger": {}},
         "canRModeSparkInterrupt"


### PR DESCRIPTION
Room Notes:
- Respawning Zoa Farm.
- The full length runway is nice to have, but the 22-tile shinecharge by the Zoa pit is also right there. If for some reason 22-tile shinecharges aren't enabled, you have to get back across to the left side so you can use the long-run again.
- Morph tunnel crossing for [4, 4] is an option, but since it's optional I didn't put a `collectsItem` on it. In practice if you can do it you can collect that item separately anyway.