### PR TITLE
Boyon Gate Hall R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/outer/Boyon Gate Hall.json
+++ b/region/maridia/outer/Boyon Gate Hall.json
@@ -1457,10 +1457,11 @@
             {"canShineCharge": {"usedTiles": 13, "openEnd": 1}}
           ]},
           {"and": [
-            {"or": [
-              {"doorUnlockedAtNode": 1},
-              {"doorUnlockedAtNode": 2}
-            ]},
+            {"doorUnlockedAtNode": 1},
+            {"canShineCharge": {"usedTiles": 12, "openEnd": 1}}
+          ]},
+          {"and": [
+            {"doorUnlockedAtNode": 2},
             {"canShineCharge": {"usedTiles": 13, "openEnd": 0}}
           ]},
           {"canShineCharge": {"usedTiles": 12, "openEnd": 0}}


### PR DESCRIPTION
Room notes:
- Respawning Zebbo farm.
- Green gate runway is Expert-usable at least, otherwise 1-tile runway between the bottom doors.
- Convenient Boyon right as you walljump up from the doors. From the runway... have your pick.
- [1, 4] movement to get up from the shinecharge is covered by starting the spark strat from [4].
- Candidate for Combined Direct + Indirect G-Mode to despawn the gate when entering from below and still use an R-Mode interrupt.