### PR TITLE
Main Hall G-Mode Spark Interrupt

### DIFF
--- a/region/lowernorfair/east/Main Hall.json
+++ b/region/lowernorfair/east/Main Hall.json
@@ -538,15 +538,17 @@
           "canRModePauseAbuseSparkInterrupt",
           {"and": [
             "canRModeSparkInterrupt",
-            {"acidFrames": 30}
+            {"acidFrames": 30},
+            {"heatFrames": 70}
           ]}
         ]},
-        {"heatFrames": 80}
+        {"heatFrames": 90}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Cross to the center platform to get to the shinecharge runway. Crystal Flash and then use the acid left of the elevator platform to interrupt."
+        "Cross to the center platform to get to the shinecharge runway. Crystal Flash and then use the acid left of the elevator platform to interrupt.",
+        "Time the entry so that the acid is low to ensure Samus can escape: if not using pause abuse, this must include the time taken for the reserve trigger."
       ]
     },
     {


### PR DESCRIPTION
G-Mode for psuedo-Varia from either door. Fundamentally identical in execution to the R-Mode strat, CF variant.