### PR TITLE
East Cactus Alley R-Mode Spark Interrupt

### DIFF
--- a/region/maridia/inner-pink/East Cactus Alley.json
+++ b/region/maridia/inner-pink/East Cactus Alley.json
@@ -794,16 +794,16 @@
         "canXMode",
         "h_XModeSpikeHit",
         "h_shinechargeMaxRunway",
-        "canNeutralDamageBoost",
         {"autoReserveTrigger": {}},
-        "canRModePauseAbuseSparkInterrupt"
+        "canRModePauseAbuseSparkInterrupt",
+        {"spikeHits": 1}
       ],
       "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
         "Crystal Flash at the door, and enter X-Mode on the spikes and shinecharge.",
-        "Pause abuse on the spikes: land on the spike three tiles from the ledge and face left to neutral damage boost back to safety before the pause."
+        "Pause abuse on the spikes to interrupt. Let the damage push Samus into the wall to avoid multiple spike hits after gaining blue suit."
       ]
     },
     {


### PR DESCRIPTION
All X-Mode shinecharges are `canBeVeryPatient` due to being 1-try.