### PR TITLE
Basement R-Mode Spark Interrupt

### DIFF
--- a/region/wreckedship/main/Basement.json
+++ b/region/wreckedship/main/Basement.json
@@ -365,6 +365,31 @@
       "flashSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "R-Mode Spark Interrupt",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        "f_DefeatedPhantoon",
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        "h_shinechargeMaxRunway",
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm atomics and push the robots apart to open up the runway. Use an Atomic to interrupt."
+      ]
+    },
+    {
       "id": 55,
       "link": [1, 2],
       "name": "G-Mode Atomic Ice Clip, Door Lock Skip",
@@ -640,6 +665,32 @@
       },
       "flashSuitChecked": true,
       "devNote": "We could add another jumpway (or two) for the long platform below but it does not yet seem to have an application."
+    },
+    {
+      "link": [2, 2],
+      "name": "R-Mode Spark Interrupt",
+      "entranceCondition": {
+        "comeInWithRMode": {},
+        "comesThroughToilet": "no"
+      },
+      "requires": [
+        "f_DefeatedPhantoon",
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_RModeCanRefillReserves",
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        "h_shinechargeMaxRunway",
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm atomics and push the robots apart to open up the runway. Use an Atomic to interrupt."
+      ]
     },
     {
       "id": 24,
@@ -1049,6 +1100,33 @@
       "flashSuitChecked": true,
       "note": ["Bounce directly into the morph tunnel."],
       "detailNote": ["This version allows preserving a flash suit."]
+    },
+    {
+      "link": [3, 2],
+      "name": "R-Mode Spark Interrupt",
+      "entranceCondition": {
+        "comeInWithRMode": {}
+      },
+      "requires": [
+        "f_DefeatedPhantoon",
+        {"or": [
+          "h_CrystalFlashForReserveEnergy",
+          {"and": [
+            "h_bombThings",
+            "h_RModeCanRefillReserves",
+            {"partialRefill": {"type": "ReserveEnergy", "limit": 20}}
+          ]}
+        ]},
+        "h_shinechargeMaxRunway",
+        {"autoReserveTrigger": {"maxReserveEnergy": 95}},
+        "canRModeSparkInterrupt"
+      ],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Farm atomics and push the robots apart to open up the runway. Use an Atomic to interrupt."
+      ]
     },
     {
       "id": 44,


### PR DESCRIPTION
Power On only (no Coverns).

Robot shots seem too sporadic to time the shinecharge reliably.