### PR TITLE
Cosine Room R-Mode Spark Interrupt

### DIFF
--- a/region/norfair/crocomire/Cosine Room.json
+++ b/region/norfair/crocomire/Cosine Room.json
@@ -242,6 +242,7 @@
       },
       "requires": [
         {"refill": ["Energy"]},
+        "Morph",
         {"canShineCharge": {"usedTiles": 33, "gentleUpTiles": 8, "gentleDownTiles": 8, "steepUpTiles": 2, "steepDownTiles": 2, "openEnd": 0}},
         {"autoReserveTrigger": {}},
         "canRModeSparkInterrupt"


### PR DESCRIPTION
Something different I want to try for post-blue energy state when using respawning enemies - especially for fast/multiple respawns like Gamets (and could be applied to the Zoas in Maridia as well):

Normally I'd use `maxReserve 95` when an enemy can (and likely will) hit you during the reserve autofill. That same risk applies when getting hit by a Gamet to interrupt. But on the other hand, filling back up on the Gamets post-blue is free and easy. (There is also the option to dip toes in the acid - time it right and the reserve fill finishes during low tide. Acid damage does not occur during reserve autofill, nor does it "accumulate" like heat.)

Taking the `maxReserve` off, logically the strat would only assume filling up whatever the extra Gamet hits take.