### PR TITLE
Add canBufferedMomentumConservingTurnaround

### DIFF
--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1232,7 +1232,7 @@
         "canJumpIntoIBJ",
         "canTrickyJump",
         "canCrossRoomJumpIntoWater",
-        "canBufferedMomentumConservingTurnaround",
+        "canMomentumConservingTurnaround",
         {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}}
       ],
       "flashSuitChecked": true,
@@ -1258,6 +1258,41 @@
       ],
       "flashSuitChecked": true,
       "note": "Requires a runway of one tile in the adjacent room."
+    },
+    {
+      "link": [2, 3],
+      "name": "Cross Room Jump with HiJump and Speedbooster",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": true,
+          "minTiles": 1.4375
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canCrossRoomJumpIntoWater",
+        "canBufferedMomentumConservingTurnaround"
+      ],
+      "flashSuitChecked": true,
+      "note": "Requires a runway of two tiles in the adjacent room."
+    },
+    {
+      "link": [2, 3],
+      "name": "Cross Room Jump with HiJump (Lenient)",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": "any",
+          "minTiles": 5
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canCrossRoomJumpIntoWater",
+        "canBufferedMomentumConservingTurnaround",
+        "canDownGrab"
+      ],
+      "flashSuitChecked": true,
+      "note": "Requires a runway of five tiles in the adjacent room."
     },
     {
       "id": 48,
@@ -1357,10 +1392,11 @@
       "requires": [
         "canTrickySpringBallJump",
         "canCrossRoomJumpIntoWater",
-        "canBufferedMomentumConservingTurnaround"
+        "canMomentumConservingTurnaround"
       ],
       "flashSuitChecked": true,
-      "note": "Uses a runway of two tiles in the adjacent room."
+      "note": "Uses a runway of two tiles in the adjacent room.",
+      "devNote": "FIXME: Can be lowered to canBufferedMomentumConservingTurnaround."
     },
     {
       "id": 107,

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1253,7 +1253,7 @@
         "HiJump",
         "canTrickyJump",
         "canCrossRoomJumpIntoWater",
-        "canBufferedMomentumConservingTurnaround",
+        "canMomentumConservingTurnaround",
         "canDownGrab"
       ],
       "flashSuitChecked": true,

--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -1232,7 +1232,7 @@
         "canJumpIntoIBJ",
         "canTrickyJump",
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround",
+        "canBufferedMomentumConservingTurnaround",
         {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}}
       ],
       "flashSuitChecked": true,
@@ -1253,7 +1253,7 @@
         "HiJump",
         "canTrickyJump",
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround",
+        "canBufferedMomentumConservingTurnaround",
         "canDownGrab"
       ],
       "flashSuitChecked": true,
@@ -1272,7 +1272,7 @@
       "requires": [
         "canTrickyDashJump",
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround",
+        "canBufferedMomentumConservingTurnaround",
         "canDownGrab"
       ],
       "flashSuitChecked": true,
@@ -1291,7 +1291,7 @@
       "requires": [
         "canPreciseSpaceJump",
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround"
+        "canBufferedMomentumConservingTurnaround"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -1313,7 +1313,7 @@
         "canPreciseSpaceJump",
         "canInsaneJump",
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround",
+        "canBufferedMomentumConservingTurnaround",
         "canDownGrab"
       ],
       "flashSuitChecked": false,
@@ -1357,7 +1357,7 @@
       "requires": [
         "canTrickySpringBallJump",
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround"
+        "canBufferedMomentumConservingTurnaround"
       ],
       "flashSuitChecked": true,
       "note": "Uses a runway of two tiles in the adjacent room."

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -817,6 +817,23 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 4],
+      "name": "Cross Room Jump with HiJump (Lenient)",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": "any",
+          "minTiles": 2
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canCrossRoomJumpIntoWater",
+        "canBufferedMomentumConservingTurnaround"
+      ],
+      "flashSuitChecked": true,
+      "note": "Only requires a runway of approximately 2 tile in the adjacent room."
+    },
+    {
       "id": 20,
       "link": [1, 4],
       "name": "Cross Room Jump with HiJump",
@@ -830,7 +847,7 @@
         "HiJump",
         "canTrickyJump",
         "canCrossRoomJumpIntoWater",
-        "canBufferedMomentumConservingTurnaround"
+        "canMomentumConservingTurnaround"
       ],
       "flashSuitChecked": true,
       "note": "Only requires a runway of approximately 1 tile in the adjacent room.",

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -830,7 +830,7 @@
         "HiJump",
         "canTrickyJump",
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround"
+        "canBufferedMomentumConservingTurnaround"
       ],
       "flashSuitChecked": true,
       "note": "Only requires a runway of approximately 1 tile in the adjacent room.",
@@ -848,7 +848,7 @@
       },
       "requires": [
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround",
+        "canBufferedMomentumConservingTurnaround",
         "canTrickyDashJump",
         "canDownGrab"
       ],
@@ -871,7 +871,7 @@
       },
       "requires": [
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround"
+        "canBufferedMomentumConservingTurnaround"
       ],
       "flashSuitChecked": true,
       "note": "Requires around 19 tiles in the adjacent room.",
@@ -894,7 +894,7 @@
         "canTrickyDashJump",
         "canSpringBallJumpMidAir",
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround"
+        "canBufferedMomentumConservingTurnaround"
       ],
       "flashSuitChecked": true,
       "note": [
@@ -960,7 +960,7 @@
       },
       "requires": [
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround"
+        "canBufferedMomentumConservingTurnaround"
       ],
       "flashSuitChecked": true,
       "devNote": [

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -1116,7 +1116,8 @@
           {"and": [
             "canDoubleBombJump",
             {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 2}}
-          ]}
+          ]},
+          {"enemyDamage": {"enemy": "Mochtroid", "type": "contact", "hits": 3}}
         ]},
         "canCrossRoomJumpIntoWater",
         "canBufferedMomentumConservingTurnaround",
@@ -1127,7 +1128,10 @@
         "Only requires a runway of approximately 1 tile in the adjacent room.",
         "Take two Mochtroid hits or kill it using a Power Bomb or 5 Bombs."
       ],
-      "devNote": "The rhythm for placing 4 Bombs quickly is the main component of ceiling bomb jumps."
+      "devNote": [
+        "The rhythm for placing 4 Bombs quickly is the main component of ceiling bomb jumps.",
+        "canTrickyJump for the IBJ more than the through-door jump."
+      ]
     },
     {
       "id": 190,

--- a/region/maridia/inner-pink/Halfie Climb Room.json
+++ b/region/maridia/inner-pink/Halfie Climb Room.json
@@ -1119,7 +1119,7 @@
           ]}
         ]},
         "canCrossRoomJumpIntoWater",
-        "canMomentumConservingTurnaround",
+        "canBufferedMomentumConservingTurnaround",
         "canTrickyJump"
       ],
       "flashSuitChecked": true,
@@ -2551,7 +2551,7 @@
       },
       "requires": [
         "HiJump",
-        "canMomentumConservingTurnaround",
+        "canBufferedMomentumConservingTurnaround",
         "canTrickySpringBallJump",
         "canCrossRoomJumpIntoWater"
       ],

--- a/region/maridia/inner-pink/The Precious Room.json
+++ b/region/maridia/inner-pink/The Precious Room.json
@@ -321,6 +321,25 @@
       ]
     },
     {
+      "link": [2, 1],
+      "name": "Cross Room Jump with HiJump (Lenient)",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": "any",
+          "minTiles": 2
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canCrossRoomJumpIntoWater",
+        "canBufferedMomentumConservingTurnaround"
+      ],
+      "flashSuitChecked": true,
+      "note": [
+        "Requires a runway of 2 tiles in the adjacent room."
+      ]
+    },
+    {
       "id": 18,
       "link": [2, 1],
       "name": "Cross Room Jump with HiJump",

--- a/region/maridia/inner-yellow/Yoink Room.json
+++ b/region/maridia/inner-yellow/Yoink Room.json
@@ -347,7 +347,7 @@
       },
       "requires": [
         "canShinechargeMovementTricky",
-        "canMomentumConservingTurnaround",
+        "canQuickDrop",
         {"or": [
           {"and": [
             "Gravity",
@@ -378,7 +378,7 @@
       },
       "requires": [
         "canShinechargeMovementTricky",
-        "canMomentumConservingTurnaround",
+        "canQuickDrop",
         {"shineChargeFrames": 40}
       ],
       "exitCondition": {
@@ -1108,7 +1108,7 @@
       },
       "requires": [
         "canShinechargeMovementTricky",
-        "canMomentumConservingTurnaround",
+        "canQuickDrop",
         {"or": [
           {"and": [
             "Gravity",
@@ -1139,7 +1139,7 @@
       },
       "requires": [
         "canShinechargeMovementTricky",
-        "canMomentumConservingTurnaround",
+        "canQuickDrop",
         {"shineChargeFrames": 40}
       ],
       "exitCondition": {

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -630,9 +630,13 @@
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
       "flashSuitChecked": true,
-      "note": "Requires a runway of at least 6 tiles in the adjacent room.",
-      "devNote": [
-        "Using more run speed to avoid the momentumConservingTurnaround requirement will bonk the door, requiring a turnaround to get through"
+      "note": [
+        "Requires a runway of at least 6 tiles in the adjacent room."
+      ],
+      "detailNote": [
+        "Using too much run speed can make it harder to avoid bonking the door:",
+        "in this case, it can help to fire a hero shot to open the door early, while still facing left,",
+        "and/or use a momentum-conserving turnaround just before touching the door."
       ]
     },
     {

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -608,6 +608,34 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 4],
+      "name": "Cross Room Jump with HiJump and Speedbooster (Lenient)",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": true,
+          "minTiles": 6
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canCrossRoomJumpIntoWater",
+        "canBufferedMomentumConservingTurnaround",
+        "h_midAirShootUp"
+      ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "note": "Requires a runway of at least 6 tiles in the adjacent room.",
+      "devNote": [
+        "Using more run speed to avoid the momentumConservingTurnaround requirement will bonk the door, requiring a turnaround to get through"
+      ]
+    },
+    {
       "id": 10,
       "link": [1, 4],
       "name": "Cross Room Jump with HiJump and Speedbooster",
@@ -1072,6 +1100,23 @@
       ],
       "flashSuitChecked": true,
       "note": "Requires 3 tiles of run speed (with no open end) to make it past the overhang above the door."
+    },
+    {
+      "link": [1, 5],
+      "name": "Cross Room Jump with HiJump and Speedbooster (Lenient)",
+      "entranceCondition": {
+        "comeInJumping": {
+          "speedBooster": true,
+          "minTiles": 6
+        }
+      },
+      "requires": [
+        "HiJump",
+        "canCrossRoomJumpIntoWater",
+        "canBufferedMomentumConservingTurnaround"
+      ],
+      "flashSuitChecked": true,
+      "note": "Requires a runway of at least 6 tiles in the adjacent room."
     },
     {
       "id": 19,

--- a/tech.json
+++ b/tech.json
@@ -719,26 +719,42 @@
           ]
         },
         {
-          "id": 180,
-          "name": "canMomentumConservingTurnaround",
+          "name": "canBufferedMomentumConservingTurnaround",
           "techRequires": [],
           "otherRequires": [],
           "note": [
             "Uses the uninteruptable frames of turning around in order to continue moving after hitting a solid object.",
-            "Can be used to make it through an opening door, or barely just past a ledge.",
-            "It is often beneficial to be in a downward pose when hitting the ceiling, in order to shrink Samus' hitbox to delay contact."
+            "This is easiest to see following a Gravity jump through a door transition.",
+            "During the transition, hold down and backwards to begin the turnaround action.",
+            "Water physics will delay the turnaround for long enough to continue past overhead ledges with upwards momentum intact."
           ],
           "extensionTechs": [
             {
-              "id": 47,
-              "name": "canQuickDrop",
+              "id": 180,
+              "name": "canMomentumConservingTurnaround",
               "techRequires": [
-                "canMomentumConservingTurnaround"
+                "canBufferedMomentumConservingTurnaround"
               ],
               "otherRequires": [],
               "note": [
-                "Using a momentum conserving turnaround on a crumble block, an opening doorshell, or any other breaking block, to preserve Samus' momentum.",
-                "This is often used when traversing with a shinecharge, or to quickly fall through a crumble block and jump back through it before it re-forms."
+                "Uses the uninteruptable frames of turning around in order to continue moving after hitting a solid object.",
+                "Can be used to make it through an opening door, or barely just past a ledge.",
+                "It is often beneficial to be in a downward pose when hitting the ceiling, in order to shrink Samus' hitbox to delay contact.",
+                "The difficulty is in judging the timing of the turnaround, predicting the ending position, and adjusting to movement speed."
+              ],
+              "extensionTechs": [
+                {
+                  "id": 47,
+                  "name": "canQuickDrop",
+                  "techRequires": [
+                    "canMomentumConservingTurnaround"
+                  ],
+                  "otherRequires": [],
+                  "note": [
+                    "Using a momentum conserving turnaround on a crumble block, an opening doorshell, or any other breaking block, to preserve Samus' momentum.",
+                    "This is often used when traversing with a shinecharge, or to quickly fall through a crumble block and jump back through it before it re-forms."
+                  ]
+                }
               ]
             }
           ]


### PR DESCRIPTION
The side platforms looked like there was a strong chance you wanted to turn before the transition.

I'm targetting Hard with this tech, so no trickyJump for the bottom frame jump.  In most cases, if you can trickyJump the door then you can handle the unbuffered turnaround.