### PR TITLE
Rename Super Jump as Superjump

### DIFF
--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -988,7 +988,7 @@
     {
       "id": 101,
       "link": [3, 2],
-      "name": "Come in Shinecharged - Gain Blue Suit (X-Mode Super Jump)",
+      "name": "Come in Shinecharged - Gain Blue Suit (X-Mode Superjump)",
       "entranceCondition": {
         "comeInShinecharged": {}
       },
@@ -1016,7 +1016,7 @@
     {
       "id": 102,
       "link": [3, 2],
-      "name": "Gain Blue Suit (Double X-Mode Super Jump)",
+      "name": "Gain Blue Suit (Double X-Mode Superjump)",
       "requires": [
         {"or": [
           "h_thornDoubleXModeBlueSuit",

--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -1003,7 +1003,7 @@
             "excludedWeapons": ["Bombs"]
           }}
         ]},
-        "canSuperJump",
+        "canSuperjump",
         {"shinespark": {"frames": 4, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
@@ -1032,7 +1032,7 @@
             ]}
           ]}
         ]},
-        "canSuperJump",
+        "canSuperjump",
         {"shinespark": {"frames": 4, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,

--- a/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
+++ b/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
@@ -1310,7 +1310,7 @@
       "link": [1, 3],
       "name": "Gain Blue Suit - Superjump (Double X-Mode)",
       "requires": [
-        "canSuperJump",
+        "canSuperjump",
         {"obstaclesCleared": ["A"]},
         {"obstaclesCleared": ["B"]},
         "h_destroyBombWalls",

--- a/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
+++ b/region/brinstar/pink/Pink Brinstar Wave Gate Room.json
@@ -1308,7 +1308,7 @@
     {
       "id": 103,
       "link": [1, 3],
-      "name": "Gain Blue Suit - Super Jump (Double X-Mode)",
+      "name": "Gain Blue Suit - Superjump (Double X-Mode)",
       "requires": [
         "canSuperJump",
         {"obstaclesCleared": ["A"]},

--- a/region/crateria/central/Climb Supers Room.json
+++ b/region/crateria/central/Climb Supers Room.json
@@ -989,7 +989,7 @@
         }
       },
       "requires": [
-        "canSuperJump",
+        "canSuperjump",
         {"shinespark": {"frames": 7, "excessFrames": 0}},
         "h_XModeSpikeHit",
         {"or": [
@@ -1015,7 +1015,7 @@
       "name": "In-Room X-Mode BlueSuit",
       "requires": [
         {"notable": "In-Room X-Mode BlueSuit"},
-        "canSuperJump",
+        "canSuperjump",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",
         "h_XModeSpikeHit",

--- a/schema/m3-string-requirements.schema.json
+++ b/schema/m3-string-requirements.schema.json
@@ -240,7 +240,7 @@
     "canCrystalSpark",
     "canUnderwaterCrystalSpark",
     "canXModeBlueSuit",
-    "canSuperJump",
+    "canSuperjump",
     "canDoubleXModeBlueSuit",
     "canSpeedKeep",
     "canPreciseSpaceJump",

--- a/tech.json
+++ b/tech.json
@@ -2840,7 +2840,7 @@
               "extensionTechs": [
                 {
                   "id": 160,
-                  "name": "canSuperJump",
+                  "name": "canSuperjump",
                   "techRequires": [
                     "canXModeBlueSuit"
                   ],

--- a/tech.json
+++ b/tech.json
@@ -2834,7 +2834,7 @@
                 "The ability to gain a blue suit by shinesparking while in X-Mode and exiting X-Mode before the shinespark has crashed.",
                 "Release dash during the shinespark wind-up animation to exit X-Mode, interrupting the shinespark and gaining a blue suit.",
                 "A blue suit will not be gained if dash is released after a shinespark has crashed against a wall or object.",
-                "Releasing dash mid shinespark will cause Samus to SuperJump and potentially go out of bounds but this can also be used to jump away from spikes or thorns.",
+                "Releasing dash mid shinespark will cause Samus to Superjump and potentially go out of bounds but this can also be used to jump away from spikes or thorns.",
                 "Care must be taken around spikes or thorns after a blue suit is gained if there are active enemies as I-frames will expire quickly and escaping can be difficult."
               ],
               "extensionTechs": [
@@ -2847,7 +2847,7 @@
                   "otherRequires": [],
                   "note": [
                     "Ability to Shinespark while in XMode in a controlled way.",
-                    "A side effect of Super Jumping is that Samus gains a Blue Suit."
+                    "A side effect of Superjumping is that Samus gains a Blue Suit."
                   ]
                 }
               ]
@@ -2869,7 +2869,7 @@
                 "Before the shinecharged window expires, quickly re-enter X-Mode and peform a shinespark. Due to the short window, this second X-Mode has to be done first try.",
                 "Release dash during the shinespark wind-up animation to exit X-Mode, interrupting the shinespark and gaining a blue suit.",
                 "A blue suit will not be gained if dash is released after a shinespark has crashed against a wall or object.",
-                "Releasing dash mid shinespark will cause Samus to SuperJump and potentially go out of bounds but this can also be used to jump away from spikes or thorns.",
+                "Releasing dash mid shinespark will cause Samus to Superjump and potentially go out of bounds but this can also be used to jump away from spikes or thorns.",
                 "Care must be taken around spikes or thorns after a blue suit is gained if there are active enemies as I-frames will expire quickly and escaping can be difficult."
               ]
             }


### PR DESCRIPTION
Selicre suggested this, and after some thinking on it, I think they're right. This is also how the wiki spells it, though they have the J capitalized half the time. I kept the tech name with a capital J, for readability, but maybe we should make it always capital instead, I'm not sure.