### PR TITLE
Metroid Eat Ammo

### DIFF
--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -36,6 +36,9 @@
       ],
       "mapTileMask": [
         [2, 2, 2, 1, 1, 1]
+      ],
+      "devNote": [
+        "FIXME: Add doorunlock requirements on strats that get grabbed by metroids."
       ]
     },
     {
@@ -48,6 +51,9 @@
       "doorEnvironments": [{"physics": "air"}],
       "mapTileMask": [
         [1, 1, 1, 2, 2, 2]
+      ],
+      "devNote": [
+        "FIXME: Add doorunlock requirements on strats that get grabbed by metroids."
       ]
     }
   ],

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -332,6 +332,18 @@
       "requires": [
         {"metroidFrames": 80}
       ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [
+          {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}}
+        ]},
+        {"types": ["super"], "requires": [
+          {"metroidFrames": 15}
+        ]},
+        {"types": ["powerbomb"], "requires": []}
+      ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
       "flashSuitChecked": true
     },
     {
@@ -588,6 +600,24 @@
       "requires": [
         {"metroidFrames": 180}
       ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [
+          {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
+          {"ammo": {"type":"Missile", "count": 2}}
+        ]},
+        {"types": ["super"], "requires": [
+          {"or": [
+            {"ammo": {"type": "Super", "count": 1}},
+            "canDodgeWhileShooting"
+          ]}
+        ]},
+        {"types": ["powerbomb"], "requires": [
+          {"metroidFrames": 25}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
       "flashSuitChecked": true
     },
     {

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -588,7 +588,24 @@
       "requires": [
         {"metroidFrames": 670}
       ],
-      "flashSuitChecked": true
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [
+          {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
+          {"ammo": {"type":"Missile", "count": 2}}
+        ]},
+        {"types": ["super"], "requires": [
+            {"metroidFrames": 15},
+            {"ammo": {"type": "Super", "count": 1}}
+        ]},
+        {"types": ["powerbomb"], "requires": []}
+      ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
+      "flashSuitChecked": true,
+      "devNote": [
+        "PB at door is energy neutral."
+      ]
     },
     {
       "id": 25,
@@ -752,6 +769,24 @@
       "requires": [
         {"metroidFrames": 600}
       ],
+      "unlocksDoors": [
+        {"types": ["missiles"], "requires": [
+          {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
+          {"ammo": {"type":"Missile", "count": 2}}
+        ]},
+        {"types": ["super"], "requires": [
+          {"or": [
+            {"ammo": {"type": "Super", "count": 1}},
+            "canDodgeWhileShooting"
+          ]}
+        ]},
+        {"types": ["powerbomb"], "requires": [
+          {"metroidFrames": 25}
+        ]}
+      ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
       "flashSuitChecked": true
     },
     {

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -580,8 +580,8 @@
         ]}
       ],
       "unlocksDoors": [
-        {"nodeId": 2, "types": ["missiles"], "requires": ["canDodgeWhileShooting", {"metroidFrames": 50}]},
-        {"nodeId": 2, "types": ["super"], "requires": [
+        {"nodeId": 1, "types": ["missiles"], "requires": ["canDodgeWhileShooting", {"metroidFrames": 50}]},
+        {"nodeId": 1, "types": ["super"], "requires": [
           {"or": [
             {"and": [
               "canDodgeWhileShooting",

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -357,21 +357,31 @@
       "link": [1, 2],
       "name": "Tank the Damage",
       "requires": [
-        {"metroidFrames": 240},
-        {"or": [
-          "Plasma",
-          "Wave",
-          "canDodgeWhileShooting"
-        ]}
+        {"metroidFrames": 240}
       ],
       "flashSuitChecked": true,
       "unlocksDoors": [
-        {"nodeId": 2, "types": ["missiles"], "requires": ["canDodgeWhileShooting", {"metroidFrames": 50}]},
-        {"nodeId": 2, "types": ["super"], "requires": ["canTrickyJump", {"metroidFrames": 50}]}
+        {"types": ["missiles"], "requires": [
+          {"ammo": {"type": "Missile", "count": 1}},
+          {"metroidFrames": 50}
+        ]},
+        {"types": ["super"], "requires": [
+          "canTrickyJump",
+          {"metroidFrames": 50}
+        ]},
+        {"types": ["powerbomb"], "requires": [
+          {"metroidFrames": 50}
+        ]}
       ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
       "note": [
         "Taking a rinka hit stops the Metroid damage for a while and is less damage.",
         "Note that angle-down shots with a Metroid on Samus are unreliable, so it is recommended to jump and shoot down to open the door."
+      ],
+      "devNote": [
+        "Power Bombs negate some of the damage taken while waiting for the door to unlock."
       ]
     },
     {
@@ -572,28 +582,27 @@
       "name": "Tank the Damage",
       "requires": [
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
-        {"metroidFrames": 256},
-        {"or": [
-          "Plasma",
-          "Wave",
-          "canDodgeWhileShooting"
-        ]}
+        {"metroidFrames": 256}
       ],
       "unlocksDoors": [
-        {"nodeId": 1, "types": ["missiles"], "requires": ["canDodgeWhileShooting", {"metroidFrames": 50}]},
-        {"nodeId": 1, "types": ["super"], "requires": [
-          {"or": [
-            {"and": [
-              "canDodgeWhileShooting",
-              {"ammo": {"type": "Super", "count": 1}}
-            ]},
-            "canTrickyJump"
-          ]}
-        ]}
+        {"types": ["missiles"], "requires": [
+          {"metroidFrames": 50},
+          {"ammo": {"type":"Missile", "count": 2}}
+        ]},
+        {"types": ["super"], "requires": [
+            {"ammo": {"type": "Super", "count": 1}}
+        ]},
+        {"types": ["powerbomb"], "requires": []}
       ],
+      "exitCondition": {
+        "leaveNormally": {}
+      },
       "flashSuitChecked": true,
       "note": "Taking a rinka hit stops the Metroid damage for a while and is less damage.",
-      "devNote": "Avoiding Rinkas is more difficult than getting hit, so it is not important to know to want to get hit."
+      "devNote": [
+        "Avoiding Rinkas is more difficult than getting hit, so it is not important to know to want to get hit.",
+        "Opening a door with a Power Bomb is energy neutral since you can place it early."
+      ]
     },
     {
       "id": 27,

--- a/region/tourian/main/Metroid Room 4.json
+++ b/region/tourian/main/Metroid Room 4.json
@@ -357,9 +357,18 @@
       "link": [1, 2],
       "name": "Tank the Damage",
       "requires": [
-        {"metroidFrames": 240}
+        {"metroidFrames": 240},
+        {"or": [
+          "Plasma",
+          "Wave",
+          "canDodgeWhileShooting"
+        ]}
       ],
       "flashSuitChecked": true,
+      "unlocksDoors": [
+        {"nodeId": 2, "types": ["missiles"], "requires": ["canDodgeWhileShooting", {"metroidFrames": 50}]},
+        {"nodeId": 2, "types": ["super"], "requires": ["canTrickyJump", {"metroidFrames": 50}]}
+      ],
       "note": [
         "Taking a rinka hit stops the Metroid damage for a while and is less damage.",
         "Note that angle-down shots with a Metroid on Samus are unreliable, so it is recommended to jump and shoot down to open the door."
@@ -563,7 +572,24 @@
       "name": "Tank the Damage",
       "requires": [
         {"enemyDamage": {"enemy": "Rinka", "type": "contact", "hits": 1}},
-        {"metroidFrames": 256}
+        {"metroidFrames": 256},
+        {"or": [
+          "Plasma",
+          "Wave",
+          "canDodgeWhileShooting"
+        ]}
+      ],
+      "unlocksDoors": [
+        {"nodeId": 2, "types": ["missiles"], "requires": ["canDodgeWhileShooting", {"metroidFrames": 50}]},
+        {"nodeId": 2, "types": ["super"], "requires": [
+          {"or": [
+            {"and": [
+              "canDodgeWhileShooting",
+              {"ammo": {"type": "Super", "count": 1}}
+            ]},
+            "canTrickyJump"
+          ]}
+        ]}
       ],
       "flashSuitChecked": true,
       "note": "Taking a rinka hit stops the Metroid damage for a while and is less damage.",


### PR DESCRIPTION
I want to put logic on shooting a door with metroids attached.  I'm not sure if this works as I want.  
- I want these unlockdoors requirements added on top of any ammo costs, and for logic to not reach the door but use a different door unlock strat.
- Beam doors are on their own whereto you would swap from plasma to spazer.