### PR TITLE
Crocomire R-Mode Spark Interrupt

### DIFF
--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -591,7 +591,8 @@
       "blueSuitChecked": true,
       "note": [
         "Crystal Flash after entering. If Crocomire is alive, run to the left to avoid hitting him with the Power Bomb.",
-        "Use the acid or Crocmomire's swipe to interrupt."
+        "Use the acid or Crocmomire's swipe to interrupt.",
+        "Crocomire will always swipe the first time it is brought on camera."
       ]
     },
     {


### PR DESCRIPTION
Room notes:
- 30 missiles to farm croc feels low, considering the likely need to let Croc walk back and forth while farming. On the other hand, you can (likely will) farm missiles while doing so.
- Trying to farm using Supers seems super cursed considering the drop rate and, again, the need to let Croc walk back and forth. So I left that one out.
- Charge Beam farming has a `disableEquipment Plasma`. Disabling beams isn't something that normally gets called out but you definitely do not want to forget to switch off Plasma.
- CF can be done with croc alive or dead. Alive = shorter runway, damage with spikes, swipe for interrupt. Dead = full runway, acid dip interrupt.