### PR TITLE
Big Boy Spark Interrupt

### DIFF
--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -443,6 +443,8 @@
         "comeInNormally": {}
       },
       "requires": [
+        "canShinechargeMovementTricky",
+        {"notable": "Baby Drain Spark Interrupt"},
         {"or": [
           {"resourceAvailable": [{"type": "Energy", "count": 799}]},
           {"and": [
@@ -770,8 +772,17 @@
         "Then jump towards the transition and touch it with a walljump check.",
         "A clockwise setup is more difficult to clear the seaweed, but can jump directly into the transition."
       ]
+    },
+    {
+      "id": 3,
+      "name": "Baby Drain Spark Interrupt",
+      "note": [
+        "Gain blue suit by interrupting a shinespark windup due to being drained by the Baby Metroid.",
+        "The shinecharge can be gained in a shorter distance than usual due to the slowed movement while being drained.",
+        "A large amount of energy is needed to have enough time to shinecharge and begin windup before reaching 01 energy."
+      ]
     }
   ],
   "nextStratId": 38,
-  "nextNotableId": 3
+  "nextNotableId": 4
 }


### PR DESCRIPTION
This might want a notable for the classic Big Boy non-R-Mode.

There's also the technical possibility of a true r-mode spark by combining goo/metroid slowdown to be able to shinecharge and using the big sidehopper during its brief existence.