### PR TITLE
Indiana Jones Room R-Mode Spark Interrupt

### DIFF
--- a/region/norfair/crocomire/Indiana Jones Room.json
+++ b/region/norfair/crocomire/Indiana Jones Room.json
@@ -463,20 +463,14 @@
         {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
         {"partialRefill": {"type": "ReserveEnergy", "limit": 20}},
         {"canShineCharge": {"usedTiles": 17, "openEnd": 0}},
-        {"or": [
-          {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-          {"and": [
-            {"autoReserveTrigger": {}},
-            {"acidFrames": 20}
-          ]}
-        ]},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Get past the speed blocks and farm the Mellas. Shinecharge while running back and use a Mella or the acid to interrupt.",
+        "Get past the speed blocks and farm the Mellas. Shinecharge while running back and use a Mella to interrupt.",
         "Getting past the blocks without Morph requires either an Insane Short Charge or an Acid Shinespark."
       ]
     },
@@ -1607,20 +1601,14 @@
         {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
         {"partialRefill": {"type": "ReserveEnergy", "limit": 20}},
         {"canShineCharge": {"usedTiles": 17, "openEnd": 0}},
-        {"or": [
-          {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-          {"and": [
-            {"autoReserveTrigger": {}},
-            {"acidFrames": 20}
-          ]}
-        ]},
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
         "canRModeSparkInterrupt"
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Farm the Mellas for energy, then run through the speed blocks, shinecharge, and use a Mella or the acid to interrupt."
+        "Farm the Mellas for energy, then run through the speed blocks, shinecharge, and use a Mella to interrupt."
       ]
     },
     {


### PR DESCRIPTION
Two strats from each door: one has no Power Bombs, the other can clear the PB blocks.

Must be separate due to tracking the "A" PB blocks obstacle.