### PR TITLE
East Sand Hall Gravity Jump to VH

### DIFF
--- a/region/maridia/inner-green/East Sand Hall.json
+++ b/region/maridia/inner-green/East Sand Hall.json
@@ -1508,6 +1508,7 @@
               "canWallJump",
               {"and": [
                 "canGravityJump",
+                "canTrickyJump",
                 "h_doubleEquipmentScreenCycleFrames"
               ]}
             ]}
@@ -1575,6 +1576,7 @@
           "HiJump",
           {"and": [
             "canGravityJump",
+            "canTrickyJump",
             "h_doubleEquipmentScreenCycleFrames"
           ]}
         ]},
@@ -2275,11 +2277,11 @@
       "name": "Gravity in Sand",
       "requires": [
         "Gravity",
+        {"noBlueSuit": {}},
         {"or": [
           "canTrickyJump",
           "Ice",
           "ScrewAttack",
-          {"haveBlueSuit": {}},
           {"enemyKill": {
             "enemies": [["Evir"]],
             "explicitWeapons": ["Plasma", "Super", "PowerBombPeriphery"]
@@ -2290,23 +2292,60 @@
         {"or": [
           "canWallJump",
           "HiJump",
-          "canUseFrozenEnemies",
-          "canGravityJump",
-          {"and": [
-            "canTrickyJump",
-            "can4HighMidAirMorph",
-            "canTrickySpringBallJump"
-          ]}
-        ]},
-        {"or": [
-          {"noBlueSuit": {}},
-          {"notable": "Blue Suit Sand Walk"}
+          "canUseFrozenEnemies"
         ]}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "devNote": [
-        "Technically it could make sense to clear obstacle A if the Evirs are killed, but with Gravity it is irrelevant."
+        "Technically it could make sense to clear obstacle A if the Right Evir is killed, but with Gravity it is irrelevant."
+      ]
+    },
+    {
+      "link": [4, 5],
+      "name": "Gravity Jump",
+      "requires": [
+        {"noBlueSuit": {}},
+        "Gravity",
+        "canTrickyJump",
+        "canPlayInSand",
+        {"or": [
+          "canGravityJump",
+          {"and": [
+            "can4HighMidAirMorph",
+            "canTrickySpringBallJump"
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "wallJumpAvoid": true,
+      "note": [
+        "From the low platform, Gravity Jump to the raised platform.",
+        "The pause should initiate significantly later than a normal Gravity Jump, while Samus is a couple tiles off the ground.",
+        "It is possible to instead Spring Ball jump off the sand, with a tight midair morph, but this is more precise."
+      ]
+    },
+    {
+      "link": [4, 5],
+      "name": "Gravity Blue Suit Sand Walk",
+      "requires": [
+        {"haveBlueSuit": {}},
+        {"notable": "Blue Suit Sand Walk"},
+        "Gravity",
+        "canPlayInSand",
+        {"or": [
+          "canWallJump",
+          "HiJump",
+          "canUseFrozenEnemies",
+          "canGravityJump",
+          "canTrickySpringBallJump"
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Simply walk off the ledges and hold forward to walk on the sand with a blue suit."
       ]
     },
     {
@@ -2371,7 +2410,7 @@
       "note": [
         "On the left side of the raised platform, jump for max height.",
         "Lateral Midair Morph for horizontal momentum, and perform the Spring Ball jump the moment before touching the sandfall.",
-        "Pause again to disable springball as soon as possible."
+        "Pause again to disable Spring Ball as soon as possible."
       ]
     },
     {


### PR DESCRIPTION
This bumps up the gravity jump to VH. It's not intuitive, but also not precise, and is only required if you select walljumpless, so I'm fine to lower it back to Hard if you prefer.