### PR TITLE
Plasma Room R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -401,7 +401,10 @@
             {"or": [
               {"and": [
                 "canUseIFrames",
-                {"enemyDamage": {"enemy": "Pink Space Pirate (standing)", "type": "laser", "hits": 1}}
+                {"or": [
+                  {"enemyDamage": {"enemy": "Pink Space Pirate (standing)", "type": "laser", "hits": 1}},
+                  "h_pauseAbuseMinimalReserveRefill"
+                ]}
               ]},
               "ScrewAttack",
               "Plasma",


### PR DESCRIPTION
Room notes:
- A lot of pirates makes it easy to get 20 energy regardless of Missiles.
- Standing pirates need Screw Attack or Plasma Beam to kill. Pseudo-Screw is also possible using the damage-free notable.
  - ~~No Shinespark kill option due to energy cost.~~
- Killing any remaining pirates is free with blue suit.