### PR TITLE
refine heatframes for double chamber spike ibj

### DIFF
--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -3321,7 +3321,7 @@
         "canDash",
         "h_heatedIBJFromSpikes",
         {"or": [
-          {"heatFrames": 770},
+          {"heatFrames": 730},
           {"and": [
             "canDoubleBombJump",
             {"heatFrames": 550}
@@ -4454,13 +4454,19 @@
       "requires": [
         "canDash",
         "h_heatedIBJFromSpikes",
-        {"heatFrames": 1100}
+        {"or": [
+          {"heatFrames": 730},
+          {"and": [
+            "canDoubleBombJump",
+            {"heatFrames": 550}
+          ]}
+        ]
+        }
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "devNote": [
-        "FIXME: refine these heat frames.",
-        "A crumble jump into IBJ is also possible."
+        "FIXME: A crumble jump into IBJ is also possible."
       ]
     },
     {

--- a/region/norfair/east/Double Chamber.json
+++ b/region/norfair/east/Double Chamber.json
@@ -3320,13 +3320,19 @@
       "requires": [
         "canDash",
         "h_heatedIBJFromSpikes",
-        {"heatFrames": 1100}
+        {"or": [
+          {"heatFrames": 770},
+          {"and": [
+            "canDoubleBombJump",
+            {"heatFrames": 550}
+          ]}
+        ]
+        }
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "devNote": [
-        "FIXME: Refine these heat frames.",
-        "A crumble jump into IBJ is also possible."
+        "FIXME: A crumble jump into IBJ is also possible."
       ]
     },
     {


### PR DESCRIPTION
came up in a seed recently and the heatframes were so lenient it was easy to break logic.

Heat frames could maybe be tightened a little more?

single ibj

https://videos.maprando.com/video/10411

double ibj

https://videos.maprando.com/video/10412