### PR TITLE
Maridia Swiss Cheese Room R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-yellow/Maridia Swiss Cheese Room.json
+++ b/region/maridia/inner-yellow/Maridia Swiss Cheese Room.json
@@ -284,6 +284,39 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 3],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"or": [
+              {"and": [
+                {"enemyKill": {"enemies": [["Owtch", "Owtch"]], "excludedWeapons": ["PowerBomb"]}},
+                {"enemyKill": {"enemies": [["Menu", "Menu"]], "explicitWeapons": ["Missile", "Plasma", "Ice+Wave+Spazer"]}}
+              ]},
+              "h_usePowerBomb"
+            ]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        {"canShineCharge": {"usedTiles": 22, "openEnd": 2}},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm the two Owtches for energy and clear away all but one Menu from the left.",
+        "Shinecharge through the tunnel and use the last Menu to interrupt. If you had to kill it",
+        "with a Power Bomb, there are more to the right."
+      ]
+    },
+    {
       "id": 7,
       "link": [2, 1],
       "name": "G-Mode Morph",
@@ -552,6 +585,48 @@
         {"obstaclesCleared": ["A"]}
       ],
       "flashSuitChecked": true
+    },
+    {
+      "link": [2, 3],
+      "name": "R-Mode Spark Interrupt (Gain Blue Suit)",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        {"or": [
+          "h_bombThings",
+          "h_useSpringBall",
+          {"and": [
+            "canMidAirMorph",
+            "Gravity",
+            "canTrickyJump"
+          ]},
+          "h_threeTileJumpMorph"
+        ]},
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"or": [
+              {"and": [
+                {"enemyKill": {"enemies": [["Owtch", "Owtch"]], "excludedWeapons": ["PowerBomb"]}},
+                {"enemyKill": {"enemies": [["Menu", "Menu"]], "explicitWeapons": ["Missile", "Plasma", "Ice+Wave+Spazer"]}}
+              ]},
+              "h_usePowerBomb"
+            ]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        {"canShineCharge": {"usedTiles": 22, "openEnd": 2}},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm the two Owtches for energy and clear away all but one Menu from the left.",
+        "Shinecharge through the tunnel and use the Menus from the left to interrupt."
+      ]
     },
     {
       "id": 19,


### PR DESCRIPTION
Room notes:

- Owtches are better for farming. With just all five Menus, it's pretty bad. For now I went for requiring killing Owtches.
  - There's technically seven Owtches but the two below the runway are considered inaccessible.
- Good chance for 20 energy on just two Owtches, but there's a total of five that can be farmed from [2] (and from [1] with a Morph requirement). The Menus don't add much on top of them.
- [1, 3] doesn't need Morph, [2, 3] does, plus getting past the morph jump.
