### PR TITLE
Add lenience to Screw Attack Room speedy jump

### DIFF
--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -1519,7 +1519,17 @@
           "h_backIntoCorner"
         ]},
         {"doorUnlockedAtNode": 2},
-        {"heatFrames": 160}
+        {"or": [
+          {"and": [
+            "canInsaneJump",
+            {"heatFrames": 160}
+          ]},
+          {"and": [
+            "canTrickyJump",
+            {"heatFrames": 200}
+          ]},
+          {"heatFrames": 445}
+        ]}
       ],
       "unlocksDoors": [
         {
@@ -1536,7 +1546,8 @@
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note": "Position yourself in the door way, then run and jump. Makes it possible to walljump up."
+      "note": "Position Samus in the door way, then run and jump. Makes it possible to walljump up.",
+      "devNote": "Without canTrickyJump, this gives enough lenience for a second attempt."
     },
     {
       "id": 19,

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -1518,17 +1518,15 @@
           "canTrickyJump",
           "h_backIntoCorner"
         ]},
-        {"doorUnlockedAtNode": 2},
         {"or": [
-          {"and": [
-            "canInsaneJump",
-            {"heatFrames": 160}
-          ]},
-          {"and": [
-            "canTrickyJump",
-            {"heatFrames": 200}
-          ]},
-          {"heatFrames": 445}
+          "canInsaneJump",
+          {"heatFrames": 40}
+        ]},
+        {"doorUnlockedAtNode": 2},
+        {"heatFrames": 160},
+        {"or": [
+          "canTrickyJump",
+          {"heatFrames": 200}
         ]}
       ],
       "unlocksDoors": [
@@ -1547,7 +1545,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": "Position Samus in the door way, then run and jump. Makes it possible to walljump up.",
-      "devNote": "Without canTrickyJump, this gives enough lenience for a second attempt."
+      "devNote": "Without canTrickyJump, this assumes you miss the jump and have to set it up a second time."
     },
     {
       "id": 19,


### PR DESCRIPTION
This felt pretty difficult to get first-try. Though, maybe it is reliable to get first-try if you have more breathing room and you dont need a full second attempt. What do you think? 

In the video, it looks like it takes about 240 frames (~240 to 180E). At those counts, it's 50% more than the strat says, which would put the video noticeably below VH-level execution. 
https://dev.maprando.com/logic/room/151/2/3/18