### PR TITLE
Spiky Platforms Tunnel R-Mode Spark Interrupt

### DIFF
--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -145,6 +145,7 @@
       },
       "requires": [
         "h_heatProof",
+        "Morph",
         "h_RModeCanRefillReserves",
         {"enemyKill": {"enemies": [["Tripper"]]}},
         {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
@@ -332,6 +333,7 @@
       },
       "requires": [
         "h_heatProof",
+        "Morph",
         "h_RModeCanRefillReserves",
         {"enemyKill": {"enemies": [["Tripper"]]}},
         {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
@@ -632,6 +634,7 @@
       },
       "requires": [
         "h_heatProof",
+        "Morph",
         "h_RModeCanRefillReserves",
         {"enemyKill": {"enemies": [["Tripper"]]}},
         {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
@@ -859,6 +862,7 @@
       },
       "requires": [
         "h_heatProof",
+        "Morph",
         "h_RModeCanRefillReserves",
         {"enemyKill": {"enemies": [["Tripper"]]}},
         {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},


### PR DESCRIPTION
Room-crossing variants force leaving to reset the room and the trippers.

Crystal Flash isn't an option due to HDMA overload.