### PR TITLE
Refine Fish Tank cross room speedy jump

### DIFF
--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -1113,7 +1113,7 @@
     {
       "id": 21,
       "link": [1, 5],
-      "name": "Tricky Cross Room Jump with Speedbooster",
+      "name": "Cross Room Tricky Dash Jump",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
@@ -1126,7 +1126,11 @@
         "canMomentumConservingTurnaround"
       ],
       "flashSuitChecked": true,
-      "note": "Requires running a precise distance of 7 tiles in the adjacent room, to hit a peak of the speed vs height graph."
+      "note": "Requires running a precise distance of 7 tiles in the adjacent room, to hit a peak of the speed vs height graph.",
+      "detailNote": [
+        "This requires a dash speed of $2.0 or $2.1.",
+        "If 12 tiles of runway (with closed ends) is available, speeds of $2.F, $3.0, or $3.1 also work and do not require a turnaround."
+      ]
     },
     {
       "id": 22,
@@ -1135,14 +1139,15 @@
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": true,
-          "minTiles": 11.4375
+          "minTiles": 17.4375
         }
       },
       "requires": [
         "canCrossRoomJumpIntoWater"
       ],
       "flashSuitChecked": true,
-      "note": "Requires a runway of at least 12 tiles (with no open end) in the adjacent room."
+      "note": "Requires a runway of at least 18 tiles (with no open end) in the adjacent room.",
+      "detailNote": "This requires a dash speed of at least $3.F."
     },
     {
       "id": 23,


### PR DESCRIPTION
The 12-tile runway only works with 3 speed values (a window of about 1 tile in runway length), which seems too precise for the base "canCrossRoomJumpIntoWater" tech (Hard difficulty). So this PR absorbs this option into the same strat as the "tricky dash jump" which requires the 7-tile runway and works with 2 speed values. The 12-tile runway does have an advantage of not requiring a turnaround but still seems precise enough to require the "canTrickyDashJump" tech.
