### PR TITLE
Botwoon's Room R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -125,7 +125,6 @@
         {"not": "f_DefeatedBotwoon"},
         "canRiskPermanentLossOfAccess",
         "Gravity",
-        "canTrickyDodgeEnemies",
         "h_CrystalFlashForReserveEnergy",
         {"canShineCharge": {"usedTiles": 13, "openEnd": 0}},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},


### PR DESCRIPTION
Boss room!

- Loss of access risk, since you need Botwoon alive, naturally.
- No way to get energy during the Botwoon fight, so Crystal Flash is required. An immediate CF is safe with Botwoon's opening snake patterns. Spit patterns also give enough time to Crystal Flash relatively safely.
- Very short runway. But at least it's not Ridley Tank.
- Unless the door isn't locked (e.g. MapRando), you'll have to kill Botwoon afterward.