### PR TITLE
Botwoon Hallway R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -540,39 +540,6 @@
       "flashSuitChecked": true
     },
     {
-      "link": [2, 1],
-      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
-      "entranceCondition": {
-        "comeInWithRMode": {}
-      },
-      "requires": [
-        "Gravity",
-        {"or": [
-          "h_CrystalFlashForReserveEnergy",
-          {"and": [
-            "h_RModeCanRefillReserves",
-            {"or": [
-              {"and": [
-                {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
-                {"partialRefill": {"type": "ReserveEnergy", "limit": 40}}
-              ]},
-              {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
-            ]}
-          ]}
-        ]},
-        "h_shinechargeMaxRunway",
-        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-        "canRModeSparkInterrupt"
-      ],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": [
-        "Leave the Mochtroid trapped in the box just above the runway. Open up the runway, then",
-        "damage down on the far right Puyo. Run right to left to shinecharge, open the box, and",
-        "use the Mochtroid to interrupt."
-      ]
-    },
-    {
       "id": 14,
       "link": [2, 1],
       "name": "Reverse Shinespark, Come in Shinecharged",
@@ -883,6 +850,39 @@
         }
       },
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 2],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        "Gravity",
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"or": [
+              {"and": [
+                {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+                {"partialRefill": {"type": "ReserveEnergy", "limit": 40}}
+              ]},
+              {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+            ]}
+          ]}
+        ]},
+        "h_shinechargeMaxRunway",
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Leave the Mochtroid trapped in the box just above the runway. Open up the runway, then",
+        "damage down on the far right Puyo. Run right to left to shinecharge, open the box, and",
+        "use the Mochtroid to interrupt."
+      ]
     },
     {
       "id": 23,


### PR DESCRIPTION
Room notes:
- Gravity leaves traversing this room fairly trivial.
- Four Mochtroids and two Puyos to farm.
- The interrupt is done by going right-to-left on the runway, opening the leftmost box from below, and letting that Mochtroid grab you.