### PR TITLE
Botwoon energy tank shinecharged sand exit

### DIFF
--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -89,6 +89,19 @@
         "This represents having gained blue speed while moving right-to-left,",
         "including running, speedballing, or blue spring ball bouncing."
       ]
+    },
+    {
+      "id": 8,
+      "name": "Right of Sand with Blue Speed (Running)",
+      "nodeType": "junction",
+      "nodeSubType": "junction",
+      "mapTileMask": [
+        [1, 1, 1, 1, 1, 2, 1]
+      ],
+      "devNote": [
+        "This represents having gained blue speed while moving right-to-left,",
+        "exclusively by running."
+      ]
     }
   ],
   "obstacles": [
@@ -2824,58 +2837,6 @@
       "devNote": "This requires canInsaneJump even though it is not difficult, because it is not very intuitive."
     },
     {
-      "id": 53,
-      "link": [4, 7],
-      "name": "Suitless Water Blue Speed Run",
-      "entranceCondition": {
-        "comeInGettingBlueSpeed": {
-          "length": 6,
-          "openEnd": 1
-        }
-      },
-      "requires": [
-        "h_waterGetBlueSpeed"
-      ],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "devNote": [
-        "This is just a rough estimate of the minimum number of tiles that this runway can represent.",
-        "It is designed for a skill level that won't be able to use canStutterWaterShineCharge."
-      ]
-    },
-    {
-      "id": 54,
-      "link": [4, 7],
-      "name": "Suitless Stutter Water Get Blue Speed",
-      "entranceCondition": {
-        "comeInStutterGettingBlueSpeed": {
-          "minTiles": 2
-        }
-      },
-      "requires": [],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true
-    },
-    {
-      "id": 109,
-      "link": [4, 7],
-      "name": "Precise Suitless Stutter Water Blue Speed",
-      "entranceCondition": {
-        "comeInStutterGettingBlueSpeed": {
-          "minTiles": 1
-        }
-      },
-      "requires": [
-        {"tech": "canPreciseStutterWaterShineCharge"}
-      ],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": [
-        "With only 1 tile of runway, this requires releasing forward for 1 or 2 frames",
-        "and repressing forward on the last possible frame."
-      ]
-    },
-    {
       "id": 56,
       "link": [4, 7],
       "name": "Speedball",
@@ -2911,6 +2872,58 @@
       "devNote": [
         "With a mid-air spring ball jump it would be possible to go through the morph tunnel.",
         "This strat exists mainly as a way to avoid collecting the item, by passing through the Speed blocks."
+      ]
+    },
+    {
+      "id": 53,
+      "link": [4, 8],
+      "name": "Suitless Water Blue Speed Run",
+      "entranceCondition": {
+        "comeInGettingBlueSpeed": {
+          "length": 6,
+          "openEnd": 1
+        }
+      },
+      "requires": [
+        "h_waterGetBlueSpeed"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "This is just a rough estimate of the minimum number of tiles that this runway can represent.",
+        "It is designed for a skill level that won't be able to use canStutterWaterShineCharge."
+      ]
+    },
+    {
+      "id": 54,
+      "link": [4, 8],
+      "name": "Suitless Stutter Water Get Blue Speed",
+      "entranceCondition": {
+        "comeInStutterGettingBlueSpeed": {
+          "minTiles": 2
+        }
+      },
+      "requires": [],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
+    },
+    {
+      "id": 109,
+      "link": [4, 8],
+      "name": "Precise Suitless Stutter Water Blue Speed",
+      "entranceCondition": {
+        "comeInStutterGettingBlueSpeed": {
+          "minTiles": 1
+        }
+      },
+      "requires": [
+        {"tech": "canPreciseStutterWaterShineCharge"}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "With only 1 tile of runway, this requires releasing forward for 1 or 2 frames",
+        "and repressing forward on the last possible frame."
       ]
     },
     {
@@ -3101,7 +3114,64 @@
         "The `h_getBlueSpeedMaxRunway` requirement is to satisfy the tests,",
         "since we don't yet have a way to represent that being at node 7 implies already having blue speed."
       ]
+    },
+    {
+      "link": [8, 2],
+      "name": "Leave Shinecharged",
+      "requires": [
+        "h_shinechargeMaxRunway",
+        "canShinechargeMovementTricky",
+        "canQuickDrop",
+        "canPlayInSand",
+        {"shineChargeFrames": 75}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "To most quickly reach the transition while in a Shinespark ready state,",
+        "sink into the sand slightly and then hold a spinjump with Gravity and HiJump disabled."
+      ],
+      "devNote": [
+        "The `h_getBlueSpeedMaxRunway` requirement is to satisfy the tests,",
+        "since we don't yet have a way to represent that being at node 7 implies already having blue speed."
+      ]
+    },
+    {
+      "link": [8, 3],
+      "name": "Leave Shinecharged",
+      "requires": [
+        "h_shinechargeMaxRunway",
+        "canShinechargeMovementTricky",
+        "canQuickDrop",
+        "canPlayInSand",
+        {"shineChargeFrames": 75}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "To most quickly reach the transition while in a Shinespark ready state,",
+        "sink into the sand slightly and then hold a spinjump with Gravity and HiJump disabled."
+      ],
+      "devNote": [
+        "The `h_getBlueSpeedMaxRunway` requirement is to satisfy the tests,",
+        "since we don't yet have a way to represent that being at node 7 implies already having blue speed."
+      ]
+    },
+    {
+      "link": [8, 7],
+      "name": "Base",
+      "requires": [],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true
     }
+    
+
   ],
   "notables": [
     {

--- a/region/maridia/inner-pink/Botwoon Energy Tank Room.json
+++ b/region/maridia/inner-pink/Botwoon Energy Tank Room.json
@@ -1626,83 +1626,6 @@
       "note": "Coming in with zero momentum, all it takes is one non-HiJump full height jump forward, then activate."
     },
     {
-      "id": 116,
-      "link": [4, 1],
-      "name": "Suitless Water Shinecharge, Leave Shinecharged",
-      "entranceCondition": {
-        "comeInShinecharging": {
-          "length": 6,
-          "openEnd": 1
-        }
-      },
-      "requires": [
-        "canWaterShineCharge",
-        {"shineChargeFrames": 55}
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {}
-      },
-      "unlocksDoors": [
-        {"types": ["super"], "requires": []},
-        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "devNote": [
-        "This is just a rough estimate of the minimum number of tiles that this runway can represent.",
-        "It is designed for a skill level that won't be able to use canStutterWaterShineCharge."
-      ]
-    },
-    {
-      "id": 117,
-      "link": [4, 1],
-      "name": "Suitless Stutter Water Shinecharge, Leave Shinecharged",
-      "entranceCondition": {
-        "comeInStutterShinecharging": {
-          "minTiles": 2
-        }
-      },
-      "requires": [
-        {"shineChargeFrames": 55}
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {}
-      },
-      "unlocksDoors": [
-        {"types": ["super"], "requires": []},
-        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true
-    },
-    {
-      "id": 118,
-      "link": [4, 1],
-      "name": "Precise Suitless Stutter Water Shinecharge, Leave Shinecharged",
-      "entranceCondition": {
-        "comeInStutterShinecharging": {
-          "minTiles": 1
-        }
-      },
-      "requires": [
-        "canPreciseStutterWaterShineCharge",
-        {"shineChargeFrames": 55}
-      ],
-      "exitCondition": {
-        "leaveShinecharged": {}
-      },
-      "unlocksDoors": [
-        {"types": ["super"], "requires": []},
-        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
-      ],
-      "flashSuitChecked": true,
-      "blueSuitChecked": true,
-      "note": [
-        "With only 1 tile of runway, this requires releasing forward for 1 or 2 frames",
-        "and repressing forward on the last possible frame."
-      ]
-    },
-    {
       "id": 60,
       "link": [4, 1],
       "name": "G-Mode Overload PLMs",
@@ -3116,6 +3039,59 @@
       ]
     },
     {
+      "id": 116,
+      "link": [8, 1],
+      "name": "Suitless Water Shinecharge, Leave Shinecharged",
+      "requires": [
+        "h_shinechargeMaxRunway",
+        "canWaterShineCharge",
+        {"shineChargeFrames": 55}
+      ],
+      "exitCondition": {
+        "leaveShinecharged": {}
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "The `h_getBlueSpeedMaxRunway` requirement is to satisfy the tests,",
+        "since we don't yet have a way to represent that being at node 8 implies already having blue speed."
+      ]
+    },
+    {
+      "link": [8, 1],
+      "name": "Leave With Mockball",
+      "requires": [
+        "h_getBlueSpeedMaxRunway"
+      ],
+      "exitCondition": {
+        "leaveWithMockball": {
+          "remoteRunway": {
+            "length": 45,
+            "openEnd": 1
+          },
+          "landingRunway": {
+            "length": 3,
+            "openEnd": 1
+          },
+          "blue": "yes"
+        }
+      },
+      "unlocksDoors": [
+        {"types": ["super"], "requires": []},
+        {"types": ["missiles", "powerbomb"], "requires": ["never"]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "devNote": [
+        "The `h_getBlueSpeedMaxRunway` requirement is to satisfy the tests,",
+        "since we don't yet have a way to represent that being at node 8 implies already having blue speed."
+      ]
+    },
+    {
       "link": [8, 2],
       "name": "Leave Shinecharged",
       "requires": [
@@ -3136,7 +3112,7 @@
       ],
       "devNote": [
         "The `h_getBlueSpeedMaxRunway` requirement is to satisfy the tests,",
-        "since we don't yet have a way to represent that being at node 7 implies already having blue speed."
+        "since we don't yet have a way to represent that being at node 8 implies already having blue speed."
       ]
     },
     {
@@ -3160,7 +3136,7 @@
       ],
       "devNote": [
         "The `h_getBlueSpeedMaxRunway` requirement is to satisfy the tests,",
-        "since we don't yet have a way to represent that being at node 7 implies already having blue speed."
+        "since we don't yet have a way to represent that being at node 8 implies already having blue speed."
       ]
     },
     {


### PR DESCRIPTION
The suitless shinecharge can be used with sandpits and sandhalls.  Leaving with Gravity and a shinecharge doesn't really have a use case.