### PR TITLE
Wrecked Ship Energy Tank R-Mode Spark Interrupt

### DIFF
--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -174,7 +174,6 @@
         "comeInWithRMode": {}
       },
       "requires": [
-        "f_DefeatedPhantoon",
         {"or": [
           "Gravity",
           {"and": [


### PR DESCRIPTION
`canBeLucky` note: 60% chance for energy from one Skultera. Overall 30% to get 20 energy from both.