### PR TITLE
Require shinespark after double x-mode blue suit helpers

### DIFF
--- a/region/brinstar/green/Etecoon Energy Tank Room.json
+++ b/region/brinstar/green/Etecoon Energy Tank Room.json
@@ -1248,7 +1248,8 @@
               }}
             ]}
           ]}
-        ]}
+        ]},
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,

--- a/region/brinstar/kraid/Kraid Eye Door Room.json
+++ b/region/brinstar/kraid/Kraid Eye Door Room.json
@@ -378,7 +378,8 @@
       "link": [1, 1],
       "name": "Gain Blue Suit (Double X-Mode)",
       "requires": [
-        "h_thornDoubleXModeBlueSuitWithoutLenience"
+        "h_thornDoubleXModeBlueSuitWithoutLenience",
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/region/maridia/inner-pink/East Cactus Alley.json
+++ b/region/maridia/inner-pink/East Cactus Alley.json
@@ -1765,7 +1765,8 @@
       "link": [4, 4],
       "name": "Gain Blue Suit (Double X-Mode)",
       "requires": [
-        "h_spikeDoubleXModeBlueSuit"
+        "h_spikeDoubleXModeBlueSuit",
+        {"shinespark": {"frames": 0, "excessFrames": 0}}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true

--- a/tests/asserts/keywords.py
+++ b/tests/asserts/keywords.py
@@ -513,7 +513,7 @@ def process_req_speed_state(req, states, err_fn):
             states = {"preshinespark"}
         elif req in ["canDoubleXModeBlueSuit", "h_spikeDoubleXModeBlueSuit", "h_thornDoubleXModeBlueSuit",
                      "h_thornDoubleXModeBlueSuitWithoutLenience"]:
-            states = {"shinespark"}
+            states = {"preshinespark"}
 
     elif isinstance(req, dict):
         if "canShineCharge" in req:


### PR DESCRIPTION
This changes the tests to use a speed state of "preshinespark" after the double x-mode helpers, so that way it will fail if we forget to include a shinespark requirement. It was missing in 3 places, which made the logic think that you could do the strats with Blue Booster.

Reported by somerando in the Map Rando Discord: https://discord.com/channels/1053421401354285129/1053436236628496454/1500478390539649134