### PR TITLE
early supers room - add gmode overload plms to top juction strats.

### DIFF
--- a/region/brinstar/green/Early Supers Room.json
+++ b/region/brinstar/green/Early Supers Room.json
@@ -163,6 +163,7 @@
       "requires": [
         {"or": [
           "canWalljump",
+          "SpaceJump",
           {"and": [
             "HiJump",
             "canTrickyUseFrozenEnemies"


### PR DESCRIPTION
Maybe a candidate for can be lucky? I noticed Kyle left a comment on Sams videos to say the global wavers might hit you (i tried it half a dozen times without issue).

The strats could also be useful for carrying a bluesuit across this room where you cannot dash.

https://videos.maprando.com/video/9531 [bluesuit with walljump]
https://videos.maprando.com/video/9530 [bluesuit gmode morph blind ibj]

https://videos.maprando.com/video/5205 [with walljump]
https://videos.maprando.com/video/5206 [with ice and hijump]