### PR TITLE
Reverse Botwoon fight

### DIFF
--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -701,71 +701,50 @@
     {
       "id": 32,
       "link": [2, 2],
-      "name": "Back-Side Waveless Microwave",
+      "name": "Back-Side Magic Pixel Fight (Plasma)",
       "requires": [
         {"notable": "Back-Side Magic Pixel Beam Fight"},
         "h_navigateUnderwater",
         "Charge",
         "Plasma",
-        "canXRayWaitForIFrames"
+        {"or": [
+          "canXRayWaitForIFrames",
+          "canTrickyDodgeEnemies",
+          "Gravity",
+          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
+        ]}
       ],
       "setsFlags": ["f_DefeatedBotwoon"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Stand on the appropriate pixel for shooting diagonally through the wall and use the microwave trick to defeat Botwoon.",
-        "Using angle up, it is where Samus' front foot is on the seam in the floor.",
-        "There is not proper spacing for landing an angle down shot and xraying.",
-        "Waiting for Botwoon to peak their head through the wall works too but is less safe."
+        "A charge beam shot will pass right through the dividing wall if fired from the correct 2-pixel window.",
+        "Using angle up, it is where Samus' front foot is on the seam in the floor."
       ]
     },
     {
       "id": 33,
       "link": [2, 2],
-      "name": "Back-Side Magic Pixel Fight",
+      "name": "Back-Side Magic Pixel Fight (Spazer)",
       "requires": [
         {"notable": "Back-Side Magic Pixel Beam Fight"},
         "h_navigateUnderwater",
         "Charge",
+        "Spazer",
         {"or": [
+          "canInsaneJump",
           {"and": [
-            "Plasma",
+            "Gravity",
             {"or": [
-              "canTrickyDodgeEnemies",
-              "Gravity",
+              "canTrickyJump",
               {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
             ]}
           ]},
           {"and": [
-            "Spazer",
-            {"or": [
-              "canInsaneJump",
-              {"and": [
-                "Gravity",
-                {"or": [
-                  "canTrickyJump",
-                  {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
-                ]}
-              ]},
-              {"and": [
-                "canTrickyDodgeEnemies",
-                {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
-              ]},
-              {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 4}}
-            ]}
+            "canTrickyDodgeEnemies",
+            {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
           ]},
-          {"and": [
-            "canBeVeryPatient",
-            {"or": [
-              "canInsaneJump",
-              {"and": [
-                "Gravity",
-                "canTrickyJump",
-                {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}}
-              ]},
-              {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 6}}
-            ]}
-          ]}
+          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 4}}
         ]},
         "h_trickyToCarryFlashSuit"
       ],
@@ -774,8 +753,36 @@
       "blueSuitChecked": true,
       "note": [
         "A charge beam shot will pass right through the dividing wall if fired from the correct 2-pixel window.",
-        "Using angle down the spot is where Samus' front toe touches the wall.",
-        "Using angle up, it is where Samus' front foot is on the seam in the floor."
+        "Using angle up, it is where Samus' front foot is on the seam in the floor.",
+        "Angle down can also be used where where Samus' front toe touches the wall."
+      ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Back-Side Magic Pixel Fight (Slow)",
+      "requires": [
+        {"notable": "Back-Side Magic Pixel Beam Fight"},
+        "h_navigateUnderwater",
+        "Charge",
+        "canBeVeryPatient",
+        {"or": [
+          "canInsaneJump",
+          {"and": [
+            "Gravity",
+            "canTrickyJump",
+            {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}}
+          ]},
+          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 6}}
+        ]},
+        "h_trickyToCarryFlashSuit"
+      ],
+      "setsFlags": ["f_DefeatedBotwoon"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "A charge beam shot will pass right through the dividing wall if fired from the correct 2-pixel window.",
+        "Using angle up, it is where Samus' front foot is on the seam in the floor.",
+        "Angle down can also be used where where Samus' front toe touches the wall."
       ]
     },
     {

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -664,7 +664,7 @@
             {"and": [
               "canDodgeWhileShooting",
               {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
-            ]},
+            ]}
           ]},
           {"and": [
             "Spazer",

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -661,7 +661,7 @@
             "Spazer",
             "Ice",
             {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}},
-            {"and": [
+            {"or": [
               "canDodgeWhileShooting",
               {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
             ]}

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -622,14 +622,24 @@
           "Plasma",
           {"and": [
             "Spazer",
-            {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
+            "Ice"
           ]},
-          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}}
+          {"and": [
+            {"or": [
+              "canDodgeWhileShooting",
+              {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
+            ]},
+            {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
+          ]}
         ]}
       ],
       "setsFlags": ["f_DefeatedBotwoon"],
       "flashSuitChecked": true,
-      "blueSuitChecked": true
+      "blueSuitChecked": true,
+      "note": [
+        "It is safest to pseudoscrew through any acid projectiles.",
+        "Alternatively, standing on the stairs gives more time to run away."
+      ]
     },
     {
       "id": 31,
@@ -641,13 +651,15 @@
         "Charge",
         "Wave",
         {"or": [
+          "Plasma",
           "canTrickyDodgeEnemies",
           {"and": [
             "canDodgeWhileShooting",
             {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}}
           ]},
           {"and": [
-            "Plasma",
+            "Spazer",
+            "Ice",
             {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
           ]},
           {"and": [
@@ -720,10 +732,7 @@
             "Plasma",
             {"or": [
               "canTrickyDodgeEnemies",
-              {"and": [
-                "Gravity",
-                "canTrickyJump"
-              ]},
+              "Gravity",
               {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
             ]}
           ]},
@@ -733,13 +742,16 @@
               "canInsaneJump",
               {"and": [
                 "Gravity",
-                "canTrickyJump"
+                {"or": [
+                  "canTrickyJump",
+                  {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
+                ]}
               ]},
               {"and": [
                 "canTrickyDodgeEnemies",
                 {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
               ]},
-              {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 3}}
+              {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 4}}
             ]}
           ]},
           {"and": [

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -660,7 +660,11 @@
           {"and": [
             "Spazer",
             "Ice",
-            {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
+            {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}},
+            {"and": [
+              "canDodgeWhileShooting",
+              {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
+            ]},
           ]},
           {"and": [
             "Spazer",
@@ -718,7 +722,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "A charge beam shot will pass right through the dividing wall if fired from the correct 2-pixel window.",
+        "A charge beam shot will pass right through the dividing wall if fired diagonally from the correct 2-pixel window.",
         "Using angle up, it is where Samus' front foot is on the seam in the floor."
       ]
     },
@@ -752,7 +756,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "A charge beam shot will pass right through the dividing wall if fired from the correct 2-pixel window.",
+        "A charge beam shot will pass right through the dividing wall if fired diagonally from the correct 2-pixel window.",
         "Using angle up, it is where Samus' front foot is on the seam in the floor.",
         "Angle down can also be used where where Samus' front toe touches the wall."
       ]
@@ -780,7 +784,7 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "A charge beam shot will pass right through the dividing wall if fired from the correct 2-pixel window.",
+        "A charge beam shot will pass right through the dividing wall if fired diagonally from the correct 2-pixel window.",
         "Using angle up, it is where Samus' front foot is on the seam in the floor.",
         "Angle down can also be used where where Samus' front toe touches the wall."
       ]

--- a/region/maridia/inner-pink/Botwoon's Room.json
+++ b/region/maridia/inner-pink/Botwoon's Room.json
@@ -618,23 +618,18 @@
         "Charge",
         "Wave",
         {"or": [
-          "canDodgeWhileShooting",
+          "canTrickyJump",
           "Plasma",
-          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}},
           {"and": [
             "Spazer",
             {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
-          ]}
+          ]},
+          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}}
         ]}
       ],
       "setsFlags": ["f_DefeatedBotwoon"],
       "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": ["Fight Botwoon from behind the wall."],
-      "devNote": [
-        "With Gravity, dodging the acid is pretty trivial.",
-        "Even without knowing about the distance trick expected in the suitless version."
-      ]
+      "blueSuitChecked": true
     },
     {
       "id": 31,
@@ -646,10 +641,7 @@
         "Charge",
         "Wave",
         {"or": [
-          {"and": [
-            "canDodgeWhileShooting",
-            "Morph"
-          ]},
+          "canTrickyDodgeEnemies",
           {"and": [
             "canDodgeWhileShooting",
             {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}}
@@ -662,7 +654,11 @@
             "Spazer",
             {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 4}}
           ]},
-          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 6}}
+          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 6}},
+          {"and": [
+            "canCameraManip",
+            "canBePatient"
+          ]}
         ]}
       ],
       "setsFlags": ["f_DefeatedBotwoon"],
@@ -718,10 +714,47 @@
       "requires": [
         {"notable": "Back-Side Magic Pixel Beam Fight"},
         "h_navigateUnderwater",
-        {"enemyKill": {
-          "enemies": [["Reverse Botwoon 1"], ["Reverse Botwoon 2"]],
-          "explicitWeapons": ["Charge+Plasma", "Charge+Ice+Spazer"]
-        }},
+        "Charge",
+        {"or": [
+          {"and": [
+            "Plasma",
+            {"or": [
+              "canTrickyDodgeEnemies",
+              {"and": [
+                "Gravity",
+                "canTrickyJump"
+              ]},
+              {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
+            ]}
+          ]},
+          {"and": [
+            "Spazer",
+            {"or": [
+              "canInsaneJump",
+              {"and": [
+                "Gravity",
+                "canTrickyJump"
+              ]},
+              {"and": [
+                "canTrickyDodgeEnemies",
+                {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 1}}
+              ]},
+              {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 3}}
+            ]}
+          ]},
+          {"and": [
+            "canBeVeryPatient",
+            {"or": [
+              "canInsaneJump",
+              {"and": [
+                "Gravity",
+                "canTrickyJump",
+                {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}}
+              ]},
+              {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 6}}
+            ]}
+          ]}
+        ]},
         "h_trickyToCarryFlashSuit"
       ],
       "setsFlags": ["f_DefeatedBotwoon"],
@@ -743,7 +776,15 @@
         "canSpecialBeamAttack",
         "Plasma",
         "canXRayWaitForIFrames",
-        {"ammo": {"type": "PowerBomb", "count": 2}}
+        {"ammo": {"type": "PowerBomb", "count": 1}},
+        {"or": [
+          "canTrickyDodgeEnemies",
+          {"ammo": {"type": "PowerBomb", "count": 2}}
+        ]},
+        {"or": [
+          "canBeLucky",
+          {"ammo": {"type": "PowerBomb", "count": 1}}
+        ]}        
       ],
       "setsFlags": ["f_DefeatedBotwoon"],
       "flashSuitChecked": true,
@@ -752,7 +793,11 @@
         "Wait for Botwoon to spawn then use a Plasma Special Beam Attack.",
         "Use XRay to slow time and watch for a particle to overlap Botwoons head, then proceed to Microwave."
       ],
-      "devNote": "Killing in 1 SBA takes some luck."
+      "devNote": [
+        "Killing in 1 SBA takes some luck.",
+        "Microwaving effeciently takes some dexterity.",
+        "This strat only applies to those who don't know the magic pixel strat is possible."
+      ]
     },
     {
       "id": 35,
@@ -761,10 +806,18 @@
       "requires": [
         {"notable": "Back-Side Plasma Shield Fight"},
         "h_navigateUnderwater",
-        {"enemyKill": {
-          "enemies": [["Reverse Botwoon 1"], ["Reverse Botwoon 2"]],
-          "explicitWeapons": ["Plasma Shield"]
-        }}
+        "canSpecialBeamAttack",
+        "Plasma",
+        {"ammo": {"type": "PowerBomb", "count": 5}},
+        {"or": [
+          "canBeLucky",
+          {"ammo": {"type": "PowerBomb", "count": 2}}
+        ]},
+        {"or": [
+          "Gravity",
+          "canTrickyDodgeEnemies",
+          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 2}}
+        ]}
       ],
       "setsFlags": ["f_DefeatedBotwoon"],
       "flashSuitChecked": true,
@@ -779,10 +832,15 @@
         {"notable": "Back-Side Super Only Fight"},
         "h_navigateUnderwater",
         "canBeVeryPatient",
-        {"enemyKill": {
-          "enemies": [["Reverse Botwoon 1"], ["Reverse Botwoon 2"]],
-          "explicitWeapons": ["Super"]
-        }}
+        {"ammo": {"type": "Super", "count": 10}},
+        {"or": [
+          "canInsaneJump",
+          {"and": [
+            "Gravity",
+            "canTrickyJump"
+          ]},
+          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 3}}
+        ]}
       ],
       "setsFlags": ["f_DefeatedBotwoon"],
       "flashSuitChecked": true,
@@ -791,6 +849,44 @@
         "Wait for the one pattern (bottom->right) where Botwoon's head passes through the dividing barrier briefly and fire TWO Super Missiles.",
         "This takes a long time, averaging two supers per minute."
       ]
+    },
+    {
+      "link": [2, 2],
+      "name": "Back-Side Missile Only Fight",
+      "requires": [
+        {"notable": "Back-Side Super Only Fight"},
+        "h_navigateUnderwater",
+        {"ammo": {"type": "Missile", "count": 30}},
+        {"or": [
+          "canBeExtremelyPatient",
+          {"and": [
+            "canBeVeryPatient",
+            "canBeVeryLucky",
+            "canGateGlitch",
+            {"noFlashSuit": {}},
+            {"ammo": {"type": "Missile", "count": 30}}
+          ]}
+        ]},
+        {"or": [
+          "canInsaneJump",
+          {"and": [
+            "Gravity",
+            "canTrickyJump"
+          ]},
+          {"enemyDamage": {"enemy": "Botwoon 1", "type": "acid", "hits": 6}}
+        ]},
+        {"ammo": {"type": "Missile", "count": 10}}
+      ],
+      "setsFlags": ["f_DefeatedBotwoon"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Wait for the one pattern (bottom->right) where Botwoon's head passes through the dividing barrier briefly.",
+        "The extent Botwoon's head passes through the wall varies ranging from almost no damage window up to enough time for 2 missiles.",
+        "By jumping there is a doppler effect allowing up to 2 more missiles to hit Botwoon.",
+        "The fight can be sped up by Gate Glitching through the wall and landing lucky hits throughout the fight."
+      ],
+      "devNote": "It is much easier to miss with missiles, so 10 leniency missiles are added."
     }
   ],
   "notables": [

--- a/region/tourian/main/Tourian Escape Room 3.json
+++ b/region/tourian/main/Tourian Escape Room 3.json
@@ -270,11 +270,7 @@
                 "hits": 1
               }}
             ]},
-            {"or": [
-              "Morph",
-              "canTurnaroundAimCancel",
-              "canXRayTurnaround"
-            ]}
+            "Morph"
           ]}
         ]}
       ],
@@ -814,11 +810,7 @@
                 "hits": 1
               }}
             ]},
-            {"or": [
-              "Morph",
-              "canTurnaroundAimCancel",
-              "canXRayTurnaround"
-            ]}
+            "Morph"
           ]}
         ]}
       ],


### PR DESCRIPTION
https://videos.maprando.com/video/10258
Charge+Wave ends somewhat fast so you don't need to dodge much.
Plasma shield wasn't very reliable and were harder to execute than the base requirements and don't really have an interaction with the plasma magic pixel kill which is already a pretty easy fight.
The missile only reverse fight is both very slow and hard to hit the boss.  But I got better at dodging!

The tourian pirate wiggles are extremely slow until you really practice the positioning where pirates come on camera.  And I figure if you grind that then you also are grinding the runaway and fight method.  Requirements come out to be kinda similar.