### PR TITLE
Tweak to Cathedral R->L PB option

### DIFF
--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -408,7 +408,10 @@
         "canFarmWhileShooting",
         "canTrickyJump",
         {"or": [
-          "h_usePowerBomb",
+          {"and": [
+            "h_usePowerBomb",
+            {"heatFrames": 60}
+          ]},
           "Spazer",
           "Plasma",
           "Wave"


### PR DESCRIPTION
A quick follow-up to #2520. It may be that I'm missing something, but it seemed that the PB option right-to-left wasn't possible with the given heat frames. This was around the best I could get: https://videos.maprando.com/video/9464. The detour for 2 more drops didn't seem to help much unless it is 2 big energy, which wouldn't be reliable.