### PR TITLE
UN Farm: gate glitch with only reserves

### DIFF
--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -1333,6 +1333,7 @@
           {"ammo": {"type": "Super", "count": 1}}
         ]},
         {"or": [
+          "h_heatResistant",
           "canTrickyJump",
           {"resourceCapacity": [{"type": "RegularEnergy", "count": 199}]}
         ]}


### PR DESCRIPTION
This recently came up in a Hard seed with only a reserve tank; should that require an E-Tank?
This was the best method I could think of to bump it up.