### PR TITLE
Crab Gate Room R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/outer/Crab Gate Room.json
+++ b/region/maridia/outer/Crab Gate Room.json
@@ -1043,7 +1043,6 @@
         {"autoReserveTrigger": {}},
         "canRModeSparkInterrupt"
       ],
-      "clearsObstacles": ["A"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [


### PR DESCRIPTION
Room notes:
- 6 Scisers total, but one is blocked by the gate from the right side.
- Left side must open the gate.
- Right side doesn't open the gate. 42 tiles is more than enough.