### PR TITLE
Crab Maze G-Mode Spark Interrupt

### DIFF
--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -416,8 +416,7 @@
         "Without Springball or Gravity, it is possible to overload PLMs with the crumble blocks with bombs.",
         "Take the first left above the waterline. Place bombs in the single tile nook on the left.",
         "The Sciser that starts inside the Morph maze area will move off-screen: wait for it to come back out.",
-        "The second one, however, does not and so should be prioritized to kill before it slips inside the Morph maze.",
-        "Once those are dealt with, use X-Ray until the beam reaches full width to exit G-Mode and remain in R-Mode, then collect drops.",
+        "Once outside of the Morph tunnel area, use X-Ray until the beam reaches full width to exit G-Mode and remain in R-Mode, then collect drops.",
         "Farm the rest of the Scisers, keeping the slower local Sciser at the bottom left corner to use for the interrupt.",
         "Position it in the ceiling cubby hole to safely perform the Shinecharge and jump into the Sciser as it walks back down."
       ]
@@ -459,7 +458,8 @@
         "Crystal Flash under the bomb block; Samus can then no longer use X-Ray.",
         "Jump through, and drop through to the other side. Avoid the Scisers, and manipulate one to the far right.",
         "Shinecharge and windup near the Sciser to interrupt."
-      ]
+      ],
+      "devNote": "Also possible to escape with Space Jump + frame perfect downgrab"
     },
     {
       "id": 34,


### PR DESCRIPTION
Artificial morph from top door.

For CF, you have to overload through the shortcut tunnel and CF on the left side. Farming after the fact will only guarantee farming out of health-bomb, after that they drop most likely power bombs.