### PR TITLE
Fix ExitCondition on KraidMouth strats

### DIFF
--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -297,7 +297,7 @@
             "openEnd": 1
           },
           "landingRunway": {
-            "length": 17,
+            "length": 1,
             "openEnd": 1
           },
           "movementType": "controlled",
@@ -323,7 +323,7 @@
             "openEnd": 1
           },
           "landingRunway": {
-            "length": 17,
+            "length": 1,
             "openEnd": 1
           },
           "movementType": "controlled",

--- a/region/brinstar/kraid/Warehouse Entrance.json
+++ b/region/brinstar/kraid/Warehouse Entrance.json
@@ -287,14 +287,20 @@
       "link": [1, 3],
       "name": "Leave With Controlled Spring Ball Bounce (Super Blocks Broken)",
       "requires": [
+        "canTrickyJump",
         {"obstaclesCleared": ["A"]}
       ],
       "exitCondition": {
-        "leaveSpinning": {
+        "leaveWithSpringBallBounce": {
           "remoteRunway": {
             "length": 17,
             "openEnd": 1
           },
+          "landingRunway": {
+            "length": 17,
+            "openEnd": 1
+          },
+          "movementType": "controlled",
           "minExtraRunSpeed": "$1.9"
         }
       },
@@ -306,15 +312,21 @@
       "link": [1, 3],
       "name": "Leave With Controlled Spring Ball Bounce (Super Blocks Broken, Door Open)",
       "requires": [
+        "canTrickyJump",
         {"obstaclesCleared": ["A"]},
         {"doorUnlockedAtNode": 1}
       ],
       "exitCondition": {
-        "leaveSpinning": {
+        "leaveWithSpringBallBounce": {
           "remoteRunway": {
             "length": 18,
             "openEnd": 1
           },
+          "landingRunway": {
+            "length": 17,
+            "openEnd": 1
+          },
+          "movementType": "controlled",
           "minExtraRunSpeed": "$1.9"
         }
       },


### PR DESCRIPTION
The canTrickyJump is because the full speed mockball needs to avoid the Statue face and its kinda awkward.