### PR TITLE
Rest of blue suit carry logic

### DIFF
--- a/region/brinstar/blue/Blue Brinstar Boulder Room.json
+++ b/region/brinstar/blue/Blue Brinstar Boulder Room.json
@@ -216,6 +216,7 @@
         {"types": ["powerbomb"], "requires": []}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Some missed shots are expected for missile and super doors at this difficulty."
     },
     {
@@ -723,6 +724,7 @@
         {"disableEquipment": "HiJump"}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Artificial morph on entry to land on the doorsill.",
         "From the left edge, pause then press left and jump just before the pause fully triggers.",
@@ -1024,6 +1026,7 @@
         {"shinespark": {"frames": 7, "excessFrames": 2}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "There is a small pixel range which lands on the platform and does not touch the boulder."
     },
     {

--- a/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
+++ b/region/brinstar/blue/Blue Brinstar Energy Tank Room.json
@@ -27,7 +27,8 @@
             {
               "name": "Base",
               "requires": [],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -1104,7 +1105,8 @@
         ]}
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 76,

--- a/region/brinstar/blue/Morph Ball Room.json
+++ b/region/brinstar/blue/Morph Ball Room.json
@@ -34,6 +34,7 @@
                 {"obstaclesCleared": ["C"]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "devNote": "Obstacle can be destroyed either going 1 -> 6 or 6 -> 1."
             }
           ],
@@ -112,7 +113,8 @@
                   "h_allItemsSpawned"
                 ]}
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "note": "Item doesn't appear before Zebes is awakened."
@@ -1417,6 +1419,7 @@
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Tank the Sidehopper hits or kill them after a single hit by quickly placing a Power Bomb.",
         "It is also possible to kill the Sidehoppers with a very fast Screw Attack, if Samus has Morph Ball.",

--- a/region/brinstar/green/Brinstar Pre-Map Room.json
+++ b/region/brinstar/green/Brinstar Pre-Map Room.json
@@ -46,11 +46,13 @@
                     "canSlowShortCharge",
                     {"getBlueSpeed": {"usedTiles": 14, "openEnd": 1}},
                     "canSpeedball"
-                  ]}
+                  ]},
+                  {"haveBlueSuit": {}}
                 ]}
               ],
               "clearsObstacles": ["A"],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": [
                 "Both sides of the room must be accessed to reach all enemies and unlock the door.",
                 "Beyond that, the enemies can be killed with Power Beam."
@@ -249,6 +251,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "There is 1 unusable tile in this runway."
     },
     {

--- a/region/brinstar/green/Green Brinstar Main Shaft.json
+++ b/region/brinstar/green/Green Brinstar Main Shaft.json
@@ -178,7 +178,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -5554,6 +5555,7 @@
         {"shinespark": {"frames": 21, "excessFrames": 12}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "With a runway of at least 4 tiles in the adjacent room, jump just before hitting the right wall then spark diagonally to the left at the top of the jump.",
       "devNote": "FIXME: This could be done with a blue suit but is not possible to model currently."
     },

--- a/region/brinstar/green/Spore Spawn Kihunter Room.json
+++ b/region/brinstar/green/Spore Spawn Kihunter Room.json
@@ -27,6 +27,7 @@
               "name": "Base",
               "requires": [],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "The enemies can be killed with Power Beam"
             }
           ],
@@ -55,6 +56,7 @@
               "name": "Base",
               "requires": [],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "The enemies can be killed with Power Beam"
             }
           ],

--- a/region/brinstar/green/Spore Spawn Room.json
+++ b/region/brinstar/green/Spore Spawn Room.json
@@ -157,6 +157,7 @@
       ],
       "setsFlags": ["f_DefeatedSporeSpawn"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
        "Stand on the right half of Spore Spawn's pit. When Spore Spawn begins it's third left rotation begin to charge the SBA attack.",
        "Perform a full height jump just as the SBA attack is about to fire."
@@ -350,6 +351,7 @@
         "canRiskPermanentLossOfAccess"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Crystal Flash on the left side of the room when Spore Spawn starts moving, or on the right side when it is in the top right of its swoop."
       ]

--- a/region/brinstar/kraid/Kraid Recharge Station.json
+++ b/region/brinstar/kraid/Kraid Recharge Station.json
@@ -112,14 +112,16 @@
       "link": [2, 3],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
       "link": [3, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -128,7 +130,8 @@
       "requires": [
         "h_useMissileRefillStation"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -138,6 +141,7 @@
         "h_RefillStationAllAmmo10PowerBombCrystalFlash"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "In quick succession, place a Power Bomb, refill at the refill station, then morph and Crystal Flash.",
         "Holding an angle button and/or down while exiting the dialogue box is required, as it will prevent Samus from being boosted by the bomb."

--- a/region/brinstar/kraid/Kraid Room.json
+++ b/region/brinstar/kraid/Kraid Room.json
@@ -29,7 +29,8 @@
               "requires": [
                 "f_DefeatedKraid"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -57,7 +58,8 @@
               "requires": [
                 "f_DefeatedKraid"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/brinstar/kraid/Warehouse Energy Tank Room.json
+++ b/region/brinstar/kraid/Warehouse Energy Tank Room.json
@@ -29,6 +29,7 @@
                 {"obstaclesCleared": ["A"]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "This is a softlock if no means to kill Beetoms are available."
             }
           ],

--- a/region/brinstar/kraid/Warehouse Zeela Room.json
+++ b/region/brinstar/kraid/Warehouse Zeela Room.json
@@ -42,7 +42,8 @@
               "requires": [
                 "f_DefeatedKraid"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/brinstar/pink/Big Pink.json
+++ b/region/brinstar/pink/Big Pink.json
@@ -3614,7 +3614,8 @@
         "canXRayTurnaround"
       ],
       "clearsObstacles": ["D"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 88,

--- a/region/brinstar/pink/Mission Impossible Room.json
+++ b/region/brinstar/pink/Mission Impossible Room.json
@@ -31,6 +31,7 @@
                 {"obstaclesCleared": ["A"]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "devNote": "Obstacle must be destroyed by going to 4 and back."
             }
           ],

--- a/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
+++ b/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
@@ -31,7 +31,8 @@
               "requires": [
                 {"obstaclesCleared": ["A"]}
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]
@@ -60,7 +61,8 @@
               "requires": [
                 {"obstaclesCleared": ["A"]}
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"],
@@ -821,6 +823,7 @@
       ],
       "resetsObstacles": ["C"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "A one frame dash jump will give Samus 4 pixels of leniency for the bounce position, two frames is pixel perfect and more than two frames it doesn't work.",
         "Samus will jump approximately two tiles higher with a one frame jump compared to a two frame jump."
@@ -1317,7 +1320,8 @@
       ],
       "resetsObstacles": ["C"],
       "wallJumpAvoid": true,
-      "flashSuitChecked": true  ,
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "A one frame dash jump will give Samus maximum leniency for bouncing into the spikes without hitting the wall to build a shinecharge"
       ]

--- a/region/brinstar/pink/Waterway Energy Tank Room.json
+++ b/region/brinstar/pink/Waterway Energy Tank Room.json
@@ -282,7 +282,8 @@
         {"enemy": "Puyo", "count": 3},
         {"enemy": "Skultera", "count": 2}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "link": [1, 1],

--- a/region/brinstar/red/Beta Power Bomb Room.json
+++ b/region/brinstar/red/Beta Power Bomb Room.json
@@ -29,7 +29,8 @@
               "requires": [
                 {"obstaclesCleared": ["A"]}
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]

--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -1421,6 +1421,7 @@
         {"spikeHits": 1}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Crouch jump and Spring Ball near the peak of the jump to hit the side of the spikes and boost up onto them.",
         "This is also possible with a springwall, or from standing on the spikes to avoid the crouch jump.",

--- a/region/brinstar/red/Red Tower.json
+++ b/region/brinstar/red/Red Tower.json
@@ -1625,7 +1625,8 @@
         "h_CrystalFlash"
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 152,

--- a/region/brinstar/red/X-Ray Scope Room.json
+++ b/region/brinstar/red/X-Ray Scope Room.json
@@ -28,6 +28,7 @@
                 "h_usePowerBomb"
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "Raise the shutter before checking the item to not become stuck."
             }
           ]

--- a/region/ceres/main/58 Escape.json
+++ b/region/ceres/main/58 Escape.json
@@ -56,6 +56,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -71,7 +72,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -82,6 +84,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -102,6 +105,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -122,6 +126,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -139,6 +144,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -146,7 +152,8 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -165,7 +172,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -184,14 +192,16 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -210,7 +220,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -229,7 +240,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -243,6 +255,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -258,7 +271,8 @@
           "openEnd": 0
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 15,
@@ -278,6 +292,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -298,6 +313,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -315,6 +331,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ],

--- a/region/ceres/main/Ceres Elevator Room.json
+++ b/region/ceres/main/Ceres Elevator Room.json
@@ -28,7 +28,8 @@
               "requires": [
                 "f_DefeatedCeresRidley"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -65,14 +66,16 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -85,7 +88,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
   ],
   "notables": [],

--- a/region/ceres/main/Ceres Ridley's Room.json
+++ b/region/ceres/main/Ceres Ridley's Room.json
@@ -28,7 +28,8 @@
               "requires": [
                 "f_DefeatedCeresRidley"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -60,7 +61,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -70,7 +72,8 @@
         "h_usePowerBomb"
       ],
       "bypassesDoorShell": "yes",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -86,7 +89,8 @@
         }
       },
       "bypassesDoorShell": "yes",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,
@@ -127,6 +131,7 @@
       ],
       "setsFlags": ["f_DefeatedCeresRidley"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Just taking damage is enough to finish the fight.",
       "devNote": [
         "It is possible to finish the fight with more Reserve Energy.",

--- a/region/ceres/main/Dead Scientist Room.json
+++ b/region/ceres/main/Dead Scientist Room.json
@@ -57,6 +57,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -74,7 +75,8 @@
           "steepDownTiles": 3
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -85,6 +87,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -105,6 +108,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -125,6 +129,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -142,6 +147,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -149,7 +155,8 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -168,7 +175,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -187,14 +195,16 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -213,7 +223,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -232,7 +243,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -247,6 +259,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -264,7 +277,8 @@
           "steepDownTiles": 3
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 15,
@@ -284,6 +298,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -304,6 +319,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -321,6 +337,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ],

--- a/region/ceres/main/Falling Tile Room.json
+++ b/region/ceres/main/Falling Tile Room.json
@@ -62,6 +62,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -78,7 +79,8 @@
           "steepUpTiles": 3
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -89,6 +91,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -109,6 +112,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -129,6 +133,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -146,6 +151,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Destroy the left door with a Power Bomb."
     },
     {
@@ -167,6 +173,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -174,7 +181,8 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -193,7 +201,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
@@ -217,14 +226,16 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -243,7 +254,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -267,7 +279,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 14,
@@ -282,6 +295,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -298,7 +312,8 @@
           "steepUpTiles": 3
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 16,
@@ -318,6 +333,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -338,6 +354,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -355,6 +372,7 @@
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Destroy the right door with a Power Bomb."
     },
     {
@@ -376,6 +394,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ],

--- a/region/ceres/main/Magnet Stairs Room.json
+++ b/region/ceres/main/Magnet Stairs Room.json
@@ -64,6 +64,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -79,7 +80,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 3,
@@ -90,6 +92,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -110,6 +113,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -130,6 +134,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -147,6 +152,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     },
     {
@@ -154,7 +160,8 @@
       "link": [1, 2],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 8,
@@ -173,7 +180,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -192,14 +200,16 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,
       "link": [2, 1],
       "name": "Base",
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 11,
@@ -218,7 +228,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -239,7 +250,8 @@
         }
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 13,
@@ -253,6 +265,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Because of Ceres's slow opening doors, runways are at most 4 tiles with 0 open ends + 4 more pixels."
     },
     {
@@ -269,7 +282,8 @@
           "steepDownTiles": 3
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 15,
@@ -289,6 +303,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -309,6 +324,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "Samus can open Ceres doors even while in indirect G-Mode."
     },
     {
@@ -326,6 +342,7 @@
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Destroy the right door with a Power Bomb."
     },
     {
@@ -344,6 +361,7 @@
       ],
       "clearsObstacles": ["A", "B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Destroy both doors with a Power Bomb placed in the middle of the room."
     }
   ],

--- a/region/crateria/central/230 Missile Room.json
+++ b/region/crateria/central/230 Missile Room.json
@@ -43,6 +43,7 @@
                 ]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "devNote": [
                 "Item doesn't spawn until Zebes is awake.",
                 "Interestingly, the Chozo also has a scope that observes Samus, like in Blue Brinstar."

--- a/region/crateria/central/Bomb Torizo Room.json
+++ b/region/crateria/central/Bomb Torizo Room.json
@@ -422,6 +422,7 @@
         {"ammo": {"type": "Missile", "count": 10}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "As Bomb Torizo is standing, Crystal Flash in front of it in order to get hit and reserve trigger."
       ],

--- a/region/crateria/central/Climb Supers Room.json
+++ b/region/crateria/central/Climb Supers Room.json
@@ -1386,6 +1386,7 @@
       ],
       "collectsItems": [3],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Crystal Flash then Shinespark up to the item, touch it, and return through the speed block that is now air.",
         "Use the Boyons and acid to reserve trigger to exit G-mode below to collect the item."

--- a/region/crateria/central/Climb.json
+++ b/region/crateria/central/Climb.json
@@ -58,7 +58,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -93,7 +94,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -129,7 +131,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -165,7 +168,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -1471,7 +1475,8 @@
         "can4HighMidAirMorph",
         "canSpringBallBounce"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 50,

--- a/region/crateria/central/Crateria Power Bomb Room.json
+++ b/region/crateria/central/Crateria Power Bomb Room.json
@@ -162,7 +162,8 @@
         "canTrickySpikeSuit",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,
@@ -213,7 +214,8 @@
         "canTrickySpikeSuit",
         {"shinespark": {"frames": 1, "excessFrames": 1}}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 7,

--- a/region/crateria/central/Flyway.json
+++ b/region/crateria/central/Flyway.json
@@ -44,6 +44,7 @@
                 ]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "The end game sequence overrides the color lock."
             }
           ]

--- a/region/crateria/central/Landing Site.json
+++ b/region/crateria/central/Landing Site.json
@@ -33,7 +33,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -81,7 +82,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -113,7 +115,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -157,7 +160,8 @@
               "requires": [
                 "f_ZebesSetAblaze"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -703,7 +707,8 @@
         {"types": ["missiles", "super"], "requires": []},
         {"types": ["powerbomb"], "requires": ["never"]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 21,
@@ -1815,7 +1820,8 @@
         ]}
       ],
       "clearsObstacles": ["B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 71,
@@ -1826,7 +1832,8 @@
         {"shinespark": {"frames": 54, "excessFrames": 38}}
       ],
       "clearsObstacles": ["B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 98,

--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -33,7 +33,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -65,7 +66,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -97,7 +99,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -161,7 +164,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -193,7 +197,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -598,6 +603,7 @@
       },
       "requires": [],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "None of the tiles in-room are usable, because there is no reason to speedball if you can come in gaining blue speed."
     },
     {

--- a/region/crateria/central/Pit Room.json
+++ b/region/crateria/central/Pit Room.json
@@ -31,6 +31,7 @@
                 "Morph"
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": [
                 "Entering this room with Morph and any missile capacity (0 current missiles is fine) spawns the enemies in this room and makes both doors gray and unlockable by killing the enemies.",
                 "Once the enemies actually spawn, they can be killed with just Power Beam.",
@@ -65,6 +66,7 @@
               "name": "Base",
               "requires": [],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "This door is unlocked until having morph and missiles, and then free to open after with just power beam."
             }
           ],
@@ -101,6 +103,7 @@
                 ]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "Item doesn't spawn unless Samus has Morph and Missiles, even if Zebes is awake.",
               "devNote": "canAwakenZebes is included to indicate the knowledge for how to spawn the item, the tech's description discusses this item as well."
             }

--- a/region/crateria/east/Crab Maze.json
+++ b/region/crateria/east/Crab Maze.json
@@ -465,6 +465,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "It is required to avoid hitting the Sciser with the Power Bomb, and to position the Crystal Flash so that the Sciser can hit Samus from above so it avoids the light orb.",
         "Using the global counter-clockwise crab, the only spot in the room that is usable is the spot with the two shot blocks by the left door.",
@@ -973,6 +974,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "It is required to avoid hitting the Sciser with the Power Bomb, and to position the Crystal Flash so that the Sciser can hit Samus from above so it avoids the light orb.",
         "Using the global counter-clockwise crab, the only spot in the room that is usable is the spot with the two shot blocks by the left door.",

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -790,6 +790,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "It is required to avoid double hitting the Skultera with the Power Bomb,",
         "and to position the Crystal Flash so that the Skultera can hit Samus from above so it avoids the light orb.",
@@ -1162,7 +1163,7 @@
     {
       "id": 81,
       "link": [2, 3],
-      "name": "Direct G-mode Morph, Bomb Into Spring Ball Jump, Crystal Flash Interrupt",
+      "name": "Direct G-Mode Morph, Bomb Into Spring Ball Jump, Crystal Flash Interrupt",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -1190,6 +1191,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Perform a double Spring Ball jump using a precisely timed bomb boost",
         "to propel Samus upward just long enough to get the mid-air Spring Ball jump.",
@@ -1217,7 +1219,7 @@
     {
       "id": 82,
       "link": [2, 4],
-      "name": "Direct G-mode Morph, Crystal Flash Interrupt",
+      "name": "Direct G-Mode Morph, Crystal Flash Interrupt",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "direct",
@@ -1252,6 +1254,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "It is required to avoid double hitting the Skultera with the Power Bomb,",
         "and to position the Crystal Flash so that the Skultera can hit Samus from above so it avoids the light orb.",
@@ -1353,7 +1356,8 @@
         "h_storedSpark",
         {"shinespark": {"frames": 6, "excessFrames": 4}}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 36,
@@ -1463,6 +1467,7 @@
       ],
       "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "It is required to avoid double hitting the Skultera with the Power Bomb,",
         "and to position the Crystal Flash so that the Skultera can hit Samus from above so it avoids the light orb.",
@@ -1972,6 +1977,7 @@
       ],
       "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "It is required to avoid double hitting the Skultera with the Power Bomb,",
         "and to position the Crystal Flash so that the Skultera can hit Samus from above so it avoids the light orb.",

--- a/region/crateria/east/Homing Geemer Room.json
+++ b/region/crateria/east/Homing Geemer Room.json
@@ -237,7 +237,8 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 9,

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -523,6 +523,7 @@
         {"disableEquipment": "HiJump"}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "With Spring Ball, pause then press right and jump just before the pause fully triggers.",
         "Disable Spring Ball in order to get a large horizontal boost.",
@@ -685,7 +686,8 @@
       ],
       "collectsItems": [3],
       "flashSuitChecked": true,
-      "note": "This jump is much easier without HiJump or Speedbooster equipped."
+      "blueSuitChecked": true,
+      "note": "This jump is much easier without HiJump or Speed Booster equipped."
     },
     {
       "id": 21,
@@ -703,7 +705,8 @@
         ]}
       ],
       "collectsItems": [3],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 22,
@@ -998,6 +1001,7 @@
       ],
       "collectsItems": [3],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "With Spring Ball, pause then press forward and jump just before the pause fully triggers.",
         "Disable Spring Ball in order to get a large horizontal boost.",
@@ -1349,6 +1353,7 @@
       ],
       "collectsItems": [3],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "With Spring Ball, pause then press right and jump just before the pause fully triggers.",
         "Disable Spring Ball in order to get a large horizontal boost.",
@@ -1488,7 +1493,8 @@
         "h_storedSpark",
         {"shinespark": {"frames": 4, "excessFrames": 2}}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 60,

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -88,7 +88,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -1278,7 +1279,8 @@
         }
       },
       "requires": [],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 41,
@@ -3006,6 +3008,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "It may be best to have shorter, later jumps to prevent bonking the ceiling or hitting the Ripper."
     },
     {

--- a/region/crateria/west/Gauntlet Energy Tank Room.json
+++ b/region/crateria/west/Gauntlet Energy Tank Room.json
@@ -522,6 +522,7 @@
       ],
       "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Crystal Flashing on the Zebbo spawner will usually not deal enough damage to Samus to trigger reserves.",
         "One way to make this fairly reliable is to kill the Yapping Maw then take a Zebbo hit while on its spawner,",

--- a/region/crateria/west/Lower Mushrooms.json
+++ b/region/crateria/west/Lower Mushrooms.json
@@ -100,7 +100,8 @@
           "openEnd": 1
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,

--- a/region/crateria/west/Statues Room.json
+++ b/region/crateria/west/Statues Room.json
@@ -30,7 +30,8 @@
             {
               "name": "Base",
               "requires": [],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/crateria/west/Terminator Room.json
+++ b/region/crateria/west/Terminator Room.json
@@ -377,12 +377,13 @@
     {
       "id": 14,
       "link": [2, 2],
-      "name": "G-Mode Setup - Get hit by Geemer or Waver",
+      "name": "G-Mode Setup - Get Hit by Geemer or Waver",
       "requires": [],
       "exitCondition": {
         "leaveWithGModeSetup": {}
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 15,

--- a/region/lowernorfair/east/Amphitheatre.json
+++ b/region/lowernorfair/east/Amphitheatre.json
@@ -366,6 +366,7 @@
         "h_heatedGModeOpenDifferentDoor"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Cross the room while avoiding the pirate's stationary invisible lasers.",
         "On entry, fall to the right to land past the first pirate, then run and jump over the next pirate and continue to the top door.",
@@ -626,7 +627,8 @@
         {"heatFrames": 180}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 55,
@@ -1712,6 +1714,7 @@
         "h_heatedCrystalFlash"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "This requires acting quickly enough that the acid does not catch Samus,",
         "but this is not difficult to do.",

--- a/region/lowernorfair/east/Fast Pillars Setup Room.json
+++ b/region/lowernorfair/east/Fast Pillars Setup Room.json
@@ -477,6 +477,7 @@
         {"heatFrames": 120}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Walljump from directly above the door to avoid the left wall pirate."
     },
     {

--- a/region/lowernorfair/east/Lower Norfair Fireflea Room.json
+++ b/region/lowernorfair/east/Lower Norfair Fireflea Room.json
@@ -1521,7 +1521,8 @@
         "canDash",
         "canUseIFrames"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 39,

--- a/region/lowernorfair/east/Lower Norfair Spring Ball Maze.json
+++ b/region/lowernorfair/east/Lower Norfair Spring Ball Maze.json
@@ -1200,6 +1200,7 @@
       ],
       "collectsItems": [4],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "It is tricky to climb the room without fully overloading PLMs.",
         "With Spring Ball, jump to barely land on the lowest platform while avoiding the camera scroll blocks one tile above, then use Spring Ball again to jump to the next platform.",
@@ -2190,9 +2191,14 @@
       "link": [6, 7],
       "name": "Base",
       "requires": [
-        {"heatFrames": 160}
+        {"heatFrames": 160},
+        {"or": [
+          "canDash",
+          {"heatFrames": 50}
+        ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 51,
@@ -2367,7 +2373,8 @@
           "requires": [{"heatFrames": 60}]
         }
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 58,

--- a/region/lowernorfair/east/Main Hall.json
+++ b/region/lowernorfair/east/Main Hall.json
@@ -235,6 +235,7 @@
         {"heatFrames": 900}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "High jumps for more control when landing."
     },
     {

--- a/region/lowernorfair/east/Metal Pirates Room.json
+++ b/region/lowernorfair/east/Metal Pirates Room.json
@@ -29,7 +29,8 @@
               "requires": [
                 {"obstaclesCleared": ["A"]}
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"],

--- a/region/lowernorfair/east/Mickey Mouse Room.json
+++ b/region/lowernorfair/east/Mickey Mouse Room.json
@@ -35,6 +35,7 @@
                 {"obstaclesCleared": ["D"]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "devNote": [
                 "The Multiviolas are far away and can't be killed from here, hence the obstacle requirement.",
                 "The only path through this room where killing them and leaving here would be meaningful would have passed through node 4 at some point.",
@@ -48,6 +49,7 @@
                 {"obstaclesCleared": ["E"]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "devNote": "The obstacles must already be cleared on the assumption that Samus travels to 7 or 6 and back to unlock the door."
             }
           ],
@@ -397,7 +399,8 @@
       ],
       "resetsObstacles": ["A", "B", "C", "D", "E", "F"],
       "farmCycleDrops": [{"enemy": "Multiviola", "count": 1}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 90,
@@ -2047,7 +2050,8 @@
         "h_heatedCrystalFlash"
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 44,
@@ -2058,7 +2062,8 @@
         {"heatFrames": 120}
       ],
       "clearsObstacles": ["A", "B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 45,

--- a/region/lowernorfair/west/Acid Statue Room.json
+++ b/region/lowernorfair/west/Acid Statue Room.json
@@ -1135,9 +1135,9 @@
     {
       "id": 55,
       "link": [5, 1],
-      "name": "Shinespark Slope Clip X-Ray Climb (Use Flash Suit)",
+      "name": "Shinespark Slope Clip X-Ray Climb (Use Stored Spark)",
       "requires": [
-        {"useFlashSuit": {}},
+        "h_storedSpark",
         {"shinespark": {"frames": 1, "excessFrames": 1}},
         "canShinesparkSlopeClip",
         "canXRayClimb",
@@ -1145,8 +1145,9 @@
         {"heatFrames": 1020}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
-        "Jump, press against the wall, and use a flash suit to spark into it, clipping inside of it.",
+        "Jump, press against the wall, and use a flash suit or blue suit to spark into it, clipping inside of it.",
         "From there, X-Ray climb to the top portion of the room (about 0.75 screens).",
         "Samus will be visible but off-camera, making the movement tricky."
       ]
@@ -1165,7 +1166,8 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 70,
@@ -1649,6 +1651,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Jump a high as possible, and use a flash suit or blue suit to diagonally spark either to the right or left to reach the top of the room.",
         "If heat protection is available, sparking diagonally left uses less energy;",
@@ -1661,7 +1664,7 @@
     {
       "id": 38,
       "link": [6, 4],
-      "name": "CF Grapple Clip",
+      "name": "Crystal Flash Grapple Clip",
       "requires": [
         "h_heatProof",
         "h_bombThings",
@@ -1670,7 +1673,8 @@
         "Grapple"
       ],
       "flashSuitChecked": true,
-      "note": "Menu to Grappling Beam before the crystal flash ends and mash shoot while holding down.",
+      "blueSuitChecked": true,
+      "note": "Menu to Grappling Beam before the Crystal Flash ends and mash shoot while holding down.",
       "devNote": "The extra Power Bomb or bombs is to get through the bomb blocks."
     },
     {

--- a/region/lowernorfair/west/Fast Ripper Room.json
+++ b/region/lowernorfair/west/Fast Ripper Room.json
@@ -772,7 +772,8 @@
           ]}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 6,
@@ -784,7 +785,8 @@
         "ScrewAttack"
       ],
       "clearsObstacles": ["B"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 69,

--- a/region/lowernorfair/west/Screw Attack Room.json
+++ b/region/lowernorfair/west/Screw Attack Room.json
@@ -1098,7 +1098,8 @@
       },
       "requires": [],
       "bypassesDoorShell": "yes",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 12,
@@ -1138,6 +1139,7 @@
       ],
       "clearsObstacles": ["B"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Use Screw Attack or a blue suit to pass through the bomb blocks before exiting G-mode below."
     },
     {
@@ -2111,6 +2113,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Use Screw Attack to pass through the bomb blocks and exit G-mode above."
     },
     {
@@ -2133,6 +2136,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Use a blue suit to pass through the bomb blocks and exit G-mode above."
     },
     {
@@ -3371,6 +3375,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Use Screw Attack or a blue suit to pass through the bomb blocks before exiting G-mode below."
     },
     {

--- a/region/maridia/inner-green/West Sand Hall.json
+++ b/region/maridia/inner-green/West Sand Hall.json
@@ -1038,6 +1038,7 @@
         {"noBlueSuit": {}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "It is possible to cross this segment with nothing. Cancel spin before hitting the sand, then get a good jump off the sand in multiple places."
     },
     {

--- a/region/maridia/inner-pink/Below Botwoon Energy Tank.json
+++ b/region/maridia/inner-pink/Below Botwoon Energy Tank.json
@@ -483,6 +483,7 @@
         "h_navigateUnderwater"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Fall down the left side of the sand entrance. If Samus gets stuck in the left sand pit, simply hold down and press jump to escape."
     },
     {

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -29,7 +29,8 @@
               "requires": [
                 "f_DefeatedBotwoon"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/maridia/inner-pink/Crab Shaft.json
+++ b/region/maridia/inner-pink/Crab Shaft.json
@@ -636,6 +636,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": ["never"]}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Spinjump through the shotblocks and fire a Plasma + Wave shot on the way down, clearing the crabs.",
         "Begin the Shinespark windup while the Beam shot travels towards the door to open it."

--- a/region/maridia/inner-pink/Draygon's Room.json
+++ b/region/maridia/inner-pink/Draygon's Room.json
@@ -30,7 +30,8 @@
               "requires": [
                 "f_DefeatedDraygon"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -58,7 +59,8 @@
               "requires": [
                 "f_DefeatedDraygon"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/maridia/inner-pink/East Cactus Alley.json
+++ b/region/maridia/inner-pink/East Cactus Alley.json
@@ -1863,12 +1863,22 @@
           "canInsaneJump",
           "canStationaryLateralMidAirMorph"
         ]},
-        "canNeutralDamageBoost",
+        {"or": [
+          "canNeutralDamageBoost",
+          {"and": [
+            "canSpringFling",
+            "h_midAirMorphDamageBoost"
+          ]}
+        ]},
         {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 2}}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": "When the Cacatac on the ground fires a spike, perform a Spring Ball jump to break the waterline and then hit the spike for extra height.",
+      "detailNote": [
+        "With a blue suit, after the mid-air Spring Ball jump Samus would be invulnerable and unable to take a boost from the spike.",
+        "But by unequipping Spring Ball again, it becomes possible."
+      ],
       "devNote": ["The crouch jump is not strictly necessary but it helps significantly."]
     },
     {

--- a/region/maridia/inner-pink/East Cactus Alley.json
+++ b/region/maridia/inner-pink/East Cactus Alley.json
@@ -1867,6 +1867,7 @@
         {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 2}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "When the Cacatac on the ground fires a spike, perform a Spring Ball jump to break the waterline and then hit the spike for extra height.",
       "devNote": ["The crouch jump is not strictly necessary but it helps significantly."]
     },

--- a/region/maridia/inner-yellow/Plasma Room.json
+++ b/region/maridia/inner-yellow/Plasma Room.json
@@ -31,7 +31,8 @@
               "requires": [
                 {"obstaclesCleared": ["A", "B", "C"]}
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -86,7 +86,8 @@
               "requires": [
                 "f_DefeatedDraygon"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/maridia/inner-yellow/The Beach.json
+++ b/region/maridia/inner-yellow/The Beach.json
@@ -1254,6 +1254,7 @@
         "canTrickyJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Gain run speed to the right and jump through the door without bonking the door frame.",
         "After the transition, continue holding right while remaining in spin jump.",

--- a/region/maridia/inner-yellow/Yoink Room.json
+++ b/region/maridia/inner-yellow/Yoink Room.json
@@ -1821,6 +1821,7 @@
         "canCarefulJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Freeze the Zoa as it spawns and jump on it then jump across the room.",
         "Freeze any Yapping Maws that attack and use them or a frozen Zoa as a platform to leave."
@@ -1852,6 +1853,7 @@
         {"noBlueSuit": {}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Avoid the Yapping Maw after entering by not standing in one place for too long.",
         "Kill the Zoa and quickly jump across the sand.",

--- a/region/maridia/outer/Fish Tank.json
+++ b/region/maridia/outer/Fish Tank.json
@@ -389,7 +389,8 @@
         {"enemyDamage": {"enemy": "Skultera", "type": "contact", "hits": 1}}
       ],
       "gModeRegainMobility": {},
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 134,
@@ -1092,7 +1093,7 @@
     {
       "id": 18,
       "link": [1, 5],
-      "name": "Cross Room Jump with HiJump and Springball",
+      "name": "Cross Room Jump with HiJump and Spring Ball",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "yes",
@@ -1107,12 +1108,13 @@
         "canInsaneJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Requires 3 tiles of run speed (with no open end) to make it past the overhang above the door."
     },
     {
       "id": 149,
       "link": [1, 5],
-      "name": "Cross Room Jump with HiJump and Speedbooster (Lenient)",
+      "name": "Cross Room Jump with HiJump and Speed Booster (Lenient)",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "yes",
@@ -1131,7 +1133,7 @@
     {
       "id": 19,
       "link": [1, 5],
-      "name": "Cross Room Jump with HiJump and Speedbooster",
+      "name": "Cross Room Jump with HiJump and Speed Booster",
       "entranceCondition": {
         "comeInJumping": {
           "speedBooster": "yes",
@@ -3999,7 +4001,8 @@
       "requires": [
         "Gravity"
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 81,

--- a/region/maridia/outer/Main Street.json
+++ b/region/maridia/outer/Main Street.json
@@ -5405,6 +5405,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "It is possible to get to the item tankless with HiJump, or from jumping off of a frozen crab.",
       "devNote": "The excess frames occur after the item is obtained, but it shouldn't matter, as Samus can farm a bit in room if needed."
     },

--- a/region/maridia/outer/Mt. Everest.json
+++ b/region/maridia/outer/Mt. Everest.json
@@ -2595,6 +2595,7 @@
         "HiJump"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Standing on a platform in the room below, jump straight up through the door, with HiJump equipped.",
       "devNote": "A crouch jump can be used but is not needed."
     },
@@ -5095,6 +5096,7 @@
         {"shinespark": {"frames": 29, "excessFrames": 28}}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Jump from the second lowest peak, then vertically spark while between it and the next peak, in order to hit the grapple blocks and save energy."
     },
     {

--- a/region/norfair/crocomire/Crocomire's Room.json
+++ b/region/norfair/crocomire/Crocomire's Room.json
@@ -44,7 +44,8 @@
               "requires": [
                 "f_DefeatedCrocomire"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/norfair/crocomire/Grapple Beam Room.json
+++ b/region/norfair/crocomire/Grapple Beam Room.json
@@ -548,7 +548,8 @@
         {"shineChargeFrames": 35},
         {"shinespark": {"frames": 40, "excessFrames": 3}}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 21,

--- a/region/norfair/crocomire/Grapple Tutorial Room 3.json
+++ b/region/norfair/crocomire/Grapple Tutorial Room 3.json
@@ -323,6 +323,7 @@
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Carefully and quickly lure the Gamets to the right door without letting them go off camera.",
         "It may help to kill any extra Gamets once they spread apart.",

--- a/region/norfair/east/Bat Cave.json
+++ b/region/norfair/east/Bat Cave.json
@@ -685,7 +685,8 @@
           {"heatFrames": 10}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 21,

--- a/region/norfair/east/Bubble Mountain.json
+++ b/region/norfair/east/Bubble Mountain.json
@@ -777,6 +777,7 @@
         {"disableEquipment": "HiJump"}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Kill the Cacatac by shooting, jumping to the right to scroll the camera slightly, and returning.",
         "From the right edge, pause then press left and jump just before the pause fully triggers.",
@@ -801,6 +802,7 @@
         {"disableEquipment": "HiJump"}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Place a Power Bomb at the right edge of the runway to kill the Cacatac. It helps to delay placing it to also kill the Wavers.",
         "From the right edge, pause then press right and jump just before the pause fully triggers.",
@@ -2760,7 +2762,8 @@
       ],
       "resetsObstacles": ["A"],
       "farmCycleDrops": [{"enemy": "Sova", "count": 1}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 76,
@@ -3227,6 +3230,7 @@
         {"disableEquipment": "HiJump"}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "On entry, place a Power Bomb at the peak of a jump to kill the Cacatac without letting it place any projectiles.",
         "Without Power Bombs, either kill it with Bombs then jump over the projectiles it has spawned,",
@@ -3300,7 +3304,8 @@
         "leaveWithTemporaryBlue": {}
       },
       "unlocksDoors": [{"types": ["ammo"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 95,
@@ -3956,6 +3961,7 @@
         {"disableEquipment": "HiJump"}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "From the left edge of the Cacatac's platform, pause then press left and jump just before the pause fully triggers.",
         "Disable Spring Ball in order to get a large horizontal boost.",
@@ -3983,6 +3989,7 @@
         {"disableEquipment": "HiJump"}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Kill the Cacatac with a Power Bomb or Bombs, then jump over the projectiles it has spawned.",
         "Without a way to kill the Cacatac jump over it and land on one of the last pixels of the corner without touching it.",

--- a/region/norfair/east/Cathedral Entrance.json
+++ b/region/norfair/east/Cathedral Entrance.json
@@ -203,7 +203,8 @@
         {"enemy": "Sova", "count": 2},
         {"enemy": "Sm. Dessgeega", "count": 2}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 69,
@@ -1479,6 +1480,7 @@
       "link": [5, 2],
       "name": "Move Assist Leave with Runway",
       "requires": [
+        "canDash",
         {"or": [
           {"and": [
             "HiJump",
@@ -1507,7 +1509,8 @@
           "requires": [{"heatFrames": 110}]
         }
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 44,

--- a/region/norfair/east/Cathedral.json
+++ b/region/norfair/east/Cathedral.json
@@ -670,6 +670,7 @@
         {"heatFrames": 300}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": ["This number waits for the Geruta an extra cycle."]
     },
     {
@@ -708,7 +709,8 @@
         ]},
         {"heatFrames": 190}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 38,
@@ -733,6 +735,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Place a Power Bomb near below the Sova to kill both Gerutas, resulting in 4 drops."
       ]
@@ -1000,7 +1003,8 @@
           ]}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 42,

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -2954,6 +2954,7 @@
       "resetsObstacles": ["A", "R-Mode"],
       "farmCycleDrops": [{"enemy": "Ripper 2 (green)", "count": 1}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": "FIXME: It is possible but risky to farm using hijump, walljump, and crumble jumps."
     },
     {
@@ -3309,7 +3310,8 @@
           {"heatFrames": 135}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 50,
@@ -4195,7 +4197,8 @@
         ]}
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 159,
@@ -4472,7 +4475,8 @@
         "canSpringBallJumpMidAir",
         {"heatFrames": 260}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 162,
@@ -4484,7 +4488,8 @@
         "canSpringFling",
         {"heatFrames": 190}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 163,

--- a/region/norfair/east/Kronic Boost Room.json
+++ b/region/norfair/east/Kronic Boost Room.json
@@ -611,7 +611,8 @@
         }
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 64,

--- a/region/norfair/east/Lava Farm Tunnel.json
+++ b/region/norfair/east/Lava Farm Tunnel.json
@@ -338,7 +338,8 @@
           {"heatFrames": 25}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 59,

--- a/region/norfair/east/Norfair Reserve Tank Room.json
+++ b/region/norfair/east/Norfair Reserve Tank Room.json
@@ -634,7 +634,8 @@
         ]},
         {"heatFrames": 195}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 49,
@@ -993,6 +994,7 @@
       "link": [4, 1],
       "name": "Base",
       "requires": [
+        "canDash",
         {"or": [
           "canTrickyJump",
           "SpaceJump",
@@ -1006,7 +1008,8 @@
         ]},
         {"heatFrames": 210}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 50,

--- a/region/norfair/east/Red Pirate Shaft.json
+++ b/region/norfair/east/Red Pirate Shaft.json
@@ -294,7 +294,8 @@
         "canMoonfall"
       ],
       "bypassesDoorShell": "yes",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 10,

--- a/region/norfair/east/Rising Tide.json
+++ b/region/norfair/east/Rising Tide.json
@@ -91,7 +91,8 @@
           "minExtraRunSpeed": "$1.B"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 51,
@@ -119,7 +120,8 @@
           "minExtraRunSpeed": "$1.B"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 52,
@@ -143,7 +145,8 @@
           "movementType": "uncontrolled"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 53,
@@ -162,7 +165,8 @@
           "minExtraRunSpeed": "$1.B"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 2,
@@ -720,6 +724,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Build up run speed to travel farther when jumping."
     },
     {
@@ -730,7 +735,8 @@
         {"haveBlueSuit": {}},
         {"heatFrames": 840}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 18,
@@ -766,6 +772,7 @@
         {"lavaFrames": 240}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Jump to the first long platform then use a the full platform to jump and mockball through the lava."
     },
     {
@@ -1024,7 +1031,8 @@
           "minExtraRunSpeed": "$1.A"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 55,
@@ -1058,6 +1066,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": ["FIXME: a 1 -> 2 version of this could be added, to save heat frames."]
     },
     {
@@ -1093,6 +1102,7 @@
         }
       },
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": ["FIXME: a 1 -> 2 version of this could be added, to save heat frames."]
     },
     {
@@ -1127,7 +1137,8 @@
           "movementType": "controlled"
         }
       },
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 40,

--- a/region/norfair/east/Speed Booster Hall.json
+++ b/region/norfair/east/Speed Booster Hall.json
@@ -244,7 +244,8 @@
         }
       ],
       "clearsObstacles": ["A"],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 48,
@@ -434,6 +435,7 @@
         {"heatFrames": 30}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Use a Crystal Flash after crossing 3 crumble block bridges,",
         "and a second Crystal Flash after crossing 3 more."
@@ -1142,6 +1144,7 @@
         {"types": ["powerbomb"], "requires": ["h_heatProof"]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Free the Geruta and lure it to this door.",
         "To speed it up, it helps to prevent breaking most of the crumbles (no more than two consecutive) so the Geruta doesn't get stuck."
@@ -1244,6 +1247,7 @@
       "resetsObstacles": ["A"],
       "farmCycleDrops": [{"enemy": "Geruta", "count": 3}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": ["FIXME: Variants could be added for dashless and/or rising lava."]
     },
     {

--- a/region/norfair/east/Upper Norfair Farming Room.json
+++ b/region/norfair/east/Upper Norfair Farming Room.json
@@ -421,7 +421,8 @@
           {"heatFrames": 25}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 53,
@@ -785,7 +786,8 @@
       },
       "requires": [],
       "bypassesDoorShell": "yes",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 18,
@@ -947,7 +949,8 @@
       },
       "requires": [],
       "bypassesDoorShell": "yes",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 24,

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -1090,6 +1090,7 @@
       "resetsObstacles": ["A"],
       "farmCycleDrops": [{"enemy": "Dragon", "count": 5}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Jump and aim down to make the Dragons active by bringing them on camera."
     },
     {
@@ -1340,6 +1341,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Either freeze the Geruta and turn off and on Ice to quickly thaw it and save Energy, or carefully jump over it without freezing it or getting hit.",
         "Then lure it left by jumping towards it from below with a series of mid-air Spring Ball jumps. Freeze it when it performs a larger swoop and use it as a platform to get to the item.",
@@ -1719,6 +1721,7 @@
       ],
       "clearsObstacles": ["A"],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "devNote": [
         "Goes to 3 because opening the gate mostly only makes sense when going back to the right for a longer runway or obtaining the item.",
         "FIXME: A variant with only ice and reset fall speed could be added (possibly while carrying blue suit)."
@@ -1993,6 +1996,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "This can be done from the top right, single tile block."
     },
     {
@@ -2041,7 +2045,8 @@
           }}
         ]}
       ],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 72,

--- a/region/norfair/west/Hi Jump Energy Tank Room.json
+++ b/region/norfair/west/Hi Jump Energy Tank Room.json
@@ -41,7 +41,8 @@
             {
               "name": "Base",
               "requires": [],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"],
@@ -1022,6 +1023,7 @@
         {"obstaclesCleared": ["A"]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "The crumble blocks do not respawn, so it is possible to enter from the right, obtain the left item and return, without needing to break the bomb blocks."
     },
     {

--- a/region/norfair/west/Ice Beam Snake Room.json
+++ b/region/norfair/west/Ice Beam Snake Room.json
@@ -463,7 +463,8 @@
         ]}
       ],
       "unlocksDoors": [{"types": ["powerbomb"], "requires": []}],
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 86,

--- a/region/tourian/main/Big Boy Room.json
+++ b/region/tourian/main/Big Boy Room.json
@@ -40,7 +40,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Dust Torizo Room.json
+++ b/region/tourian/main/Dust Torizo Room.json
@@ -40,7 +40,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -28,7 +28,8 @@
               "requires": [
                 {"obstaclesCleared": ["A", "B"]}
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]
@@ -983,6 +984,7 @@
         ]}
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": "Bomb Jump between the two floating platforms.",
       "devNote": ["FIXME: This is probably possible dashless."]
     },

--- a/region/tourian/main/Metroid Room 2.json
+++ b/region/tourian/main/Metroid Room 2.json
@@ -42,7 +42,8 @@
               "requires": [
                 "f_KilledMetroidRoom2"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]

--- a/region/tourian/main/Metroid Room 3.json
+++ b/region/tourian/main/Metroid Room 3.json
@@ -40,7 +40,8 @@
               "requires": [
                 "f_KilledMetroidRoom3"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "yields": ["f_ZebesAwake"]

--- a/region/tourian/main/Mother Brain Room.json
+++ b/region/tourian/main/Mother Brain Room.json
@@ -28,7 +28,8 @@
               "requires": [
                 "f_DefeatedMotherBrain"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Tourian Escape Room 1.json
+++ b/region/tourian/main/Tourian Escape Room 1.json
@@ -30,7 +30,8 @@
               "requires": [
                 "h_openTourianEscape1RightDoor"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Tourian Escape Room 2.json
+++ b/region/tourian/main/Tourian Escape Room 2.json
@@ -29,7 +29,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -29,7 +29,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Tourian Escape Room 4.json
+++ b/region/tourian/main/Tourian Escape Room 4.json
@@ -33,7 +33,8 @@
               "requires": [
                 "never"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/tourian/main/Tourian Hopper Room.json
+++ b/region/tourian/main/Tourian Hopper Room.json
@@ -266,6 +266,7 @@
         }
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Wait for the top hopper to move right, then jump through the left hopper.",
         "The left hopper may be harder to dodge if the camera is scrolled to the left."

--- a/region/wreckedship/main/Attic.json
+++ b/region/wreckedship/main/Attic.json
@@ -29,6 +29,7 @@
                 "f_DefeatedPhantoon"
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "The enemies are killable using Power Beam, once they actually spawn."
             }
           ],
@@ -58,6 +59,7 @@
               "name": "Base",
               "requires": [],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "The enemies are killable using Power Beam, once they actually spawn."
             }
           ],
@@ -88,6 +90,7 @@
                 "f_DefeatedPhantoon"
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "The enemies are killable using Power Beam, once they actually spawn."
             }
           ],

--- a/region/wreckedship/main/Bowling Alley.json
+++ b/region/wreckedship/main/Bowling Alley.json
@@ -1980,7 +1980,7 @@
         ]}
       ],
       "flashSuitChecked": true,
-
+      "blueSuitChecked": true,
       "note": [
         "The shot blocks must be broken using Bombs or Power Bombs because Beams will instantly despawn.",
         "Use X-Ray or a Crystal Flash to stand up, followed by a Partial Floor clip to jump through the Crumble blocks."

--- a/region/wreckedship/main/Electric Death Room.json
+++ b/region/wreckedship/main/Electric Death Room.json
@@ -31,7 +31,8 @@
               "requires": [
                 "h_openRedDoor"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ],
           "note": "Somehow this door is blue, not red, before Phantoon dies."

--- a/region/wreckedship/main/Gravity Suit Room.json
+++ b/region/wreckedship/main/Gravity Suit Room.json
@@ -55,6 +55,7 @@
                 ]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]

--- a/region/wreckedship/main/Phantoon's Room.json
+++ b/region/wreckedship/main/Phantoon's Room.json
@@ -28,7 +28,8 @@
               "requires": [
                 "f_DefeatedPhantoon"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/wreckedship/main/Robot Assembly Line.json
+++ b/region/wreckedship/main/Robot Assembly Line.json
@@ -43,6 +43,7 @@
                 ]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]
@@ -224,7 +225,7 @@
         {"shinespark": {"frames": 3}}
       ],
       "flashSuitChecked": true,
-
+      "blueSuitChecked": true,
       "note": ["It is only possible to enter X-Mode with a first frame unmorph in this room"]
     },
     {

--- a/region/wreckedship/main/Spiky Death Room.json
+++ b/region/wreckedship/main/Spiky Death Room.json
@@ -913,7 +913,8 @@
       },
       "requires": [],
       "bypassesDoorShell": "yes",
-      "flashSuitChecked": true
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 31,

--- a/region/wreckedship/main/Wrecked Ship East Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship East Super Room.json
@@ -43,6 +43,7 @@
                 ]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]

--- a/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
+++ b/region/wreckedship/main/Wrecked Ship Energy Tank Room.json
@@ -45,6 +45,7 @@
                 ]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]
@@ -352,6 +353,7 @@
       "resetsObstacles": ["A"],
       "farmCycleDrops": [{"enemy": "Skultera", "count": 1}],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "The sinking platforms can be used to collect drops if the fish gets away.",
         "Without movement items, hold down while jumping to ascend while on the platform."
@@ -472,6 +474,7 @@
         "f_DefeatedPhantoon"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Jump onto the first platform, which is easiest when the water is low.",
         "Continue jumping on the platforms to prevent them from going into the water.",
@@ -487,6 +490,7 @@
         "f_DefeatedPhantoon"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "From a standstill at the door, jump just before the first step.",
         "Do a lateral mid-air morph and bounce on the first platform.",

--- a/region/wreckedship/main/Wrecked Ship Main Shaft.json
+++ b/region/wreckedship/main/Wrecked Ship Main Shaft.json
@@ -73,7 +73,8 @@
               "requires": [
                 "f_DefeatedPhantoon"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -126,7 +127,8 @@
               "requires": [
                 "f_DefeatedPhantoon"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }
@@ -2035,9 +2037,10 @@
         "Morph"
       ],
       "flashSuitChecked": true,
+      "blueSuitChecked": true,
       "note": [
         "Use the camera scroll blocks just right of the bomb blocks, in order to overload PLMs and go through them.",
-        "Cancel g-mode, morph and move back towards the bomb blocks in order to fix the camera."
+        "Cancel G-mode, morph and move back towards the bomb blocks in order to fix the camera."
       ]
     },
     {

--- a/region/wreckedship/main/Wrecked Ship Map Room.json
+++ b/region/wreckedship/main/Wrecked Ship Map Room.json
@@ -37,7 +37,8 @@
               "requires": [
                 "f_DefeatedPhantoon"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/wreckedship/main/Wrecked Ship Save Room.json
+++ b/region/wreckedship/main/Wrecked Ship Save Room.json
@@ -37,7 +37,8 @@
               "requires": [
                 "f_DefeatedPhantoon"
               ],
-              "flashSuitChecked": true
+              "flashSuitChecked": true,
+              "blueSuitChecked": true
             }
           ]
         }

--- a/region/wreckedship/main/Wrecked Ship West Super Room.json
+++ b/region/wreckedship/main/Wrecked Ship West Super Room.json
@@ -43,6 +43,7 @@
                 ]}
               ],
               "flashSuitChecked": true,
+              "blueSuitChecked": true,
               "note": "The item doesn't spawn until Phantoon is defeated."
             }
           ]

--- a/schema/m3-room.schema.json
+++ b/schema/m3-room.schema.json
@@ -56,7 +56,7 @@
     },
     "strat": {
       "type": "object",
-      "required": ["name", "requires", "flashSuitChecked"],
+      "required": ["name", "requires", "flashSuitChecked", "blueSuitChecked"],
       "additionalProperties": false,
       "properties": {
         "id": {

--- a/tests/asserts/validate.py
+++ b/tests/asserts/validate.py
@@ -20,7 +20,7 @@ def format_validation_error(error, value):
     msg = f"{list(error.path)}\n{error.message}"
     if len(error.path) >= 2 and error.path[0] == "strats":
         strat = value["strats"][error.path[1]]
-        msg = f"In strat (id={strat['id']}): {strat['name']}\n{msg}"
+        msg = f"In strat (id={strat.get('id')}): {strat.get('name')}\n{msg}"
     if len(error.path) >= 4 and error.path[0] == "helperCategories" and error.path[2] == "helpers":
         helper = value["helperCategories"][error.path[1]]["helpers"][error.path[3]]
         msg = f"In helper {helper.get('name')}\n{msg}"


### PR DESCRIPTION
These are the random strats here and there that were missed on the first pass. It looks like almost all of them were either already checked but just forgot to set blueSuitChecked, or they're the gray doors and other node-level strats that I usually overlooked (but mostly have no interaction with blue suit anyway).

Set "blueSuitChecked" to be required now. Also fixed a thing in `validate.py` that was sometimes making the validation errors blow up in size.