### PR TITLE
Crab Shaft R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -1468,6 +1468,40 @@
       "flashSuitChecked": true
     },
     {
+      "link": [2, 2],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "requires": [
+        {"obstaclesCleared": ["R-Mode"]},
+        "Gravity",
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"or": [
+              {"and": [
+                {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 2}]},
+                {"partialRefill": {"type": "ReserveEnergy", "limit": 40}}
+              ]},
+              {"and": [
+                {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 0}]},
+                {"partialRefill": {"type": "ReserveEnergy", "limit": 80}}
+              ]}
+            ]}
+          ]}
+        ]},
+        {"canShineCharge": {"usedTiles": 23, "openEnd": 0}},
+        {"autoReserveTrigger": {}},
+        "canRModeSparkInterrupt"
+      ],
+      "resetsObstacles": ["R-Mode"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm three Scisers for energy or Crystal Flash. Run across the bottom, then use the last",
+        "Sciser to interrupt."
+      ]
+    },
+    {
       "id": 42,
       "link": [2, 2],
       "name": "Leave With Runway - Frozen Sciser",


### PR DESCRIPTION
Room notes:

- Already had an obstacle from R-Mode CF so I used it.
- Four Scisers to farm. All four can be reached (the top one is global so you don't need to climb the shaft to get to it).
- Best runway is at the bottom. Movement is free between this one and the upper level runway.