### PR TITLE
Main Street R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -3052,16 +3052,7 @@
           "h_CrystalFlashForReserveEnergy",
           {"and": [
             "h_RModeCanRefillReserves",
-            {"or": [
-              {"and": [
-                {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 0}]},
-                {"partialRefill": {"type": "ReserveEnergy", "limit": 60}}
-              ]},
-              {"and": [
-                {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 1}]},
-                {"partialRefill": {"type": "ReserveEnergy", "limit": 40}}
-              ]}
-            ]}
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
           ]}
         ]},
         {"or": [


### PR DESCRIPTION
Room notes:
- Two Scisers accessible in the platforms above,  plus the global Sciser used to interrupt.
  - You can get to three more with gravity jumps, but two are already enough so I didn't include them.
  - Crab Supers Sciser is considered inaccessible.
- Assumed use of one Super to knock down the global Sciser in case it starts climbing above the runway - if it passes the top corner of that wall, you're stuck waiting until it loops near the Speed block to try to knock it down again - or else wait for it to lap all the way around.