### PR TITLE
UN: Medium updates with Varia and low Energy Part 1

### DIFF
--- a/region/norfair/east/Spiky Platforms Tunnel.json
+++ b/region/norfair/east/Spiky Platforms Tunnel.json
@@ -208,7 +208,10 @@
         {"lavaFrames": 130},
         {"or": [
           "canCarefulJump",
-          {"heatFrames": 40}
+          {"and": [
+            {"spikeHits": 1},
+            {"heatFrames": 40}
+          ]}
         ]},
         {"or": [
           {"and": [
@@ -235,6 +238,10 @@
         {"or": [
           "canDash",
           {"heatFrames": 10}
+        ]},
+        {"or": [
+          "canCarefulJump",
+          {"spikeHits": 1}
         ]}
       ],
       "flashSuitChecked": true,
@@ -565,7 +572,10 @@
         {"lavaFrames": 130},
         {"or": [
           "canCarefulJump",
-          {"heatFrames": 40}
+          {"and": [
+            {"spikeHits": 1},
+            {"heatFrames": 40}
+          ]}
         ]},
         {"or": [
           {"and": [
@@ -592,6 +602,10 @@
         {"or": [
           "canDash",
           {"heatFrames": 15}
+        ]},
+        {"or": [
+          "canCarefulJump",
+          {"spikeHits": 1}
         ]}
       ],
       "flashSuitChecked": true,

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -1178,14 +1178,11 @@
         {"heatFrames": 360},
         {"or": [
           "canDodgeWhileShooting",
+          "Ice",
           {"enemyKill": {
             "enemies": [["Dragon"]],
             "explicitWeapons": ["Missile", "Super", "Plasma"]
           }},
-          {"and": [
-            "h_heatProof",
-            "Charge"
-          ]},
           {"and": [
             "h_lavaProof",
             {"or": [

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -1185,6 +1185,7 @@
           }},
           {"and": [
             "h_lavaProof",
+            "h_heatProof",
             {"or": [
               "Charge",
               "ScrewAttack",

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -411,9 +411,8 @@
           "Charge",
           "Ice",
           "Plasma",
-          {"ammo": {"type": "Missile", "count": 2}},
+          {"ammo": {"type": "Missile", "count": 6}},
           {"ammo": {"type": "Super", "count": 2}},
-          {"ammo": {"type": "PowerBomb", "count": 2}},
           {"enemyDamage": {"enemy": "Dragon", "type": "fireball", "hits": 5}},
           {"and": [
             "h_lavaProof",
@@ -493,7 +492,7 @@
           "Charge",
           "Ice",
           "Plasma",
-          {"ammo": {"type": "Missile", "count": 2}},
+          {"ammo": {"type": "Missile", "count": 6}},
           {"ammo": {"type": "Super", "count": 2}},
           {"enemyDamage": {"enemy": "Dragon", "type": "fireball", "hits": 5}},
           {"and": [
@@ -1178,6 +1177,26 @@
         "canWallJump",
         {"heatFrames": 360},
         {"or": [
+          "canDodgeWhileShooting",
+          {"enemyKill": {
+            "enemies": [["Dragon"]],
+            "explicitWeapons": ["Missile", "Super", "Plasma"]
+          }},
+          {"and": [
+            "h_heatProof",
+            "Charge"
+          ]},
+          {"and": [
+            "h_lavaProof",
+            {"or": [
+              "ScrewAttack",
+              "h_usePowerBomb"
+            ]}
+          ]},
+          {"enemyDamage": {"enemy": "Dragon", "type": "fireball", "hits": 1}}
+        ]},
+        {"or": [
+          "Morph",
           "canInsaneJump",
           {"and": [
             "canTrickyDodgeEnemies",

--- a/region/norfair/west/Crocomire Escape.json
+++ b/region/norfair/west/Crocomire Escape.json
@@ -1186,8 +1186,12 @@
           {"and": [
             "h_lavaProof",
             {"or": [
+              "Charge",
               "ScrewAttack",
-              "h_usePowerBomb"
+              {"and": [
+                "h_usePowerBomb",
+                "h_usePowerBomb"
+              ]}
             ]}
           ]},
           {"enemyDamage": {"enemy": "Dragon", "type": "fireball", "hits": 1}}

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -2605,20 +2605,19 @@
           {"and": [
             {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}},
             {"heatFrames": 20}
+          ]},
+          {"and": [
+            "h_heatProof",
+            {"or": [
+              "Wave",
+              "canDodgeWhileShooting",
+              "h_usePowerBomb"
+            ]}
           ]}
         ]},
         {"or": [
           "canDash",
           {"heatFrames": 20}
-        ]},
-        {"or": [
-          "Wave",
-          "canDodgeWhileShooting",
-          {"and": [
-            "h_usePowerBomb",
-            {"heatFrames": 120}
-          ]},
-          {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}}
         ]}
       ],
       "flashSuitChecked": true,

--- a/region/norfair/west/Crocomire Speedway.json
+++ b/region/norfair/west/Crocomire Speedway.json
@@ -2610,6 +2610,15 @@
         {"or": [
           "canDash",
           {"heatFrames": 20}
+        ]},
+        {"or": [
+          "Wave",
+          "canDodgeWhileShooting",
+          {"and": [
+            "h_usePowerBomb",
+            {"heatFrames": 120}
+          ]},
+          {"enemyDamage": {"enemy": "Cacatac", "type": "spike", "hits": 1}}
         ]}
       ],
       "flashSuitChecked": true,


### PR DESCRIPTION
I went through all the rooms below Bubble Mountain and left of Business Center. 

There was a complaint about Spiky Platforms being too hard at 1E+Varia, but it felt fine for Medium. I added the hit in Basic.