### PR TITLE
Move helpers, reorder categories

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -533,6 +533,410 @@
       ]
     },
     {
+      "name": "Door Unlocks",
+      "description": "Ammo requirements needed to unlock different door types.",
+      "helpers": [
+        {
+          "name": "h_openRedDoor",
+          "requires": [
+            {"or": [
+              {"ammo": {"type": "Missile", "count": 5}},
+              {"ammo": {"type": "Super", "count": 1}}
+            ]}
+          ]
+        },
+        {
+          "name": "h_openGreenDoor",
+          "requires": [ {"ammo": {"type": "Super", "count": 1}} ]
+        },
+        {
+          "name": "h_openYellowDoor",
+          "requires": [ "h_usePowerBomb" ]
+        },
+        {
+          "name": "h_openEyeDoor",
+          "requires": [
+            {"or": [
+              {"ammo": {"type": "Missile", "count": 3}},   
+              {"ammo": {"type": "Super", "count": 1}}
+            ]}
+          ]
+        },
+        {
+          "name": "h_heatedGMode",
+          "requires": [
+            "canGMode",
+            {"or": [
+              "h_heatProof",
+              "canHeatedGMode"
+            ]}
+          ]
+        },
+        {
+          "name": "h_heatedGModePauseAbuse",
+          "requires": [
+            "canGMode",
+            "canPauseAbuse",
+            {"or": [
+              "h_heatProof",
+              {"and": [
+                "canComplexGMode",
+                "canHeatedGMode"
+              ]}
+            ]}
+          ]
+        },
+        {
+          "name": "h_heatedDirectGModeLeaveSameDoor",
+          "requires": [
+            "h_heatedGMode",
+            {"heatFrames": 1}
+          ],
+          "note": "Leaving the same door only adds one heat frame. This is likely only useful if remote acquiring an item or opening a yellow door."
+        },
+        {
+          "name": "h_heatedIndirectGModeOpenSameDoor",
+          "requires": [
+            "h_heatedGMode",
+            {"heatFrames": 70}
+          ],
+          "note": "This requires extra frames, because the door needs to close fully before it can be shot open."
+        },
+        {
+          "name": "h_heatedGModeOpenDifferentDoor",
+          "requires": [
+            "h_heatedGMode",
+            {"heatFrames": 35}
+          ],
+          "note": "There is a delay after using X-Ray before shooting. If PLMs are already overloaded, Samus can crouch next to the door, shoot up and very quickly use X-Ray."
+        },
+        {
+          "name": "h_heatedGModeOffCameraDoor",
+          "requires": [
+            "h_heatedGMode",
+            {"or": [
+              {"heatFrames": 70},
+              {"and": [
+                "canUseGrapple",
+                {"heatFrames": 40}
+              ]}
+            ]}
+          ],
+          "note": "There is a delay after using X-Ray before shooting, but the shot cannot be buffered, as it instantly despawns. Grapple can bypass this cooldown."
+        },
+        {
+          "name": "h_heatedGrappleTeleportWallEscape",
+          "requires": [
+            {"tech": "canGrappleTeleportWallEscape"},
+            {"or": [
+              {"and": [
+                "Morph",
+                {"heatFrames": 90}
+              ]},
+              {"and": [
+                "canXRayClimb",
+                {"heatFrames": 120}
+              ]}
+            ]}
+          ]
+        },
+        {
+          "name": "h_heatedRemoteRunway",
+          "requires": [
+            {"or": [
+              "h_heatProof",
+              "canTrickyJump"
+            ]}
+          ]
+        },
+        {
+          "name": "h_heatedRemoteRunwaySpaceJump",
+          "requires": [
+            "canTrickyJump",
+            {"or": [
+              "h_heatProof",
+              "canPreciseSpaceJump"
+            ]}
+          ]
+        },
+        {
+          "name": "h_heatedRemoteRunwayPreciseSpaceJump",
+          "requires": [
+            "canPreciseSpaceJump",
+            {"or": [
+              "h_heatProof",
+              "canInsaneJump"
+            ]}
+          ]
+        },
+        {
+          "name": "h_heatedRemoteRunwaySpringBall",
+          "requires": [
+            {"or": [
+              "h_heatProof",
+              "canTrickySpringBallBounce"
+            ]}
+          ]
+        },
+        {
+          "name": "h_heatedRemoteRunwayTrickySpringBall",
+          "requires": [
+            "canTrickySpringBallBounce",
+            {"or": [
+              "h_heatProof",
+              "canInsaneJump"
+            ]}
+          ]
+        },
+        {
+          "name": "h_storedSpark",
+          "requires": [
+            {"or": [
+              {"useFlashSuit": {}},
+              {"blueSuitShinecharge": {}}
+            ]}
+          ]
+        },
+        {
+          "name": "h_stationaryNeutralDamageBoost",
+          "requires": [
+            {"tech": "canNeutralDamageBoost"}
+          ],
+          "note": [
+            "This is for neutral damage boosts that are compatible with carrying a blue suit,",
+            "because of not needing to be moving when hit.",
+            "Note that even if pressing against a wall, holding a direction input can cause a blue suit to kill the enemy before the boost would occur;",
+            "therefore, if carrying a blue suit, no direction inputs should be pressed until after taking the hit."
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Artificial Morph",
+      "description": "Helpers used in G-Mode Artificial Morph Strats.",
+      "helpers": [
+        {
+          "name": "h_artificialMorphSpringBall",
+          "requires": [
+            "SpringBall"
+          ]
+        },
+        {
+          "name": "h_artificialMorphSpringFling",
+          "requires": [
+            {"tech": "canSpringFling"},
+            "SpringBall"
+          ]
+        },
+        {
+          "name": "h_artificialMorphDoubleSpringBallJump",
+          "requires": [
+            {"tech": "canDoubleSpringBallJumpMidAir"},
+            "HiJump",
+            "SpringBall"
+          ]
+        },
+        {
+          "name": "h_artificialMorphBombThings",
+          "requires": [
+            {"or": [
+              "Bombs",
+              {"ammo": { "type": "PowerBomb", "count": 1}}
+            ]}
+          ]
+        },
+        {
+          "name": "h_artificialMorphBombs",
+          "requires": [
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_artificialMorphPowerBomb",
+          "requires": [
+            {"ammo": { "type": "PowerBomb", "count": 1}}
+          ]
+        },
+        {
+          "name": "h_artificialMorphIBJ",
+          "requires": [
+            {"tech": "canIBJ"},
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_artificialMorphLongIBJ",
+          "requires": [
+            {"tech": "canLongIBJ"},
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_artificialMorphJumpIntoIBJ",
+          "requires": [
+            {"tech": "canJumpIntoIBJ"},
+            "Bombs",
+            "SpringBall"
+          ]
+        },
+        {
+          "name": "h_artificialMorphBombAboveIBJ",
+          "requires": [
+            {"tech": "canBombAboveIBJ"},
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_artificialMorphCeilingBombJump",
+          "requires": [
+            {"tech": "canCeilingBombJump"},
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_artificialMorphLongCeilingBombJump",
+          "requires": [
+            {"tech": "canLongCeilingBombJump"},
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_artificialMorphDiagonalBombJump",
+          "requires": [
+            {"tech": "canDiagonalBombJump"},
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_artificialMorphDoubleBombJump",
+          "requires": [
+            {"tech": "canDoubleBombJump"},
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_artificialMorphStaggeredIBJ",
+          "requires": [
+            {"tech": "canStaggeredIBJ"},
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_artificialMorphBombHorizontally",
+          "requires": [
+            {"tech": "canBombHorizontally"},
+            {"or": [
+              "Bombs",
+              {"ammo": {"type": "PowerBomb", "count": 1}}
+            ]}
+          ]
+        },
+        {
+          "name": "h_artificialMorphHBJ",
+          "requires": [
+            {"tech": "canHBJ"},
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_artificialMorphResetFallSpeed",
+          "requires": [{"tech": "canResetFallSpeed"}]
+        },
+        {
+          "name": "h_artificialMorphSpringBallBombJump",
+          "requires": [
+            {"tech": "canSpringBallBombJump"},
+            "SpringBall",
+            {"or": [
+              "Bombs",
+              {"ammo": {"type": "PowerBomb", "count": 1}}
+            ]}
+          ]
+        },
+        {
+          "name": "h_artificialMorphUnderwaterBombIntoSpringBallJump",
+          "requires": [
+            {"tech": "canUnderwaterBombIntoSpringBallJump"},
+            "SpringBall",
+            "Bombs"
+          ]
+        },
+        {
+          "name": "h_artificialMorphCrystalFlash",
+          "requires": [
+            {"tech": "canCrystalFlash"},
+            {"ammo": {"type": "PowerBomb", "count": 1}},
+            {"ammo": {"type": "Missile", "count": 10}},
+            {"ammo": {"type": "Super", "count": 10}},
+            {"ammo": {"type": "PowerBomb", "count": 10}},
+            {"partialRefill": {"type": "Energy", "limit": 1500}},
+            {"noFlashSuit": {}}
+          ],
+          "devNote": "FIXME: Samus may not get a full refill, depending on the number of tanks and environment."
+        },
+        {
+          "name": "h_artificialMorphBombIntoCrystalFlashClip",
+          "requires": [
+            {"tech": "canBombIntoCrystalFlashClip"},
+            "Bombs",
+            "h_artificialMorphCrystalFlash",
+            "h_bombIntoCrystalFlashClipLeniency"
+          ]
+        },
+        {
+          "name": "h_artificialMorphRModeCrystalFlashInterrupt",
+          "requires": [
+            {"tech": "canRModeCrystalFlashInterrupt"},
+            {"resourceAtMost": [{"type": "RegularEnergy", "count": 50}]},
+            {"resourceAtMost": [{"type": "ReserveEnergy", "count": 0}]},
+            {"or": [
+              {"disableEquipment": "ETank"},
+              {"resourceMaxCapacity": [{"type": "RegularEnergy", "count": 99}]}
+            ]},
+            "h_artificialMorphPowerBomb",
+            {"resourceAvailable": [{"type": "Missile", "count": 10}]},
+            {"resourceAvailable": [{"type": "Super", "count": 10}]},
+            {"resourceAvailable": [{"type": "PowerBomb", "count": 10}]},
+            {"disableEquipment": "Varia"},
+            {"disableEquipment": "Gravity"},
+            {"gainFlashSuit": {}}
+          ]
+        },
+        {
+          "name": "h_artificialMorphComplexRModeCrystalFlashInterrupt",
+          "requires": [
+            {"tech": "canComplexRModeCrystalFlashInterrupt"},
+            "h_artificialMorphRModeCrystalFlashInterrupt"
+          ]
+        },
+        {
+          "name": "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
+          "requires": [
+            {"tech": "canTrickyRModeCrystalFlashInterrupt"},
+            "h_artificialMorphRModeCrystalFlashInterrupt"
+          ]
+        },
+        {
+          "name": "h_artificialMorphMovement",
+          "requires": [
+            {"or": [
+              "h_artificialMorphSpringBall",
+              "h_artificialMorphIBJ",
+              "Morph"
+            ]}
+          ],
+          "note": [
+            "These are ways to navigate stairs and small platforms for strats assuming G-mode artificial morph.",
+            "Having Morph means we can unmorph, jump, and remorph, as using artificial morph is not needed in that case."
+          ],
+          "devNote": [
+            "Morph will not be a usable alternative to get up very constrained ledges, such as in a morph tunnel.",
+            "IBJ is not usable for underwater rooms without Gravity."
+          ]
+        }
+      ]
+    },
+    {
       "name": "General",
       "description": "Standard helpers used to simplify the game logic.",
       "helpers": [
@@ -1299,410 +1703,6 @@
             "This is to cover cases that require running using Speed Booster,",
             "for purposes other than affecting Samus' jump height (canSpeedyJump).",
             "For example, this includes running and jumping over long horizontal gaps."
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Door Unlocks",
-      "description": "Ammo requirements needed to unlock different door types.",
-      "helpers": [
-        {
-          "name": "h_openRedDoor",
-          "requires": [
-            {"or": [
-              {"ammo": {"type": "Missile", "count": 5}},
-              {"ammo": {"type": "Super", "count": 1}}
-            ]}
-          ]
-        },
-        {
-          "name": "h_openGreenDoor",
-          "requires": [ {"ammo": {"type": "Super", "count": 1}} ]
-        },
-        {
-          "name": "h_openYellowDoor",
-          "requires": [ "h_usePowerBomb" ]
-        },
-        {
-          "name": "h_openEyeDoor",
-          "requires": [
-            {"or": [
-              {"ammo": {"type": "Missile", "count": 3}},   
-              {"ammo": {"type": "Super", "count": 1}}
-            ]}
-          ]
-        },
-        {
-          "name": "h_heatedGMode",
-          "requires": [
-            "canGMode",
-            {"or": [
-              "h_heatProof",
-              "canHeatedGMode"
-            ]}
-          ]
-        },
-        {
-          "name": "h_heatedGModePauseAbuse",
-          "requires": [
-            "canGMode",
-            "canPauseAbuse",
-            {"or": [
-              "h_heatProof",
-              {"and": [
-                "canComplexGMode",
-                "canHeatedGMode"
-              ]}
-            ]}
-          ]
-        },
-        {
-          "name": "h_heatedDirectGModeLeaveSameDoor",
-          "requires": [
-            "h_heatedGMode",
-            {"heatFrames": 1}
-          ],
-          "note": "Leaving the same door only adds one heat frame. This is likely only useful if remote acquiring an item or opening a yellow door."
-        },
-        {
-          "name": "h_heatedIndirectGModeOpenSameDoor",
-          "requires": [
-            "h_heatedGMode",
-            {"heatFrames": 70}
-          ],
-          "note": "This requires extra frames, because the door needs to close fully before it can be shot open."
-        },
-        {
-          "name": "h_heatedGModeOpenDifferentDoor",
-          "requires": [
-            "h_heatedGMode",
-            {"heatFrames": 35}
-          ],
-          "note": "There is a delay after using X-Ray before shooting. If PLMs are already overloaded, Samus can crouch next to the door, shoot up and very quickly use X-Ray."
-        },
-        {
-          "name": "h_heatedGModeOffCameraDoor",
-          "requires": [
-            "h_heatedGMode",
-            {"or": [
-              {"heatFrames": 70},
-              {"and": [
-                "canUseGrapple",
-                {"heatFrames": 40}
-              ]}
-            ]}
-          ],
-          "note": "There is a delay after using X-Ray before shooting, but the shot cannot be buffered, as it instantly despawns. Grapple can bypass this cooldown."
-        },
-        {
-          "name": "h_heatedGrappleTeleportWallEscape",
-          "requires": [
-            {"tech": "canGrappleTeleportWallEscape"},
-            {"or": [
-              {"and": [
-                "Morph",
-                {"heatFrames": 90}
-              ]},
-              {"and": [
-                "canXRayClimb",
-                {"heatFrames": 120}
-              ]}
-            ]}
-          ]
-        },
-        {
-          "name": "h_heatedRemoteRunway",
-          "requires": [
-            {"or": [
-              "h_heatProof",
-              "canTrickyJump"
-            ]}
-          ]
-        },
-        {
-          "name": "h_heatedRemoteRunwaySpaceJump",
-          "requires": [
-            "canTrickyJump",
-            {"or": [
-              "h_heatProof",
-              "canPreciseSpaceJump"
-            ]}
-          ]
-        },
-        {
-          "name": "h_heatedRemoteRunwayPreciseSpaceJump",
-          "requires": [
-            "canPreciseSpaceJump",
-            {"or": [
-              "h_heatProof",
-              "canInsaneJump"
-            ]}
-          ]
-        },
-        {
-          "name": "h_heatedRemoteRunwaySpringBall",
-          "requires": [
-            {"or": [
-              "h_heatProof",
-              "canTrickySpringBallBounce"
-            ]}
-          ]
-        },
-        {
-          "name": "h_heatedRemoteRunwayTrickySpringBall",
-          "requires": [
-            "canTrickySpringBallBounce",
-            {"or": [
-              "h_heatProof",
-              "canInsaneJump"
-            ]}
-          ]
-        },
-        {
-          "name": "h_storedSpark",
-          "requires": [
-            {"or": [
-              {"useFlashSuit": {}},
-              {"blueSuitShinecharge": {}}
-            ]}
-          ]
-        },
-        {
-          "name": "h_stationaryNeutralDamageBoost",
-          "requires": [
-            {"tech": "canNeutralDamageBoost"}
-          ],
-          "note": [
-            "This is for neutral damage boosts that are compatible with carrying a blue suit,",
-            "because of not needing to be moving when hit.",
-            "Note that even if pressing against a wall, holding a direction input can cause a blue suit to kill the enemy before the boost would occur;",
-            "therefore, if carrying a blue suit, no direction inputs should be pressed until after taking the hit."
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Artificial Morph",
-      "description": "Helpers used in G-Mode Artificial Morph Strats.",
-      "helpers": [
-        {
-          "name": "h_artificialMorphSpringBall",
-          "requires": [
-            "SpringBall"
-          ]
-        },
-        {
-          "name": "h_artificialMorphSpringFling",
-          "requires": [
-            {"tech": "canSpringFling"},
-            "SpringBall"
-          ]
-        },
-        {
-          "name": "h_artificialMorphDoubleSpringBallJump",
-          "requires": [
-            {"tech": "canDoubleSpringBallJumpMidAir"},
-            "HiJump",
-            "SpringBall"
-          ]
-        },
-        {
-          "name": "h_artificialMorphBombThings",
-          "requires": [
-            {"or": [
-              "Bombs",
-              {"ammo": { "type": "PowerBomb", "count": 1}}
-            ]}
-          ]
-        },
-        {
-          "name": "h_artificialMorphBombs",
-          "requires": [
-            "Bombs"
-          ]
-        },
-        {
-          "name": "h_artificialMorphPowerBomb",
-          "requires": [
-            {"ammo": { "type": "PowerBomb", "count": 1}}
-          ]
-        },
-        {
-          "name": "h_artificialMorphIBJ",
-          "requires": [
-            {"tech": "canIBJ"},
-            "Bombs"
-          ]
-        },
-        {
-          "name": "h_artificialMorphLongIBJ",
-          "requires": [
-            {"tech": "canLongIBJ"},
-            "Bombs"
-          ]
-        },
-        {
-          "name": "h_artificialMorphJumpIntoIBJ",
-          "requires": [
-            {"tech": "canJumpIntoIBJ"},
-            "Bombs",
-            "SpringBall"
-          ]
-        },
-        {
-          "name": "h_artificialMorphBombAboveIBJ",
-          "requires": [
-            {"tech": "canBombAboveIBJ"},
-            "Bombs"
-          ]
-        },
-        {
-          "name": "h_artificialMorphCeilingBombJump",
-          "requires": [
-            {"tech": "canCeilingBombJump"},
-            "Bombs"
-          ]
-        },
-        {
-          "name": "h_artificialMorphLongCeilingBombJump",
-          "requires": [
-            {"tech": "canLongCeilingBombJump"},
-            "Bombs"
-          ]
-        },
-        {
-          "name": "h_artificialMorphDiagonalBombJump",
-          "requires": [
-            {"tech": "canDiagonalBombJump"},
-            "Bombs"
-          ]
-        },
-        {
-          "name": "h_artificialMorphDoubleBombJump",
-          "requires": [
-            {"tech": "canDoubleBombJump"},
-            "Bombs"
-          ]
-        },
-        {
-          "name": "h_artificialMorphStaggeredIBJ",
-          "requires": [
-            {"tech": "canStaggeredIBJ"},
-            "Bombs"
-          ]
-        },
-        {
-          "name": "h_artificialMorphBombHorizontally",
-          "requires": [
-            {"tech": "canBombHorizontally"},
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]}
-          ]
-        },
-        {
-          "name": "h_artificialMorphHBJ",
-          "requires": [
-            {"tech": "canHBJ"},
-            "Bombs"
-          ]
-        },
-        {
-          "name": "h_artificialMorphResetFallSpeed",
-          "requires": [{"tech": "canResetFallSpeed"}]
-        },
-        {
-          "name": "h_artificialMorphSpringBallBombJump",
-          "requires": [
-            {"tech": "canSpringBallBombJump"},
-            "SpringBall",
-            {"or": [
-              "Bombs",
-              {"ammo": {"type": "PowerBomb", "count": 1}}
-            ]}
-          ]
-        },
-        {
-          "name": "h_artificialMorphUnderwaterBombIntoSpringBallJump",
-          "requires": [
-            {"tech": "canUnderwaterBombIntoSpringBallJump"},
-            "SpringBall",
-            "Bombs"
-          ]
-        },
-        {
-          "name": "h_artificialMorphCrystalFlash",
-          "requires": [
-            {"tech": "canCrystalFlash"},
-            {"ammo": {"type": "PowerBomb", "count": 1}},
-            {"ammo": {"type": "Missile", "count": 10}},
-            {"ammo": {"type": "Super", "count": 10}},
-            {"ammo": {"type": "PowerBomb", "count": 10}},
-            {"partialRefill": {"type": "Energy", "limit": 1500}},
-            {"noFlashSuit": {}}
-          ],
-          "devNote": "FIXME: Samus may not get a full refill, depending on the number of tanks and environment."
-        },
-        {
-          "name": "h_artificialMorphBombIntoCrystalFlashClip",
-          "requires": [
-            {"tech": "canBombIntoCrystalFlashClip"},
-            "Bombs",
-            "h_artificialMorphCrystalFlash",
-            "h_bombIntoCrystalFlashClipLeniency"
-          ]
-        },
-        {
-          "name": "h_artificialMorphRModeCrystalFlashInterrupt",
-          "requires": [
-            {"tech": "canRModeCrystalFlashInterrupt"},
-            {"resourceAtMost": [{"type": "RegularEnergy", "count": 50}]},
-            {"resourceAtMost": [{"type": "ReserveEnergy", "count": 0}]},
-            {"or": [
-              {"disableEquipment": "ETank"},
-              {"resourceMaxCapacity": [{"type": "RegularEnergy", "count": 99}]}
-            ]},
-            "h_artificialMorphPowerBomb",
-            {"resourceAvailable": [{"type": "Missile", "count": 10}]},
-            {"resourceAvailable": [{"type": "Super", "count": 10}]},
-            {"resourceAvailable": [{"type": "PowerBomb", "count": 10}]},
-            {"disableEquipment": "Varia"},
-            {"disableEquipment": "Gravity"},
-            {"gainFlashSuit": {}}
-          ]
-        },
-        {
-          "name": "h_artificialMorphComplexRModeCrystalFlashInterrupt",
-          "requires": [
-            {"tech": "canComplexRModeCrystalFlashInterrupt"},
-            "h_artificialMorphRModeCrystalFlashInterrupt"
-          ]
-        },
-        {
-          "name": "h_artificialMorphTrickyRModeCrystalFlashInterrupt",
-          "requires": [
-            {"tech": "canTrickyRModeCrystalFlashInterrupt"},
-            "h_artificialMorphRModeCrystalFlashInterrupt"
-          ]
-        },
-        {
-          "name": "h_artificialMorphMovement",
-          "requires": [
-            {"or": [
-              "h_artificialMorphSpringBall",
-              "h_artificialMorphIBJ",
-              "Morph"
-            ]}
-          ],
-          "note": [
-            "These are ways to navigate stairs and small platforms for strats assuming G-mode artificial morph.",
-            "Having Morph means we can unmorph, jump, and remorph, as using artificial morph is not needed in that case."
-          ],
-          "devNote": [
-            "Morph will not be a usable alternative to get up very constrained ledges, such as in a morph tunnel.",
-            "IBJ is not usable for underwater rooms without Gravity."
           ]
         },
         {


### PR DESCRIPTION
There were a lot of helpers added to the `artificial morph` section, which I moved to the `general` section. Then I moved the `general` section to the end, so that when new helpers are added at the end of the file, they will be much more likely to be in the correct section.

The reason that helpers need to be placed in the correct sections is because those in `leniency` and `randomizer dependent` sections typically need to have a randomizer override, where others shouldnt. Maddo recently added tests to make sure that Map Rando is addressing all helpers in these two sections, so that one isn't added and then accidentally missed