### PR TITLE
Parlor and Alcatraz G-Mode Spark Interrupt

### DIFF
--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -2107,13 +2107,16 @@
       "note": [
         "There are scroll PLMs next to the bomb blocks and on the ledge below the Alcatraz exit, which will overload PLMs when going through them.",
         "Samus will need to briefly navigate off-screen while to the right of Alcatraz before coming back left.",
-        "With springball or fast IBJ, watch the ceiling to wait for the two global Geemers to pass.",
-        "Once out of the area, jump onto the hill. Shoot the three Skree, then stand clear of the area and use X-Ray until the beam reaches full width.",
-        "Collect the energy dropped by the Skree, and farm all 10 Geemers: one is stuck offscreen to the right that can't be shot.",
-        "If this Geemer is needed as well, a Power Bomb (only) after overloading the bomb blocks but before unmorphing can hit it: in this case, exit G-mode",
-        "before farming the Skree as otherwise enemy projectiles will overload and you may fail to get drops from them.",
-        "Alternatively, Morph can be used after leaving G-Mode to fix the camer in the left tunnel of Alcatraz.",
-        "Shinecharge and drop to the Ripper by the save room door to interrupt."
+        "With a fast ascent, the global Geemers may still be in the top right section and can hit Samus off-screen.",
+        "Use X-Ray until the beam reaches full width to exit G-mode and remain in R-mode.",
+        "Kill the Skree while in health-bomb range, then the Geemers until Samus has Reserve Energy.",
+        "Shinecharge and interrupt on a Geemer or the Ripper on the left."
+      ],
+      "detailNote": [
+        "With unlucky drops, it is possible to not get Reserve Energy.",
+        "It is possible to farm the top right off-screen Geemer to help reduce the chance.",
+        "With Morph, partially enter the Alcatraz morph tunnel in order to fix the camera.",
+        "Without Morph, kill the Geemer with a Power Bomb once in this section after overloading PLMs and before unmorphing and exiting G-mode."
       ]
     },
     {


### PR DESCRIPTION
Artificial Morph from Alactraz, and PLM Overload from Terminator door.
- There's enough Geemers to feasibly farm to reserve on 0 E-Tanks (disable) even from Mobile setup.
- After CF, there's enough Geemers to make up any gap in reserve to 50 energy (guaranteed due to healthbomb).
- The right-most non-global Geemer can't be shot when coming from Alcatraz, due to overloading the Alcatraz scroll block. Wasn't worth fussing with wrangling in a ScrewAttack, 10 geemers are still good enough.
- CF means you can't go down the "Parlor" side or else you're offscreen. So these use the global geemer for interrupting. Might need patience?
- Alactraz can do Immobile, so it has a few `h_RModeCanRefillReserves`-like paths to farm, with some lenience due to the Geemer hit.