### PR TITLE
Halfie Climb Room R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -819,14 +819,12 @@
         {"obstaclesCleared": ["R-Mode"]},
         "Gravity",
         "Morph",
-        {"and": [
-          "h_RModeCanRefillReserves",
-          {"or": [
-            {"resourceMissingAtMost": [{"type": "Missile", "count": 2}]},
-            {"resourceMissingAtMost": [{"type": "Super", "count": 1}]}
-          ]},
-          {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+        "h_RModeCanRefillReserves",
+        {"or": [
+          {"resourceMissingAtMost": [{"type": "Missile", "count": 2}]},
+          {"resourceMissingAtMost": [{"type": "Super", "count": 1}]}
         ]},
+        {"partialRefill": {"type": "ReserveEnergy", "limit": 20}},
         "h_shinechargeMaxRunway",
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt"


### PR DESCRIPTION
Room notes:

- Three Mochtroids to farm: 85.8% chance of 20 energy (72.8% if you sacrifice one for a possible ammo drop)
- The runway under the Ohm is maximum length. Manipulation of the Ohms can synchronize them for easy maneuvering.
- There's two versions using the R-Mode obstacle: one comes from [1] (middle door) and the other from [2] (bottom door). The difference is in whether or not the top Mochtroid can be reached (thus allowing 1 ammo drop for leniency).
  - The top Mochtroid can be reached from [1] and [4] for free, but from [2] it requires non-trivial movement (walljump, space jump, hi jump (dash jump to [1]), long IBJ, grapple, or gravity jump) to reach.
