### PR TITLE
Mama Turtle R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/outer/Mama Turtle Room.json
+++ b/region/maridia/outer/Mama Turtle Room.json
@@ -571,20 +571,12 @@
         "Gravity",
         "h_CrystalFlashForReserveEnergy",
         {"canShineCharge": {"usedTiles": 18, "gentleUpTiles": 2, "openEnd": 1}},
+        {"autoReserveTrigger": {}},
+        "canRModeSparkInterrupt",
         {"or": [
-          {"and": [
-            {"autoReserveTrigger": {}},
-            {"or": [
-              "canInsaneJump",
-              {"enemyDamage": {"enemy": "Kame (Tatori)", "type": "contact", "hits": 1}},
-              {"resourceAtMost": [{"type": "RegularEnergy", "count": 150}]}
-            ]},
-            "canRModeSparkInterrupt"
-          ]},
-          {"and": [
-            {"autoReserveTrigger": {}},
-            "canRModePauseAbuseSparkInterrupt"
-          ]}
+          "canInsaneJump",
+          {"enemyDamage": {"enemy": "Kame (Tatori)", "type": "contact", "hits": 1}},
+          {"resourceAtMost": [{"type": "RegularEnergy", "count": 150}]}
         ]}
       ],
       "flashSuitChecked": true,


### PR DESCRIPTION
Room notes:
- No energy sources - Crystal Flash required.
- Mama Turtle hits hard, so damaging down is fast.
- Interrupt near the ledge to reduce extra mama turtle hits. At 4 R-Tanks I only get one extra hit.
- You could also pause abuse and jump out of the way after getting hit by Mama.