### PR TITLE
Colosseum R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-pink/Colosseum.json
+++ b/region/maridia/inner-pink/Colosseum.json
@@ -228,10 +228,8 @@
       "requires": [
         "canTrickyUseFrozenEnemies",
         {"or": [
-          "Spazer",
-          "Wave",
-          "Plasma",
-          "canTrickyDodgeEnemies"
+          {"enemyKill": {"enemies": [["Mochtroid", "Mochtroid"]], "excludedWeapons": ["PowerBeam", "Ice", "Bombs"]}},
+          "canInsaneJump"
         ]},
         "canPlayInSand",
         {"or": [


### PR DESCRIPTION
Frozen mochtroid is so far the only reliable setup for the X-Mode shinecharge. All variants need to get back out of the water, so traversing the room (and thus farming all 8 Mochtroids) is free.

Left door needs a fast beam or a quick evade to not get instantly eaten by a Mochtroid due to X-Ray cooldown.