### PR TITLE
Wrecked Ship East Super R-Mode Spark Interrupt

### DIFF
--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -714,10 +714,7 @@
       "requires": [
         {"obstaclesCleared": ["R-Mode"]},
         {"or": [
-          {"and": [
-            "h_CrystalFlashForReserveEnergy",
-            "canTrickyDodgeEnemies"
-          ]},
+          "h_CrystalFlashForReserveEnergy",
           {"and": [
             "h_RModeCanRefillReserves",
             {"enemyKill": {"enemies": [["Bull", "Bull"]], "excludedWeapons": ["PowerBomb"]}},
@@ -733,14 +730,14 @@
           ]}
         ]},
         {"autoReserveTrigger": {"maxReserveEnergy": 95}},
-        "canRModeSparkInterrupt"
+        "canRModePauseAbuseSparkInterrupt"
       ],
       "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
         "Power Off: Farm using Coverns or trapped Atomics. Use any conveyor belt to shinecharge and then use the next Covern spawn to interrupt.",
-        "Power On: Kill one Bull for energy. Run against a conveyor belt direction to shinecharge, and then use the other Bull to interrupt."
+        "Power On: Kill the Bulls for energy. Run against a conveyor belt direction to shinecharge, and then use the spikes to pause abuse and interrupt."
       ]
     },
     {


### PR DESCRIPTION
This also corrects the R-Mode Stand-up Clip use of obstacle, and correctly calls an `autoReserveTrigger` for energy tracking.

For the spark interrupt itself: it takes some manipulation, but it is possible to Crystal Flash and kill only one Bull, avoiding the need to make the strat a Pause Abuse one.