### PR TITLE
Dashless strats starring canWallJumpBombBoost

### DIFF
--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -489,12 +489,65 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "G-mode Morph IBJ, Remote Acquire",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "Gravity",
+        {"or": [
+          "h_artificialMorphLongIBJ",
+          {"and": [
+            "HiJump",
+            "h_artificialMorphJumpIntoIBJ"
+          ]}
+        ]}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 15,
       "link": [1, 2],
-      "name": "G-Mode Morph HBJ or Ceiling Bomb Jump",
+      "name": "G-Mode Morph Ceiling Bomb Jump",
       "entranceCondition": {
         "comeInWithGMode": {
           "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_artificialMorphCeilingBombJump"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "G-Mode Morph HBJ",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "indirect",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_artificialMorphHBJ"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 2],
+      "name": "G-Mode Morph HBJ or Ceiling Bomb Jump, Remote Acquire",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
           "morphed": true
         }
       },
@@ -504,6 +557,7 @@
           "h_artificialMorphHBJ"
         ]}
       ],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },
@@ -513,7 +567,7 @@
       "name": "G-Mode Morph Spring Fling",
       "entranceCondition": {
         "comeInWithGMode": {
-          "mode": "any",
+          "mode": "indirect",
           "morphed": true
         }
       },
@@ -522,6 +576,29 @@
         "canInsaneJump",
         {"disableEquipment": "HiJump"}
       ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "With Spring Ball, pause then press right and jump just before the pause fully triggers.",
+        "Disable Spring Ball in order to get a large horizontal boost.",
+        "Pause again as soon as possible and re-enable Spring to reset fall speed."
+      ]
+    },
+    {
+      "link": [1, 2],
+      "name": "G-Mode Morph Spring Fling, Remote Acquire",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_artificialMorphSpringFling",
+        "canInsaneJump",
+        {"disableEquipment": "HiJump"}
+      ],
+      "collectsItems": [3],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -701,6 +778,10 @@
             "Gravity",
             "canDash"
           ]},
+          {"and": [
+            "Gravity",
+            "canWalljump"
+          ]},
           "canGravityJump"
         ]}
       ],
@@ -722,6 +803,55 @@
       "collectsItems": [3],
       "flashSuitChecked": true,
       "blueSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Horizontal Bomb Jump",
+      "requires": [
+        "canHBJ"
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Spring Fling",
+      "requires": [
+        "canSpringFling"
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Double Spring Ball Jump",
+      "requires": [
+        "canSuitlessMaridia",
+        "h_doubleSpringBallJumpWithHiJump"
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "Midair Bomb Boost",
+      "requires": [
+        "h_bombThings",
+        {"or": [
+          "canBePatient",
+          "Bombs",
+          {"ammo": {"type": "PowerBomb", "count": 4}}
+        ]},
+        {"tech": "canUnmorphBombBoost"},
+        "can4HighMidAirMorph"
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": "Jump and Morph very quickly to place the bomb in a precise position to bounce off of."
     },
     {
       "id": 23,
@@ -764,6 +894,70 @@
         "A beam shot, Missile, or Super can be used."
       ],
       "devNote": "Sparking in bottom position means the item will be collected along the way."
+    },
+    {
+      "link": [1, 3],
+      "name": "G-mode Morph IBJ",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "Gravity",
+        {"or": [
+          "h_artificialMorphLongIBJ",
+          {"and": [
+            "HiJump",
+            "h_artificialMorphJumpIntoIBJ"
+          ]}
+        ]}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "G-Mode Morph HBJ or Ceiling Bomb Jump",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"or": [
+          "h_artificialMorphCeilingBombJump",
+          "h_artificialMorphHBJ"
+        ]}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [1, 3],
+      "name": "G-Mode Morph Spring Fling",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_artificialMorphSpringFling",
+        {"disableEquipment": "HiJump"}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "With Spring Ball, pause then press right and jump just before the pause fully triggers.",
+        "Disable Spring Ball in order to get a large horizontal boost.",
+        "Pause again as soon as possible and re-enable Spring to reset fall speed."
+      ]
     },
     {
       "id": 25,
@@ -930,6 +1124,21 @@
       "blueSuitChecked": true
     },
     {
+      "link": [2, 1],
+      "name": "G-Mode Morph, Blue Suit",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"haveBlueSuit": {}}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 34,
       "link": [2, 2],
       "name": "Leave with Runway",
@@ -1009,13 +1218,34 @@
       ]
     },
     {
+      "link": [2, 2],
+      "name": "Direct G-Mode Morph HBJ, Remote Acquire Item",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "direct",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "canRemoteAcquire",
+        "h_artificialMorphHBJ"
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 36,
       "link": [2, 3],
       "name": "Base",
       "requires": [
         {"or": [
           "Grapple",
-          "SpaceJump"
+          "SpaceJump",
+          {"and": [
+            "Gravity",
+            "canWalljump"
+          ]}
         ]}
       ],
       "collectsItems": [3],
@@ -1047,6 +1277,16 @@
       "devNote": "Could use a failure definition?"
     },
     {
+      "link": [2, 3],
+      "name": "Gravity Jump",
+      "requires": [
+        "canGravityJump"
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
       "id": 38,
       "link": [2, 3],
       "name": "Right to Left Jump, Run Through Door",
@@ -1067,6 +1307,37 @@
         "Execution of this strat is non-trivial, and failing will lead to falling into the pit.",
         "Depending on item loadout, that could be a softlock."
       ]
+    },
+    {
+      "link": [2, 3],
+      "name": "Horizontal Bomb Jump",
+      "requires": [
+        "canHBJ"
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 3],
+      "name": "Spring Fling",
+      "requires": [
+        "canSpringFling"
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 3],
+      "name": "Double Spring Ball Jump",
+      "requires": [
+        "canSuitlessMaridia",
+        "h_doubleSpringBallJumpWithHiJump"
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     },
     {
       "id": 39,
@@ -1146,6 +1417,70 @@
         "Sparking too late will cause the shot to despawn before reaching the door.",
         "Sparking too early will cause Samus to bonk the door as it will not yet be open.",
         "A beam shot, Missile, or Super can be used."
+      ]
+    },
+    {
+      "link": [2, 3],
+      "name": "G-mode Morph IBJ",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "Gravity",
+        {"or": [
+          "h_artificialMorphLongIBJ",
+          {"and": [
+            "HiJump",
+            "h_artificialMorphJumpIntoIBJ"
+          ]}
+        ]}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 3],
+      "name": "G-Mode Morph HBJ or Ceiling Bomb Jump",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        {"or": [
+          "h_artificialMorphCeilingBombJump",
+          "h_artificialMorphHBJ"
+        ]}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "link": [2, 3],
+      "name": "G-Mode Morph Spring Fling",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "h_artificialMorphSpringFling",
+        {"disableEquipment": "HiJump"}
+      ],
+      "collectsItems": [3],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "With Spring Ball, pause then press right and jump just before the pause fully triggers.",
+        "Disable Spring Ball in order to get a large horizontal boost.",
+        "Pause again as soon as possible and re-enable Spring to reset fall speed."
       ]
     },
     {
@@ -1349,7 +1684,8 @@
       "requires": [
         "canSpringFling",
         "canInsaneJump",
-        {"disableEquipment": "HiJump"}
+        {"disableEquipment": "HiJump"},
+        {"obstaclesNotCleared": ["A", "B", "C"]}
       ],
       "collectsItems": [3],
       "flashSuitChecked": true,
@@ -1363,19 +1699,23 @@
     {
       "id": 64,
       "link": [3, 2],
-      "name": "CWJ Bomb Boost",
+      "name": "Walljump Bomb Boost",
       "requires": [
-        {"notable": "CWJ Bomb Boost"},
-        "canCWJ",
+        {"notable": "Walljump Bomb Boost"},
+        {"or": [
+          "canCWJ",
+          "canBePatient"
+        ]},
         "canWallJumpBombBoost",
-        "canResetFallSpeed"
+        "canResetFallSpeed",
+        {"obstaclesNotCleared": ["A", "B", "C"]}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Stand on the item pedestal facing right.",
-        "Perform a short stationary spin jump with some dash speed, and do a continuous wall jump off the item pedestal.",
-        "Lay a Power Bomb (or Bomb) and use it to boost to the right, with a well-timed unmorph to reset fall speed."
+        "Perform a wall jump off the item pedestal while avoiding the water.",
+        "Lay a Power Bomb (or Bomb) and use it to boost to the right, with a well-timed unmorph to reset fall speed.",
+        "The placement of the bomb is more lenient with a CWJ."
       ],
       "detailNote": [
         "It is ideal to gain 3 frames of dash speed, the maximum possible, but lower amounts can work.",
@@ -1528,11 +1868,11 @@
     },
     {
       "id": 3,
-      "name": "CWJ Bomb Boost",
+      "name": "Walljump Bomb Boost",
       "note": [
-        "Stand on the item pedestal facing right.",
-        "Perform a stationary spin jump with some dash speed, and do a continuous wall jump off the item pedestal.",
-        "Lay a Power Bomb (or Bomb) and use it to boost to the right, with a well-timed unmorph to reset fall speed."
+        "Perform a wall jump off the item pedestal while avoiding the water.",
+        "Lay a Power Bomb (or Bomb) and use it to boost to the right, with a well-timed unmorph to reset fall speed.",
+        "The placement of the bomb is more lenient with a CWJ."
       ]
     },
     {

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -845,11 +845,12 @@
       "requires": [
         "h_bombThings",
         {"or": [
-          "canBePatient",
+          "canBeLucky",
           "Bombs",
           {"ammo": {"type": "PowerBomb", "count": 4}}
         ]},
         {"tech": "canUnmorphBombBoost"},
+        "canResetFallSpeed",
         "can4HighMidAirMorph"
       ],
       "collectsItems": [3],
@@ -858,7 +859,8 @@
       "note": [
         "Jump and Morph very quickly to place a bomb to boost Samus to the right.",
         "The bomb should be as far right as possible, and just above door height."
-      ]
+      ],
+      "devNote": "canBeLucky added for difficulty placement."
     },
     {
       "id": 23,
@@ -1134,7 +1136,12 @@
         }
       },
       "requires": [
-        {"haveBlueSuit": {}}
+        {"haveBlueSuit": {}},
+        {"or": [
+          {"disableEquipment": "Gravity"},
+          "h_artificialMorphBombHorizontally",
+          "h_artificialMorphSpringBall"
+        ]}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/crateria/east/The Moat.json
+++ b/region/crateria/east/The Moat.json
@@ -782,6 +782,10 @@
             "Gravity",
             "canWalljump"
           ]},
+          {"and": [
+            "Gravity",
+            "HiJump"
+          ]},
           "canGravityJump"
         ]}
       ],
@@ -851,7 +855,10 @@
       "collectsItems": [3],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note": "Jump and Morph very quickly to place the bomb in a precise position to bounce off of."
+      "note": [
+        "Jump and Morph very quickly to place a bomb to boost Samus to the right.",
+        "The bomb should be as far right as possible, and just above door height."
+      ]
     },
     {
       "id": 23,
@@ -906,13 +913,7 @@
       },
       "requires": [
         "Gravity",
-        {"or": [
-          "h_artificialMorphLongIBJ",
-          {"and": [
-            "HiJump",
-            "h_artificialMorphJumpIntoIBJ"
-          ]}
-        ]}
+        "h_artificialMorphLongIBJ"
       ],
       "collectsItems": [3],
       "flashSuitChecked": true,

--- a/region/crateria/east/West Ocean.json
+++ b/region/crateria/east/West Ocean.json
@@ -3005,6 +3005,10 @@
         {"or": [
           "canCarefulJump",
           "canConsecutiveWalljump"
+        ]},
+        {"or": [
+          "canDisableEquipment",
+          "canTrickyJump"
         ]}
       ],
       "flashSuitChecked": true,
@@ -3027,6 +3031,25 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "devNote": "A speedy jump would be obsoleted by another strat for being tricky."
+    },
+    {
+      "link": [13, 5],
+      "name": "Horizontal Bomb Jump",
+      "requires": [
+        {"or": [
+          "canHBJ",
+          {"and": [
+            "canBeVeryPatient",
+            "canWallJumpBombBoost",
+            "h_additionalBomb",
+            "h_additionalBomb"
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": "Use multiple HBJs or extremely precise walljump in bomb boosts to cross the room without dashing.",
+      "devNote": "canBeVeryPatient added for difficulty placement"
     },
     {
       "id": 119,

--- a/region/tourian/main/Metroid Room 1.json
+++ b/region/tourian/main/Metroid Room 1.json
@@ -989,8 +989,31 @@
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
-      "note": "Bomb Jump between the two floating platforms.",
-      "devNote": ["FIXME: This is probably possible dashless."]
+      "note": "Bomb Jump between the two floating platforms."
+    },
+    {
+      "link": [1, 2],
+      "name": "Walljump Bomb Boost",
+      "requires": [
+        "canInsaneWalljump",
+        "canWallJumpBombBoost",
+        "canHBJ",
+        {"or": [
+          {"obstaclesCleared": ["B"]},
+          {"and": [
+            "canBeLucky",
+            "canCameraManip",
+            "canMetroidAvoid"
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Walljump into a midair Horizontal Bomb Jump from just above the acid to reach the first platform.",
+        "HBJ from the ground to reach the second platform.",
+        "Then simply jump to reach the far runway."
+      ]
     },
     {
       "id": 19,
@@ -1549,6 +1572,31 @@
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true
+    },
+    {
+      "link": [2, 1],
+      "name": "Walljump Bomb Boost",
+      "requires": [
+        "canInsaneWalljump",
+        "canWallJumpBombBoost",
+        "canHBJ",
+        {"or": [
+          {"obstaclesCleared": ["A", "B"]},
+          {"and": [
+            "canTrickyDodgeEnemies",
+            "canCameraManip",
+            "canMetroidAvoid"
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Jump to the first platform.",
+        "Walljump low off the platform into a midair horizontal bomb jump.",
+        "Finally, either jump into a horizontal bomb boost, or use another horizontal bomb jump to reach the far runway.",
+        "Unmorph to clear the rinka while falling."
+      ]
     },
     {
       "id": 72,


### PR DESCRIPTION
Moat has even more options for avoiding the item when travelling door to door.

