### PR TITLE
Mt. Everest R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -4077,7 +4077,8 @@
       "blueSuitChecked": true,
       "note": [
         "Farm the Sciser in the bottom runway, then shinecharge. Interrupt using the Sciser on the center mountain."
-      ]
+      ],
+      "devNote": "Samus is able to enter this door in R-mode, even if the tunnel is not expanded. She can then morph and 'fall' into the tunnel."
     },
     {
       "id": 133,


### PR DESCRIPTION
Room notes:
- Big room, but only one runway that is easy to get to from everywhere. Only [3] needed some relatively minor movement.
- The only Scisers used in the strat are the bottom runway one to farm and the middle mountain one to interrupt.
- [3] needed some movement to get over the hill.