### PR TITLE
Edit Medium notables

### DIFF
--- a/region/maridia/inner-pink/Botwoon Hallway.json
+++ b/region/maridia/inner-pink/Botwoon Hallway.json
@@ -296,6 +296,11 @@
         "canUseFrozenEnemies",
         {"disableEquipment": "Gravity"},
         {"or": [
+          "Gravity",
+          "HiJump",
+          "canTrickyUseFrozenEnemies"
+        ]},
+        {"or": [
           "canTrickyJump",
           {"and": [
             "canDodgeWhileShooting",

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -593,7 +593,12 @@
         "Wave",
         {"or": [
           "canDodgeWhileShooting",
-          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}}
+          "Plasma",
+          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}},
+          {"and": [
+            "Spazer",
+            {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
+          ]}
         ]}
       ],
       "setsFlags": ["f_DefeatedBotwoon"],
@@ -613,10 +618,24 @@
         "canSuitlessMaridia",
         "Charge",
         "Wave",
-        "canDodgeWhileShooting",
         {"or": [
-          "Morph",
-          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}}
+          {"and": [
+            "canDodgeWhileShooting",
+            "Morph"
+          ]},
+          {"and": [
+            "canDodgeWhileShooting",
+            {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}}
+          ]},
+          {"and": [
+            "Plasma",
+            {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
+          ]},
+          {"and": [
+            "Spazer",
+            {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 4}}
+          ]},
+          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 6}}
         ]}
       ],
       "setsFlags": ["f_DefeatedBotwoon"],

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -679,13 +679,12 @@
       "name": "Walljump Climb Using the Kamer",
       "requires": [
         {"notable": "Walljump Climb Using the Kamer"},
-        "canPreciseWalljump",
+        "canTrickyWalljump",
         "canConsecutiveWalljump",
         "canUseEnemies",
         {"or": [
-          {"heatFrames": 560},
           {"and": [
-            "canTrickyWalljump",
+            "canDodgeWhileShooting",
             {"heatFrames": 360}
           ]},
           {"and": [
@@ -720,12 +719,28 @@
         {"notable": "Walljump Climb Using the Kamer"},
         "HiJump",
         "canUseEnemies",
-        "canWalljump",
+        "canPreciseWalljump",
         {"or": [
           {"heatFrames": 360},
           {"and": [
-            "canCarefulJump",
-            {"heatFrames": 250}
+            "canTrickyJump",
+            {"heatFrames": 230}
+          ]}
+        ]},
+        {"or": [
+          "canDodgeWhileShooting",
+          {"enemyDamage": {"enemy": "Fune", "type": "fireball", "hits": 1}},
+          {"and": [
+            "canUseFrozenEnemies",
+            {"heatFrames": 70}
+          ]},
+          {"and": [
+            {"ammo": {"type": "Super", "count": 1}},
+            {"heatFrames": 70}
+          ]},
+          {"and": [
+            {"ammo": {"type": "PowerBomb", "count": 1}},
+            {"heatFrames": 90}
           ]}
         ]}
       ],


### PR DESCRIPTION
Went through your list of Medium notables to edit. I think these are all still ok in Medium after these changes.

In Medium:
Botwoon Hallway -> needs an easier way to grab the upper Mochtroid 
Botwoon -> allow suitless with damage, reduce damage with more beams 
Double Chamber -> needs HiJump, kill the Fune or take a fireball hit