### PR TITLE
Attic R-Mode Spark Interrupt

### DIFF
--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -1126,7 +1126,8 @@
       "link": [2, 2],
       "name": "R-Mode Spark Interrupt",
       "entranceCondition": {
-        "comeInWithRMode": {}
+        "comeInWithRMode": {},
+        "comesThroughToilet": "no"
       },
       "requires": [
         {"or": [


### PR DESCRIPTION
All tech/movement/ammo needs are mainly for Power On. Power Off will require them in order to avoid `canRiskPermanentLossOfAccess`.