### PR TITLE
Fast Pillars Setup G-Mode Spark Interrupt

### DIFF
--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -81,6 +81,17 @@
         [1],
         [2]
       ]
+    },
+    {
+      "id": 6,
+      "name": "R-Mode, Bottom Junction",
+      "nodeType": "junction",
+      "nodeSubType": "r-mode",
+      "mapTileMask": [
+        [1],
+        [1],
+        [2]
+      ]
     }
   ],
   "obstacles": [
@@ -1351,7 +1362,30 @@
       ]
     },
     {
+      "id": 99,
       "link": [1, 5],
+      "name": "G-Mode Morph, Power Bomb the Blocks",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_heatedGMode",
+        "h_artificialMorphPowerBomb",
+        {"heatFrames": 120}
+      ],
+      "clearsObstacles": ["A"],
+      "flashSuitChecked": true,
+      "note": [
+        "Place a Power Bomb then exit G-mode to break the blocks.",
+        "If entering in indirect, without Morph, quickly place the Power Bomb and unmorph and start shooting the pirate,",
+        "in order to prevent it from moving forward or placing invisible, stationary lasers over the way down."
+      ]
+    },
+    {
+      "link": [1, 6],
       "name": "Direct G-Mode Morph Spark Interrupt",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -1377,42 +1411,7 @@
           {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
           "canBeLucky"
         ]},
-        {"partialRefill": {"type": "ReserveEnergy", "limit": 5}},
-        {"or": [
-          {"canShineCharge": {
-            "usedTiles": 12,
-            "gentleDownTiles": 2,
-            "gentleUpTiles": 2,
-            "openEnd": 0
-          }},
-          {"and": [
-            {"or": [
-              {"doorUnlockedAtNode": 2},
-              {"doorUnlockedAtNode": 3}
-            ]},
-            {"canShineCharge": {
-              "usedTiles": 13,
-              "gentleDownTiles": 2,
-              "gentleUpTiles": 2,
-              "openEnd": 0
-            }}
-          ]},
-          {"and": [
-            {"doorUnlockedAtNode": 2},
-            {"doorUnlockedAtNode": 3},
-            {"canShineCharge": {
-              "usedTiles": 14,
-              "gentleDownTiles": 2,
-              "gentleUpTiles": 2,
-              "openEnd": 0
-            }}
-          ]}
-        ]},
-        "h_heatTriggerRModeSparkInterrupt"
-      ],
-      "unlocksDoors": [
-        {"nodeId": 2, "types": ["ammo"], "requires": []},
-        {"nodeId": 3, "types": ["ammo"], "requires": []}
+        {"partialRefill": {"type": "ReserveEnergy", "limit": 5}}
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -1425,7 +1424,7 @@
       ]
     },
     {
-      "link": [1, 5],
+      "link": [1, 6],
       "name": "Direct G-Mode Morph, Bomb Pirate Kill, Spark Interrupt",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -1445,42 +1444,7 @@
           {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
           "canBeLucky"
         ]},
-        {"partialRefill": {"type": "ReserveEnergy", "limit": 5}},
-        {"or": [
-          {"canShineCharge": {
-            "usedTiles": 12,
-            "gentleDownTiles": 2,
-            "gentleUpTiles": 2,
-            "openEnd": 0
-          }},
-          {"and": [
-            {"or": [
-              {"doorUnlockedAtNode": 2},
-              {"doorUnlockedAtNode": 3}
-            ]},
-            {"canShineCharge": {
-              "usedTiles": 13,
-              "gentleDownTiles": 2,
-              "gentleUpTiles": 2,
-              "openEnd": 0
-            }}
-          ]},
-          {"and": [
-            {"doorUnlockedAtNode": 2},
-            {"doorUnlockedAtNode": 3},
-            {"canShineCharge": {
-              "usedTiles": 14,
-              "gentleDownTiles": 2,
-              "gentleUpTiles": 2,
-              "openEnd": 0
-            }}
-          ]}
-        ]},
-        "h_heatTriggerRModeSparkInterrupt"
-      ],
-      "unlocksDoors": [
-        {"nodeId": 2, "types": ["ammo"], "requires": []},
-        {"nodeId": 3, "types": ["ammo"], "requires": []}
+        {"partialRefill": {"type": "ReserveEnergy", "limit": 5}}
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -1495,7 +1459,7 @@
       ]
     },
     {
-      "link": [1, 5],
+      "link": [1, 6],
       "name": "Direct G-Mode Morph, Power Bomb Pirate Kill, Spark Interrupt",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -1514,42 +1478,7 @@
           {"resourceMissingAtMost": [{"type": "Missile", "count": 0}]},
           "canBeLucky"
         ]},
-        {"partialRefill": {"type": "ReserveEnergy", "limit": 5}},
-        {"or": [
-          {"canShineCharge": {
-            "usedTiles": 12,
-            "gentleDownTiles": 2,
-            "gentleUpTiles": 2,
-            "openEnd": 0
-          }},
-          {"and": [
-            {"or": [
-              {"doorUnlockedAtNode": 2},
-              {"doorUnlockedAtNode": 3}
-            ]},
-            {"canShineCharge": {
-              "usedTiles": 13,
-              "gentleDownTiles": 2,
-              "gentleUpTiles": 2,
-              "openEnd": 0
-            }}
-          ]},
-          {"and": [
-            {"doorUnlockedAtNode": 2},
-            {"doorUnlockedAtNode": 3},
-            {"canShineCharge": {
-              "usedTiles": 14,
-              "gentleDownTiles": 2,
-              "gentleUpTiles": 2,
-              "openEnd": 0
-            }}
-          ]}
-        ]},
-        "h_heatTriggerRModeSparkInterrupt"
-      ],
-      "unlocksDoors": [
-        {"nodeId": 2, "types": ["ammo"], "requires": []},
-        {"nodeId": 3, "types": ["ammo"], "requires": []}
+        {"partialRefill": {"type": "ReserveEnergy", "limit": 5}}
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -1563,7 +1492,7 @@
       ]
     },
     {
-      "link": [1, 5],
+      "link": [1, 6],
       "name": "Direct G-Mode Morph, Viola Farm, Spark Interrupt",
       "entranceCondition": {
         "comeInWithGMode": {
@@ -1583,42 +1512,7 @@
         {"resourceMissingAtMost": [{"type": "PowerBomb", "count": 0}]},
         "h_artificialMorphPowerBomb",
         {"refill": ["PowerBomb"]},
-        {"partialRefill": {"type": "ReserveEnergy", "limit": 5}},
-        {"or": [
-          {"canShineCharge": {
-            "usedTiles": 12,
-            "gentleDownTiles": 2,
-            "gentleUpTiles": 2,
-            "openEnd": 0
-          }},
-          {"and": [
-            {"or": [
-              {"doorUnlockedAtNode": 2},
-              {"doorUnlockedAtNode": 3}
-            ]},
-            {"canShineCharge": {
-              "usedTiles": 13,
-              "gentleDownTiles": 2,
-              "gentleUpTiles": 2,
-              "openEnd": 0
-            }}
-          ]},
-          {"and": [
-            {"doorUnlockedAtNode": 2},
-            {"doorUnlockedAtNode": 3},
-            {"canShineCharge": {
-              "usedTiles": 14,
-              "gentleDownTiles": 2,
-              "gentleUpTiles": 2,
-              "openEnd": 0
-            }}
-          ]}
-        ]},
-        "h_heatTriggerRModeSparkInterrupt"
-      ],
-      "unlocksDoors": [
-        {"nodeId": 2, "types": ["ammo"], "requires": []},
-        {"nodeId": 3, "types": ["ammo"], "requires": []}
+        {"partialRefill": {"type": "ReserveEnergy", "limit": 5}}
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
@@ -1629,29 +1523,6 @@
         "After it explodes, activate and hold X-Ray until the beam is at full width to exit G-Mode and remain in R-Mode. Samus will fall into the pit and avoid the lasers.",
         "Jump out and down to the bottom where the Violas are still alive. Kill one, collect its power bomb drop, then kill the other for energy.",
         "Shinecharge at the bottom runway and use heat damage to interrupt."
-      ]
-    },
-    {
-      "id": 99,
-      "link": [1, 5],
-      "name": "G-Mode Morph, Power Bomb the Blocks",
-      "entranceCondition": {
-        "comeInWithGMode": {
-          "mode": "any",
-          "morphed": true
-        }
-      },
-      "requires": [
-        "h_heatedGMode",
-        "h_artificialMorphPowerBomb",
-        {"heatFrames": 120}
-      ],
-      "clearsObstacles": ["A"],
-      "flashSuitChecked": true,
-      "note": [
-        "Place a Power Bomb then exit G-mode to break the blocks.",
-        "If entering in indirect, without Morph, quickly place the Power Bomb and unmorph and start shooting the pirate,",
-        "in order to prevent it from moving forward or placing invisible, stationary lasers over the way down."
       ]
     },
     {
@@ -3427,6 +3298,60 @@
         "Destroying obstacle A from above would kill the Violas prematurely.",
         "FIXME: It is possible to get past their drops from above to still be able to use them; find out if there is a consistent setup for this."
       ]
+    },
+    {
+      "link": [6, 5],
+      "name": "Base",
+      "requires": [
+        "canRMode"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [6, 5],
+      "name": "R-Mode Spark Interrupt",
+      "requires": [
+        "canRMode",
+        {"resourceAvailable": [{"type": "ReserveEnergy", "count": 1}]},
+        {"or": [
+          {"canShineCharge": {
+            "usedTiles": 12,
+            "gentleDownTiles": 2,
+            "gentleUpTiles": 2,
+            "openEnd": 0
+          }},
+          {"and": [
+            {"or": [
+              {"doorUnlockedAtNode": 2},
+              {"doorUnlockedAtNode": 3}
+            ]},
+            {"canShineCharge": {
+              "usedTiles": 13,
+              "gentleDownTiles": 2,
+              "gentleUpTiles": 2,
+              "openEnd": 0
+            }}
+          ]},
+          {"and": [
+            {"doorUnlockedAtNode": 2},
+            {"doorUnlockedAtNode": 3},
+            {"canShineCharge": {
+              "usedTiles": 14,
+              "gentleDownTiles": 2,
+              "gentleUpTiles": 2,
+              "openEnd": 0
+            }}
+          ]}
+        ]},
+        "h_heatTriggerRModeSparkInterrupt"
+      ],
+       "unlocksDoors": [
+        {"nodeId": 2, "types": ["ammo"], "requires": []},
+        {"nodeId": 3, "types": ["ammo"], "requires": []}
+      ],
+     "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -1911,6 +1911,7 @@
 
               "junction",
               "g-mode",
+              "r-mode",
 
               "save",
               "missile",


### PR DESCRIPTION
Artificial Morph from [1] to PB the barrier wall.

Only works with Immobile because it needs an X-Ray activation to release PLMs and remove the barrier wall. (Mobile would require CF which prevents X-Ray use.)

High placed PB could avoid killing the Viola and thus not require heat interrupt but I'm concerned about the pirate lasers overloading and preventing energy drops. It could work with an ammo kill.

Could also investigate psuedo-Varia, but the equivalent R-Mode strat is full-heatproof also so it didn't make sense to relax that here.