### PR TITLE
Ice Beam Tutorial G-Mode

### DIFF
--- a/region/norfair/west/Ice Beam Tutorial Room.json
+++ b/region/norfair/west/Ice Beam Tutorial Room.json
@@ -343,6 +343,56 @@
       "blueSuitChecked": true
     },
     {
+      "link": [1, 2],
+      "name": "G-Mode",
+      "entranceCondition": {
+        "comeInWithGMode": {
+          "mode": "any",
+          "morphed": true
+        }
+      },
+      "requires": [
+        "Morph",
+        {"or": [
+          "SpaceJump",
+          "canTrivialUseFrozenEnemies",
+          {"and": [
+            "canLateralMidAirMorph",
+            "canTrickyJump"
+          ]},
+          {"and": [
+            "Gravity",
+            {"lavaFrames": 24}
+          ]}
+        ]},
+        {"or": [
+          "h_heatedGModeOpenDifferentDoor",
+          {"and": [
+            "h_heatedGModePauseAbuse",
+            {"or": [
+              {"ammo": {"type": "Super", "count": 1}},
+              "h_usePowerBomb",
+              {"and": [
+                "ScrewAttack",
+                {"or": [
+                  "h_lavaProof",
+                  "SpaceJump",
+                  "canWallJump"
+                ]}
+              ]}
+            ]}
+          ]}
+        ]}
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "To save Energy, it is possible to kill to the Ripper at the far right, stand over where the drop will spawn and pause abuse to grab its Energy drop on G-mode exit.",
+        "With a Power Bomb, place on the right edge when the Ripper is about to hit the left edge.",
+        "It is also possible to kill it with Screw Attack and a precise wall jump."
+      ]
+    },
+    {
       "id": 21,
       "link": [1, 2],
       "name": "G-Mode Morph",
@@ -354,17 +404,6 @@
       },
       "requires": [
         {"or": [
-          {"and": [
-            "Morph",
-            {"or": [
-              "SpaceJump",
-              "canTrivialUseFrozenEnemies"
-            ]}
-          ]},
-          {"and": [
-            "canLateralMidAirMorph",
-            "canTrickyJump"
-          ]},
           {"and": [
             "h_artificialMorphSpringFling",
             "canTrickyJump"
@@ -380,20 +419,35 @@
             "Gravity",
             "h_artificialMorphSpringBall",
             {"lavaFrames": 40}
-          ]},
-          {"and": [
-            "Gravity",
-            "Morph",
-            {"lavaFrames": 24}
           ]}
         ]},
-        "h_heatedGModeOpenDifferentDoor"
+        {"or": [
+          "h_heatedGModeOpenDifferentDoor",
+          {"and": [
+            "h_heatedGModePauseAbuse",
+            {"or": [
+              {"ammo": {"type": "Super", "count": 1}},
+              "h_artificialMorphPowerBomb",
+              {"and": [
+                "ScrewAttack",
+                {"or": [
+                  "h_lavaProof",
+                  "SpaceJump",
+                  "canWallJump"
+                ]}
+              ]}
+            ]}
+          ]}
+        ]}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
         "Getting across the lava while artificially morphed requires an HBJ or Spring Fling.",
-        "For the Spring Fling, jump immediately before the pause triggers. With Morph, Samus can air ball across."
+        "For the Spring Fling, jump immediately before the pause triggers.",
+        "To save Energy, it is possible to kill to the Ripper at the far right, stand over where the drop will spawn and pause abuse to grab its Energy drop on G-mode exit.",
+        "With a Power Bomb, place on the left edge when the Ripper is moving left, 2/3 of the way to the left edge.",
+        "It is also possible to kill it with Screw Attack and a precise wall jump."
       ]
     },
     {


### PR DESCRIPTION
Adds a way to farm the right ripper, as well as splitting the artificial and real morph variants to make it a little easier to follow.

Sam detailed some of these, which ended up being several videos. Mostly marking them here so I can remember to assign them after this is merged:
https://videos.maprando.com/video/7068
https://videos.maprando.com/video/7069
https://videos.maprando.com/video/7070
https://videos.maprando.com/video/7073
https://videos.maprando.com/video/7074
https://videos.maprando.com/video/7075
https://videos.maprando.com/video/7076
https://videos.maprando.com/video/7077
https://videos.maprando.com/video/7078