### PR TITLE
Watering Hole R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-yellow/Watering Hole.json
+++ b/region/maridia/inner-yellow/Watering Hole.json
@@ -259,7 +259,7 @@
       "blueSuitChecked": true,
       "note": [
         "Freeze the two Zebs to create a runway to shinecharge with. Pixel perfect freezing of both Zebs",
-        "provides the longest runway, but a less perfect position of the second Zeb is still usable."
+        "provides the longest runway, but a slightly higher position of the second Zeb is still usable."
       ]
     },
     {


### PR DESCRIPTION
Room notes:

- Respawning Zebs for energy.
- Requires using frozen Zebs to get a runway. One by itself is a short runway, but two is a notable strat.
- With the Zebs frozen, you can either drop into the chasm and get hit by the Choot, or disable Ice Beam to force-unfreeze the Zebs.