### PR TITLE
Bump up requirements on Brin Reserve temp blue

### DIFF
--- a/region/brinstar/green/Brinstar Reserve Tank Room.json
+++ b/region/brinstar/green/Brinstar Reserve Tank Room.json
@@ -143,8 +143,11 @@
         "canSpeedball",
         "canTrickyJump",
         {"or": [
-          "canTemporaryBlue",
-          "h_useSpringBall"
+          "canChainTemporaryBlue",
+          {"and": [
+            "h_useSpringBall",
+            "canSlowShortCharge"
+          ]}
         ]}
       ],
       "collectsItems": [3],
@@ -169,7 +172,7 @@
         "canSpeedball",
         "canTrickyJump",
         {"or": [
-          "canTemporaryBlue",
+          "canChainTemporaryBlue",
           "h_useSpringBall"
         ]}
       ],


### PR DESCRIPTION
This bumps the requirements, moving this trick from Very Hard to Expert level. Previously we weren't considering unmorphing after a speedball as needing a "canChainTemporaryBlue" requirement, but because of the precision required in this case (to speedball into the tunnel, and to break the blocks) it feels more like the difficulty of a "canChainTemporaryBlue" than "canTemporaryBlue".