### PR TITLE
Mickey Mouse Room G-Mode Spark Interrupt

### DIFF
--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -643,7 +643,7 @@
       ],
       "detailNote": [
         "Note that a mobile G-Mode entry doesn't get hit by the Multiviola due to i-frames.",
-        "For Immobile, enter with a small enough amount of Energy to where Samus will be at or below 50 after the Multiviola hit and can immediately Crystal Flash.",
+        "For Immobile, enter with a small enough amount of Energy to where Samus will be at or below 50 after the Multiviola hit and can immediately Crystal Flash."
       ]
     },
     {


### PR DESCRIPTION
G-Mode for heat from [1]. Mobile only to ensure avoiding a Multiviola hit and CF after. (Immobile could have immediately CF after if suitless.) Testing showed multiviola still leaves powerbomb range in time and the Dessgeega that jumps Samus during the CF will die to light orb.

Nothing can be done with [2] due to shot blocks.