### PR TITLE
Crocomire Escape R-Mode Spark Interrupt

### DIFF
--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -722,10 +722,15 @@
           "h_heatedCrystalFlashForReserveEnergy",
           {"and": [
             "h_RModeCanRefillReserves",
-            {"enemyKill": {"enemies": [["Dragon"], ["Dragon"], ["Dragon"], ["Dragon"], ["Dragon"], ["Geruta"]]}},
             {"or": [
-              "h_lavaProof",
-              "Grapple"
+              {"and": [
+                {"enemyKill": {"enemies": [["Dragon"], ["Dragon"], ["Dragon"], ["Dragon"], ["Dragon"]], "explicitWeapons": ["Missile", "Super", "Charge", "Plasma"]}},
+                "Grapple"
+              ]},
+              {"and": [
+                {"enemyKill": {"enemies": [["Dragon"], ["Dragon"], ["Dragon"], ["Dragon"], ["Dragon"]]}},
+                "h_lavaProof"
+              ]}
             ]},
             {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
           ]}


### PR DESCRIPTION
Just a right-side strat here for now. An open-gate strat only gets one, maybe two more tiles.

Candidate room for a Combined Direct + Indirect G-Mode variant for despawning the gate.