### PR TITLE
Draygon R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -148,10 +148,6 @@
           "h_breakThreeDraygonTurrets"
         ]},
         "Gravity",
-        {"or": [
-          "canWalljump",
-          "SpaceJump"
-        ]},
         "h_CrystalFlashForReserveEnergy",
         {"canShineCharge": {"usedTiles": 22, "openEnd": 0}},
         "canOffScreenMovement",


### PR DESCRIPTION
The boss of Maridia has actually a few options for getting bluesuit.

- You can farm goops for energy and then perform a normal R-Mode Spark. Farming goops can take some patience, especially with lower level beams.
- This is one of the [select few rooms](https://wiki.supermetroid.run/G-Mode_Technical_Details#X-Ray_HDMA_object) in which a Crystal Flash does not corrupt the HDMA pile, if the player entered with Draygon alive, and thus does not create a light orb. This also means, should one be needed, the player can still use Power Bombs and X-Ray (especially for Microwave) normally.
  - If Draygon is already defeated, Crystal Flashes create light orbs as usual. Power Bomb can be used after CF to restore game audio and X-Ray usage.
- The Shinespark Kill can be used to gain a blue suit, as Draygon's death cutscene forces a standup and will give a blue suit.
- As usual, all Draygon-alive strats are loss-of-access.