### PR TITLE
Fish Tank R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -2065,6 +2065,31 @@
       "blueSuitChecked": true
     },
     {
+      "link": [2, 2],
+      "name": "R-Mode Spark Interrupt",
+      "requires": [
+        "Gravity",
+        {"obstaclesCleared": ["R-Mode"]},
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        {"canShineCharge": {"usedTiles": 32, "openEnd": 1}},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "resetsObstacles": ["R-Mode"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm the Skulteras, then shinecharge using the bottom runway and use the pirate's lasers to interrupt."
+      ]
+    },
+    {
       "id": 139,
       "link": [2, 2],
       "name": "R-Mode Crystal Flash Interrupt (Pirate)",
@@ -3567,31 +3592,6 @@
       "name": "Base",
       "requires": [],
       "flashSuitChecked": true
-    },
-    {
-      "link": [6, 2],
-      "name": "R-Mode Spark Interrupt",
-      "requires": [
-        "Gravity",
-        {"obstaclesCleared": ["R-Mode"]},
-        {"or": [
-          "h_CrystalFlashForReserveEnergy",
-          {"and": [
-            "h_RModeCanRefillReserves",
-            {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
-            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}},
-          ]}
-        ]},
-        {"canShineCharge": {"usedTiles": 32, "openEnd": 1}},
-        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-        "canRModeSparkInterrupt"
-      ],
-      "resetsObstacles": ["R-Mode"],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": [
-        "Farm the Skulteras, then shinecharge using the bottom runway and use the pirate's lasers to interrupt."
-      ]
     },
     {
       "id": 71,


### PR DESCRIPTION
Room notes:
- Four Skultera to farm if you can't kill Pirates (Plasma and Screw Attack only).
- As tempting as the "free Speed kill" bottom Pirate is, you need that one for the interrupt.
- Movement to get to the farming points (and back) is somewhat non-trivial, but all requirement options are covered by the `Gravity` options for getting to [6], so the strat starts there.