### PR TITLE
Add Spikesuits / Bluesuits to Red Firefleas

### DIFF
--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -950,6 +950,21 @@
     },
     {
       "link": [2, 2],
+      "name": "Short Shortcharge - Gain Flash Suit (Spikesuit)",
+      "requires": [
+          {"canShineCharge": {
+            "usedTiles": 13,
+            "openEnd": 0
+          }},
+        {"spikeHits": 1},
+        "canTrickySpikeSuit",
+        "h_spikeSuitSpikeHitLeniency",
+        {"shinespark": {"frames": 20, "excessFrames": 20}}
+      ],
+      "flashSuitChecked": true
+    },
+    {
+      "link": [2, 2],
       "name": "Come in Shinecharged, Gain Flash Suit (Spikesuit)",
       "entranceCondition": {
         "comeInShinecharged": {}


### PR DESCRIPTION
Videos:

Right Door:

https://videos.maprando.com/video/9430 - Come in shinecharged - Spikesuit 
https://videos.maprando.com/video/9431 - X-Mode Spikesuit 
https://videos.maprando.com/video/9433 - Come in Shinecharged - X-Mode Bluesuit 
https://videos.maprando.com/video/9436 - Double X-Mode Bluesuit

Right -> Left:

https://videos.maprando.com/video/9432 - Come in Shinecharged - Spikesuit 
https://videos.maprando.com/video/9434 - X-Mode Spikesuit 
https://videos.maprando.com/video/9435 - Come in Shine Charging - Spikesuit

Left Door:

https://videos.maprando.com/video/9437 - come in Shinecharged - Spikesuit 
https://videos.maprando.com/video/9438 - come in Shinecharged - X-Mode Bluesuit 
https://videos.maprando.com/video/9439 - X-Mode Spikesuit 
https://videos.maprando.com/video/9440 - Double X-Mode Bluesuit