### PR TITLE
Tech canRelyOnLuck

### DIFF
--- a/tech.json
+++ b/tech.json
@@ -35,12 +35,23 @@
           ]
         },
         {
-          "name": "canRelyOnLuck",
+          "name": "canBeLucky",
           "techRequires": [],
           "otherRequires": [],
           "note": [
             "Executing a strat that has a reasonable chance to fail due to random elements such as enemy drops.",
             "This is used where failure is unforgiving and may result in a death or a slow process to reattempt."
+          ],
+          "extensionTechs": [
+            {
+              "name": "canBeVeryLucky",
+              "techRequires": ["canBeLucky"],
+              "otherRequires": [],
+              "note": [
+                "Executing a strat that has a high chance to fail due to random elements such as enemy drops.",
+                "This is used where failure is unforgiving and may result in a death or slow process to reattempt."
+              ]
+            }
           ]
         },
         {


### PR DESCRIPTION
Proposal for a tech flag `canRelyOnLuck`, as suggested in #2466 .

What I imagined would be the scope for this flag:
- Strats with a random element determining success that the player can't¹ control, even with perfect execution. A typical example is relying on enemy drops.
- The overall chance of success is between 40-60% (lower rates to be covered with higher level brackets that need names) on average.
  - Specific strats that have a high cost of failure might wish to raise the upper bound higher.
- The cost of failure, at minimum, forces the room to be reset, even in a best case equipment scenario.
  - This would obviously not cover cases like: standing at a bug spawner and farming one bug for Power Bombs (just wait for the next one), whether a hopper enemy jumps high or low into an ice shot, or Taco Tank, where the most the player has to do is just reposition nearby, wait for an enemy to unfreeze / one block or enemy to respawn.
  - It would not cover a case where lacking equipment leaves the player somewhere inescapable.

(¹ Large-scale RNG manipulation is not considered here. If there's a local-scale RNG-manipulation method, that might be worth its own strat and associated tech.)