### PR TITLE
Metroid Room 1 R-Mode Spark Interrupt

### DIFF
--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -1742,7 +1742,13 @@
       "requires": [
         {"obstaclesCleared": ["R-Mode"]},
         {"or": [
-          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_CrystalFlashForReserveEnergy",
+            {"or": [
+              "canInsaneJump",
+              "f_KilledMetroidRoom1"
+            ]}
+          ]},
           {"and": [
             "canRiskPermanentLossOfAccess",
             {"not": "f_KilledMetroidRoom1"},


### PR DESCRIPTION
Ruled out Power Bomb kill farming due to poor drop rate and the Rinka effect likely resulting in killing all four.