### PR TITLE
Ice Beam Gate Room R-Mode Spark Interrupt

### DIFF
--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -163,7 +163,8 @@
       "from": 1,
       "to": [
         {"id": 1},
-        {"id": 5}
+        {"id": 5},
+        {"id": 7}
       ]
     },
     {
@@ -383,6 +384,37 @@
       },
       "requires": [],
       "flashSuitChecked": true
+    },
+    {
+      "link": [1, 7],
+      "name": "R-Mode Spark Interrupt",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_usePowerBomb",
+            "h_RModeCanRefillReserves",
+            {"or": [
+              {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+              {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 1}]}
+            ]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        "h_shinechargeMaxRunway",
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "clearsObstacles": ["A", "B", "C", "D"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm the enemies on the bottom - the first Sm. Dessgeega will give back the Power Bomb used to get down.",
+        "Shinecharge and use any enemy at the bottom to interrupt."
+      ]
     },
     {
       "id": 6,
@@ -761,6 +793,37 @@
       "flashSuitChecked": true
     },
     {
+      "link": [2, 7],
+      "name": "R-Mode Spark Interrupt",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_usePowerBomb",
+            "h_RModeCanRefillReserves",
+            {"or": [
+              {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+              {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 1}]}
+            ]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        "h_shinechargeMaxRunway",
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "clearsObstacles": ["C", "D"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm the enemies on the bottom - the first Sm. Dessgeega will give back the Power Bomb used to get down.",
+        "Shinecharge and use any enemy at the bottom to interrupt."
+      ]
+    },
+    {
       "id": 26,
       "link": [2, 7],
       "name": "Stored Moonfall Clip",
@@ -1038,6 +1101,40 @@
         "Avoiding damage from all enemies with just Power Beam is tricky, but doable.",
         "Enter the room holding angle to remove momentum and avoid getting hit by the Dessgeega.",
         "Crouch to fire the first two shots, stand for the next two shots, then crouch again for the final two shots."
+      ]
+    },
+    {
+      "link": [3, 7],
+      "name": "R-Mode Spark Interrupt",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        {"or": [
+          {"enemyDamage": {"enemy": "Sm. Dessgeega", "type": "contact", "hits": 1}},
+          {"enemyKill": {"enemies": [["Sm. Dessgeega"]], "explicitWeapons": ["Missile", "Super"]}}
+        ]},
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"or": [
+              {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+              {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 1}]}
+            ]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        "h_shinechargeMaxRunway",
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "clearsObstacles": ["D"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Kill or run past an enemy before attempting to Crystal Flash, or farm the Sm. Dessgeegas and Mellas.",
+        "Shinecharge and use any enemy at the bottom to interrupt."
       ]
     },
     {
@@ -1393,6 +1490,38 @@
       "resetsObstacles": ["C", "D"],
       "farmCycleDrops": [{"enemy": "Sova", "count": 1}],
       "flashSuitChecked": true
+    },
+    {
+      "link": [4, 7],
+      "name": "R-Mode Spark Interrupt",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        "h_speedDash",
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_usePowerBomb",
+            "h_RModeCanRefillReserves",
+            {"or": [
+              {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
+              {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 1}]}
+            ]},
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        "h_shinechargeMaxRunway",
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "clearsObstacles": ["C", "D"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm the enemies on the bottom - the first Sm. Dessgeega will give back the Power Bomb used to get down.",
+        "Shinecharge and use any enemy at the bottom to interrupt."
+      ]
     },
     {
       "id": 48,


### PR DESCRIPTION
Farming uses just the Mellas and Sm. Dessgeegas below. The Sova could be used but isn't needed.

Only [3] can avoid needing to use any Power Bombs.