### PR TITLE
Fix missing shinespark requirements on X-mode blue suit strats

### DIFF
--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -1221,7 +1221,8 @@
               }}
             ]}
           ]}
-        ]}
+        ]},
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
@@ -2222,7 +2223,8 @@
               }}
             ]}
           ]}
-        ]}
+        ]},
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/brinstar/kraid/Kraid Eye Door Room.json
+++ b/region/brinstar/kraid/Kraid Eye Door Room.json
@@ -350,7 +350,8 @@
       },
       "requires": [
         {"shineChargeFrames": 95},
-        "h_thornXModeBlueSuitWithoutLenience"
+        "h_thornXModeBlueSuitWithoutLenience",
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -366,7 +367,8 @@
         }
       },
       "requires": [
-        "h_thornXModeBlueSuitWithoutLenience"
+        "h_thornXModeBlueSuitWithoutLenience",
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1403,7 +1405,8 @@
       },
       "requires": [
         {"shineChargeFrames": 95},
-        "h_thornXModeBlueSuitWithoutLenience"
+        "h_thornXModeBlueSuitWithoutLenience",
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true
@@ -1419,7 +1422,8 @@
         }
       },
       "requires": [
-        "h_thornXModeBlueSuitWithoutLenience"
+        "h_thornXModeBlueSuitWithoutLenience",
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -2035,7 +2035,8 @@
           {"canShineCharge": {"usedTiles": 14, "openEnd": 1}}
         ]},
         {"spikeHits": 1},
-        "h_spikeXModeBlueSuit"
+        "h_spikeXModeBlueSuit",
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -510,7 +510,7 @@ def process_req_speed_state(req, states, err_fn):
                      "h_thornXModeBlueSuit", "h_thornXModeBlueSuitWithoutLenience"]:
             if not states.issubset(["shinecharging", "shinecharged", "preshinespark"]):
                 err_fn(f"{req} while not in shinecharging/shinecharged/preshinespark")
-            states = {"shinespark"}
+            states = {"preshinespark"}
         elif req in ["canDoubleXModeBlueSuit", "h_spikeDoubleXModeBlueSuit", "h_thornDoubleXModeBlueSuit",
                      "h_thornDoubleXModeBlueSuitWithoutLenience"]:
             states = {"shinespark"}


### PR DESCRIPTION
This fixes an issue reported in the Discord (https://discord.com/channels/1053421401354285129/1053436236628496454/1492874425744232510).

The test is adjusted to catch cases like this from happening in the future.

I considered including `{"shinespark": {"frames": 0, "excessFrames": 0}` in the helpers, but I think it's better to leave it explicit since for superjumps there may be a non-zero amount of frames required.