### PR TITLE
Green Maridia pt. 1 (Pants Room): blue suit logic

### DIFF
--- a/region/maridia/inner-green/East Pants Room.json
+++ b/region/maridia/inner-green/East Pants Room.json
@@ -91,7 +91,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -123,6 +124,7 @@
       ],
       "farmCycleDrops": [{"enemy": "Puyo", "count": 2}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Stand (don't crouch) next to the door and shoot diagonally down into the sand until the Puyos are killed.",
       "devNote": [
         "One or both of the Puyos above the shot block could also be farmed, but it doesn't seem worth modeling."
@@ -135,7 +137,8 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 4,
@@ -146,6 +149,7 @@
         "leaveWithGModeSetup": {}
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "This can only be useful if the door does not connect to the Pants Room."
     },
     {
@@ -157,6 +161,7 @@
       ],
       "gModeRegainMobility": {},
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "This can only be useful if the door does not connect to the Pants Room."
     },
     {
@@ -164,9 +169,24 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
+        "canDash",
         "Gravity"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Gravity Flatley Jump",
+      "requires": [
+        "Gravity",
+        "canFlatleyJump"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Use a Flatley jump to avoid touching the sand; this is useful to avoid losing a blue suit."
+      ]
     },
     {
       "id": 7,
@@ -181,7 +201,8 @@
           "canUseFrozenEnemies"
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -200,6 +221,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "It is recommended to shoot the ceiling block immediately upon room entry to bring one of the Puyos down so that it will not be a problem later."
     },
     {
@@ -216,6 +238,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Involves breaking the top left Puyo free and then freezing it while it falls.",
         "Walk to the end of the door platform and wait for the above puyo to land on the shot block.",
@@ -231,7 +254,8 @@
         "HiJump",
         "canJumpIntoRespawningBlock"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -248,6 +272,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "It is recommended to shoot the ceiling block immediately upon room entry to bring one of the Puyos down so that it will not be a problem later."
     },
     {
@@ -272,6 +297,7 @@
         {"noFlashSuit": {}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Quickly shoot to break the shot block and then do a momentumConservingTurnaround to ascend into the little region.",
         "Another movement item will be needed to get closer to the crumble blocks."
@@ -286,13 +312,14 @@
     {
       "id": 26,
       "link": [1, 3],
-      "name": "Use Flash Suit",
+      "name": "Use Stored Spark",
       "requires": [
-        "canPlayInSand",
+        "h_storedSpark",
         {"useFlashSuit": {}},
         {"shinespark": {"frames": 11, "excessFrames": 1}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Cross the sand, then spark up left."
     },
     {
@@ -318,7 +345,8 @@
         {"types": ["super"], "requires": []},
         {"types": ["missiles", "powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -331,7 +359,8 @@
       },
       "requires": [],
       "bypassesDoorShell": "yes",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 14,
@@ -349,7 +378,8 @@
         }
       },
       "bypassesDoorShell": "yes",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 15,
@@ -362,7 +392,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 29,
@@ -383,7 +414,10 @@
                 {"cycleFrames": 95}
               ]},
               {"and": [
-                "ScrewAttack",
+                {"or": [
+                  "ScrewAttack",
+                  {"haveBlueSuit": {}}
+                ]},
                 {"cycleFrames": 105}
               ]},
               {"and": [
@@ -416,6 +450,10 @@
                 {"cycleFrames": 185}
               ]},
               {"and": [
+                {"haveBlueSuit": {}},
+                {"cycleFrames": 200}
+              ]},
+              {"and": [
                 "canDodgeWhileShooting",
                 {"cycleFrames": 220}
               ]}
@@ -424,7 +462,8 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Puyo", "count": 1}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 30,
@@ -439,6 +478,10 @@
               {"and": [
                 "Plasma",
                 {"cycleFrames": 230}
+              ]},
+              {"and": [
+                {"haveBlueSuit": {}},
+                {"cycleFrames": 240}
               ]},
               {"and": [
                 "Grapple",
@@ -477,6 +520,7 @@
       ],
       "farmCycleDrops": [{"enemy": "Puyo", "count": 3}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "More Puyos could be farmed at the bottom of the room, but it doesn't seem worth modeling."
       ]
@@ -488,7 +532,8 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "link": [2, 2],
@@ -517,7 +562,8 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 18,
@@ -527,14 +573,16 @@
         {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}}
       ],
       "gModeRegainMobility": {},
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 19,
       "link": [2, 3],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 20,
@@ -546,7 +594,8 @@
           {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 1}}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 21,
@@ -568,6 +617,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Freeze the Puyo at standing-shot height and then jump on top of it with a spinjump before morphing, unmorphing, and using X-Ray to standup and clip.",
         "Standing on a side of the room and shooting forward will freeze the Puyo at the correct height."
@@ -593,6 +643,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Freeze the Puyo at standing-shot height and then jump on top of it with a spinjump before morphing, unmorphing, and using X-Ray to standup and clip.",
         "Standing on a side of the room and shooting forward will freeze the Puyo at the correct height."
@@ -614,6 +665,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Freeze the Puyo at the start of its jump animation, on the right frame."
     },
     {
@@ -624,6 +676,7 @@
         {"notable": "Suitless Puyo Clip"},
         "canSuitlessMaridia",
         "h_highPixelIceClip",
+        {"noBlueSuit": {}},
         {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 2}},
         {"or": [
           {"enemyDamage": {"enemy": "Puyo", "type": "contact", "hits": 6}},
@@ -639,6 +692,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Positioning the Puyo requires it to perform a big jump then start falling with a frame perfect freeze.",
         "One possible setup stands on the left tile of the right side and lets the puyo jump up taking a contact hit.",
@@ -660,6 +714,7 @@
         "Gravity"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Clip below the crumble blocks on the left side.  Hold down after clipping to break them."
     },
     {
@@ -671,6 +726,7 @@
         "canSuitlessMaridia"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Place a PB up against the crumble blocks, then jump and midair morph into that same position at the end of the explosion while holding CF inputs.",
         "Immediately after the CF, hold down to break the crumble blocks."

--- a/region/maridia/inner-green/Pants Room.json
+++ b/region/maridia/inner-green/Pants Room.json
@@ -121,7 +121,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 39,
@@ -135,7 +136,8 @@
           ]
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -144,7 +146,8 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -164,6 +167,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "This climb is from the left side of the left room, the room with the breakable grapple block.",
         "Climb up 3 screens.",
@@ -175,7 +179,7 @@
     {
       "id": 4,
       "link": [1, 2],
-      "name": "Shinespark (From the Left)",
+      "name": "Come in Shinecharged, Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -192,6 +196,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Preselect Grapple and be ready to use it when entering the room. Release up or angle up before releasing Grapple so the shinespark does not activate instantly.",
         "Use the windup frames for a shinespark to extend the duration timer."
@@ -200,7 +205,7 @@
     {
       "id": 5,
       "link": [1, 2],
-      "name": "Diagonal Shinespark (From the Left)",
+      "name": "Come in Shinecharged, Diagonal Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -220,6 +225,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Preselect Grapple and be ready to use it when entering the room. Release up or angle up before releasing Grapple so the shinespark does not activate instantly.",
         "Fall into the sand below the Grapple block with Gravity disabled.",
@@ -232,17 +238,79 @@
       "link": [1, 3],
       "name": "Base",
       "requires": [
-        "h_navigateUnderwater"
+        {"or": [
+          {"and": [
+            "Gravity",
+            {"or": [
+              "SpaceJump",
+              "Grapple",
+              {"noBlueSuit": {}}
+            ]}
+          ]},
+          {"and": [
+            {"disableEquipment": "Gravity"},
+            "canSuitlessMaridia"
+          ]}
+        ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Jump from door platform to door platform while avoiding the sand."
     },
     {
       "id": 7,
       "link": [1, 4],
       "name": "Base",
-      "requires": [],
-      "flashSuitChecked": true
+      "requires": [
+        {"noBlueSuit": {}}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 4],
+      "name": "Keep Blue Suit in Sand",
+      "requires": [
+        {"haveBlueSuit": {}},
+        {"notable": "Keep Blue Suit in Sand"}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "With Gravity, keep a blue suit in the sand by either walking off the ledge or doing a full height jump.",
+        "If suitless, do a full height spin jump and land without breaking spin."
+      ]
+    },
+    {
+      "id": 21,
+      "link": [1, 5],
+      "name": "Base",
+      "requires": [
+        "Gravity",
+        "Grapple",
+        "SpaceJump"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "id": 28,
+      "link": [1, 5],
+      "name": "Suitless Flatley Turnaround Climb",
+      "requires": [
+        {"notable": "Suitless Flatley Turnaround Climb"},
+        "Grapple",
+        "canSuitlessMaridia",
+        "HiJump",
+        "canFlatleyJump",
+        "canSunkenTileWideWallClimb"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Use a flatley turnaround jump to get Samus inside the gap during a spinjump.",
+        "Samus must jump from the left side platform."
+      ]
     },
     {
       "id": 8,
@@ -256,6 +324,7 @@
         "canBePatient"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "This climb is from the left side of the left room, the room with the breakable grapple block.",
         "Climb up 3 screens.",
@@ -279,6 +348,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "Resetting the room through this door puts you in East Pants Room, which is full of water.",
         "So effectively there is only one chance to use the runway, unless Gravity is available;",
@@ -292,7 +362,8 @@
       "requires": [
         "h_CrystalFlash"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -302,7 +373,8 @@
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -313,6 +385,7 @@
       ],
       "gModeRegainMobility": {},
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "This is not possible in vanilla, because there is no way to enter through this door.",
         "FIXME: There is a strat from here to 5 with IBJ (Spring Ball + HiJump or ceiling bomb jump)."
@@ -323,9 +396,23 @@
       "link": [3, 1],
       "name": "Base",
       "requires": [
-        "h_navigateUnderwater"
+        {"or": [
+          {"and": [
+            "Gravity",
+            {"or": [
+              "SpaceJump",
+              "Grapple",
+              {"noBlueSuit": {}}
+            ]}
+          ]},
+          {"and": [
+            {"disableEquipment": "Gravity"},
+            "canSuitlessMaridia"
+          ]}
+        ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Jump from door platform to door platform while avoiding the sand."
     },
     {
@@ -340,6 +427,7 @@
         "canBePatient"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "This climb is right side of the left room - the room with the breakable grapple block.",
         "Climb up 3 screens."
@@ -348,7 +436,7 @@
     {
       "id": 15,
       "link": [3, 2],
-      "name": "Shinespark (From the Right)",
+      "name": "Come in Shinecharged, Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -365,6 +453,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Preselect Grapple and be ready to use it when entering the room. Release up or angle up before releasing Grapple so the shinespark does not activate instantly.",
         "Use the windup frames for a shinespark to extend the duration timer."
@@ -373,7 +462,7 @@
     {
       "id": 41,
       "link": [3, 2],
-      "name": "Diagonal Shinespark (From the Right)",
+      "name": "Come in Shinecharged, Diagonal Shinespark",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -393,6 +482,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Preselect Grapple and be ready to use it when entering the room. Release up or angle up before releasing Grapple so the shinespark does not activate instantly.",
         "Fall into the sand below the Grapple block with Gravity disabled.",
@@ -411,39 +501,55 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 17,
       "link": [3, 4],
       "name": "Base",
-      "requires": [],
-      "flashSuitChecked": true
+      "requires": [
+        {"noBlueSuit": {}}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [3, 4],
+      "name": "Keep Blue Suit in Sand",
+      "requires": [
+        {"haveBlueSuit": {}},
+        {"notable": "Keep Blue Suit in Sand"}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "With Gravity, keep a blue suit in the sand by either walking off the ledge or doing a full height jump.",
+        "If suitless, do a full height spin jump and land without breaking spin."
+      ]
     },
     {
       "id": 18,
       "link": [4, 1],
       "name": "Base",
       "requires": [
-        "h_navigateUnderwater",
         {"or": [
-          "canPlayInSand",
+          "Gravity",
           {"and": [
-            "HiJump",
-            "h_useSpringBall"
-          ]},
-          {"and": [
-            "Gravity",
+            "canSuitlessMaridia",
             {"or": [
-              "HiJump",
-              "h_useSpringBall",
-              "SpaceJump"
+              "canPlayInSand",
+              "HiJump"
             ]}
           ]}
         ]}
       ],
       "flashSuitChecked": true,
-      "devNote": "It is easy enough to get out of the sand without tech, because the strats only require briefly entering it, but it is there as turning around at the wrong time will make Samus sink."
+      "blueSuitChecked": true,
+      "devNote": [
+        "It is easy enough to get out of the sand without tech, because the strats only require briefly entering it,",
+        "but it is there as turning around at the wrong time will make Samus sink."
+      ]
     },
     {
       "id": 19,
@@ -469,6 +575,7 @@
         ]}
       ],
       "flashSuitChecked": false,
+      "blueSuitChecked": true,
       "note": [
         "Use the grapple block to initiate a Grapple Jump to climb up to the higher level and above the water line.",
         "Aiming the Grapple Jump to line up with the one tile hole is difficult and Samus is moving at high speeds.",
@@ -480,10 +587,10 @@
     {
       "id": 36,
       "link": [4, 2],
-      "name": "Use Flash Suit",
+      "name": "Use Stored Spark",
       "requires": [
         "Grapple",
-        {"useFlashSuit": {}},
+        "h_storedSpark",
         "canDodgeWhileShooting",
         {"or": [
           {"shinespark": {"frames": 53, "excessFrames": 5}},
@@ -495,6 +602,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Shinespark up right in order to avoid the Menus. Samus can save some Energy with HiJump and a flatley jump from the left platform."
     },
     {
@@ -502,36 +610,20 @@
       "link": [4, 3],
       "name": "Base",
       "requires": [
-        "h_navigateUnderwater",
         {"or": [
-          "canPlayInSand",
+          "Gravity",
           {"and": [
-            "HiJump",
-            "h_useSpringBall"
-          ]},
-          {"and": [
-            "Gravity",
+            "canSuitlessMaridia",
             {"or": [
-              "HiJump",
-              "h_useSpringBall",
-              "SpaceJump"
+              "canPlayInSand",
+              "HiJump"
             ]}
           ]}
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "It is easy enough to get out of the sand without tech, because the strats only require briefly entering it, but it is there as turning around at the wrong time will make Samus sink."
-    },
-    {
-      "id": 21,
-      "link": [4, 5],
-      "name": "Base",
-      "requires": [
-        "Gravity",
-        "Grapple",
-        "SpaceJump"
-      ],
-      "flashSuitChecked": true
     },
     {
       "id": 22,
@@ -545,6 +637,7 @@
         "canPlayInSand"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Break the grapple block, then jump on the sand to get through the hole.",
         "Break spin before touching the sand, and then spinjump to get a good jump off of the sand.",
@@ -563,6 +656,7 @@
         "canPlayInSand"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Break spin before touching the sand, and then spinjump to get a good jump off of the sand."
     },
     {
@@ -579,6 +673,7 @@
         "canStationarySpinJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Break spin before touching the sand, and then spinjump to get a good jump off of the sand."
     },
     {
@@ -589,10 +684,12 @@
         "Gravity",
         "Grapple",
         "h_useSpringBall",
-        "canJumpIntoIBJ"
+        "canJumpIntoIBJ",
+        {"noBlueSuit": {}}
       ],
       "flashSuitChecked": true,
-      "note": "Springball can keep Samus out of the sand.  Place the first bomb right after Samus begins falling back towards the sand."
+      "blueSuitChecked": true,
+      "note": "Spring Ball can keep Samus out of the sand.  Place the first bomb right after Samus begins falling back towards the sand."
     },
     {
       "id": 26,
@@ -607,6 +704,7 @@
         "canTrickyJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Gets above the grapple block by doing a well-positioned and well-timed Gravity jump following a good jump off the sand.",
         "It is also possible to do this off of a wall jump on the side immediately followed by a gravity jump.",
@@ -627,28 +725,11 @@
         "canTrickyJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Requires a mid-air SpringBall jump off the sand.",
         "Break spin before touching the sand, and then spinjump to get a good jump off of the sand.",
         "A stationary spinjump or a turnaround spin jump can help but morphing will remove all horizontal momentum."
-      ]
-    },
-    {
-      "id": 28,
-      "link": [4, 5],
-      "name": "Suitless Flatley Turnaround Climb",
-      "requires": [
-        {"notable": "Suitless Flatley Turnaround Climb"},
-        "Grapple",
-        "canSuitlessMaridia",
-        "HiJump",
-        "canFlatleyJump",
-        "canSunkenTileWideWallClimb"
-      ],
-      "flashSuitChecked": true,
-      "note": [
-        "Use a flatley turnaround jump to get Samus inside the gap during a spinjump.",
-        "Samus must jump from the left side platform."
       ]
     },
     {
@@ -662,6 +743,7 @@
         "canMidairWiggle"
       ],
       "flashSuitChecked": false,
+      "blueSuitChecked": true,
       "note": [
         "Use the grapple block to initiate a Grapple Jump to climb up to the higher level.",
         "Aiming the Grapple Jump to line up with the one tile hole is difficult and Samus is moving at high speeds."
@@ -673,6 +755,7 @@
       "name": "Avoid Sand",
       "requires": [
         "canSuitlessMaridia",
+        {"disableEquipment": "Gravity"},
         "canTrickyJump",
         {"or": [
           {"and": [
@@ -687,6 +770,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Using movement tricks to reduce fall speed even slightly can avoid touching the sand.",
         "A Flatley style turnaround over the grapple block hole reduces fall speed some, but also needs a down back or a tiny jump."
@@ -703,11 +787,13 @@
         {"or": [
           "ScrewAttack",
           "canPseudoScrew",
+          {"haveBlueSuit": {}},
           {"enemyDamage": {"enemy": "Menu", "type": "contact", "hits": 1}},
           "h_pauseAbuseMinimalReserveRefill"
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "The swarm of Menus will attack Samus at the top of the room. Tank them or kill them with Screw or Pseudo Screw.",
       "devNote": "FIXME: 5->2 strats could be added, including x-ray climb and g-mode."
     },
@@ -720,12 +806,14 @@
         "canConsecutiveWalljump",
         {"or": [
           "ScrewAttack",
+          {"haveBlueSuit": {}},
           "canTrickyWalljump",
           "canWalljumpWithCharge",
           {"enemyDamage": {"enemy": "Menu", "type": "contact", "hits": 1}}
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "The swarm of Menus will attack Samus at the top of the room. Tank them, carefully dodge them, or kill them with Screw or Pseudo Screw.",
       "devNote": "The Menus prevent a reliable IBJ."
     },
@@ -747,10 +835,12 @@
           "ScrewAttack",
           "canTrickyWalljump",
           "canPseudoScrew",
+          {"haveBlueSuit": {}},
           "h_pauseAbuseMinimalReserveRefill"
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Watch for the water level to start falling to time the jump to escape at its lowest point.",
         "Then use SpaceJump to splash on top of the water.",
@@ -772,6 +862,7 @@
         "canDoubleBombJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Wait the water tide to reach its peak, then crouch jump into a spring ball jump into an IBJ.",
         "Perform the spring ball jump near max height.",
@@ -792,15 +883,16 @@
       "requires": [
         "canUnderwaterWalljumpBreakFree"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 38,
       "link": [5, 2],
-      "name": "Use Flash Suit",
+      "name": "Use Stored Spark",
       "requires": [
         "Grapple",
-        {"useFlashSuit": {}},
+        "h_storedSpark",
         "canDodgeWhileShooting",
         {"or": [
           {"shinespark": {"frames": 46, "excessFrames": 5}},
@@ -820,14 +912,31 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Shinespark up right in order to avoid the Menus."
     },
     {
       "id": 35,
       "link": [5, 4],
       "name": "Base",
-      "requires": [],
-      "flashSuitChecked": true
+      "requires": [
+        {"noBlueSuit": {}}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [5, 4],
+      "name": "Keep Blue Suit in Sand",
+      "requires": [
+        {"haveBlueSuit": {}},
+        {"notable": "Keep Blue Suit in Sand"}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Simply walk off the ledge (with or without Gravity) and hold forward, to keep a blue suit in the sand."
+      ]
     },
     {
       "id": 40,
@@ -838,12 +947,16 @@
         "Grapple",
         "Gravity",
         "SpaceJump",
-        "ScrewAttack",
+        {"or": [
+          "ScrewAttack",
+          {"haveBlueSuit": {}}
+        ]},
         "canConsecutiveWalljump",
         {"cycleFrames": 1120}
       ],
       "farmCycleDrops": [{"enemy": "Menu", "count": 6}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": ["FIXME: Many other options are possible for movement and weapons."]
     }
   ],
@@ -896,8 +1009,17 @@
         "When close to the top, perform a spring ball jump to reach the ledge;",
         "release jump as soon as Samus is high enough to clear the ledge, in order to avoid taking a Menu hit."
       ]
+    },
+    {
+      "id": 6,
+      "name": "Keep Blue Suit in Sand",
+      "note": [
+        "With Gravity, keep a blue suit in the sand by either walking off the ledge or doing a full height jump.",
+        "If suitless, do a full height spin jump and land without breaking spin.",
+        "In every case, hold forward while landing and then keep holding forward to walk on the sand."
+      ]
     }
   ],
   "nextStratId": 42,
-  "nextNotableId": 6
+  "nextNotableId": 7
 }


### PR DESCRIPTION
Pants Room:
- 4->1 and 4->3 requirements didn't seem to make sense (seemingly confused with 4->5 requirements?).
- Moved the 4->5 Base strat (Gravity + Grapple + SpaceJump) to be 1->5, since you don't need to go into the sand.
- Similarly, moved 4->5 "Suitless Flatley Turnaround Climb" to be 1->5.

East Pants Room:
- New strat 1->3 "Gravity Flatley Jump", to go up with a blue suit. There can be other options that land on the sand first but this didn't seem important.