### PR TITLE
add stationary morph turnaround as item collection method for west sand pit top right item.

### DIFF
--- a/region/maridia/inner-pink/West Sand Pit.json
+++ b/region/maridia/inner-pink/West Sand Pit.json
@@ -607,7 +607,7 @@
       "link": [6, 4],
       "name": "Turnaround Aim Cancel",
       "requires": [
-        {"notable": "Right Item Collection"},
+        {"notable": "Right Item Turn Around Collection"},
         "canTurnaroundAimCancel"
       ],
       "note": [
@@ -619,7 +619,7 @@
       "link": [6, 4],
       "name": "Stationary Morph Turn Around",
       "requires": [
-        {"notable": "Right Item Collection"},
+        {"notable": "Right Item Turn Around Collection"},
         "canMorphTurnaround"
       ],
       "note": [
@@ -631,7 +631,7 @@
       "link": [6, 4],
       "name": "X-Ray Standup",
       "requires": [
-        {"notable": "Right Item Collection"},
+        {"notable": "Right Item Turn Around Collection"},
         "canXRayStandUp"
       ],
        "note": [
@@ -644,7 +644,7 @@
       "link": [6, 4],
       "name": "X-Ray Turnaround",
       "requires": [
-        {"notable": "Right Item Collection"},
+        {"notable": "Right Item Turn Around Collection"},
         "canXRayTurnaround"
       ],
        "note": [
@@ -792,7 +792,7 @@
     },
     {
       "id": 3,
-      "name": "Right Item Collection",
+      "name": "Right Item Turn Around Collection",
       "note": [
         "Collecting the right side item is possible by aligning Samus on the closest pixel to the item while facing left, and then performing a turnaround towards the right.",
         "This can be achieved with a Morph turnaround, an X-Ray turnaround, or a small number of turnaround aim cancels."


### PR DESCRIPTION
https://videos.maprando.com/video/9413

was bought up in the logic channel today by "quick10draw"

" I was surprised to find that I had gotten them early because my usual strategy for getting the right item is not included in the logic page.  The strat is rather simple:  Roll against the item stand while morphed, turn around in place while morphed, unmorph, then turn around to grab the item."

Not sure what, if anything to put in the "requires" section.

The stationary turnaround in morph has a 2 frame leniency for the direction change.