### PR TITLE
Fix missing resetRoom on farm strats

### DIFF
--- a/region/crateria/central/Parlor and Alcatraz.json
+++ b/region/crateria/central/Parlor and Alcatraz.json
@@ -1984,10 +1984,12 @@
       "name": "Ripper Farm",
       "requires": [
         "ScrewAttack",
+        {"resetRoom": {"nodes": [5]}},
         {"noBlueSuit": {}},
         {"cycleFrames": 180}
       ],
       "farmCycleDrops": [{"enemy": "Ripper", "count": 1}],
+      "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },

--- a/region/crateria/east/East Ocean.json
+++ b/region/crateria/east/East Ocean.json
@@ -380,6 +380,7 @@
       "name": "Choot Farm (One Choot)",
       "requires": [
         "canDodgeWhileShooting",
+        {"resetRoom": {"nodes": [1]}},
         {"cycleFrames": 215},
         {"or": [
           "canDash",
@@ -390,6 +391,7 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Choot", "count": 1}],
+      "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },
@@ -399,6 +401,7 @@
       "name": "Choot Farm (Three Choots, Grapple)",
       "requires": [
         "canUseGrapple",
+        {"resetRoom": {"nodes": [1]}},
         {"cycleFrames": 330},
         {"or": [
           "canDash",
@@ -406,6 +409,7 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Choot", "count": 3}],
+      "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
@@ -418,6 +422,7 @@
       "name": "Choot Farm (Four Choots, Gravity)",
       "requires": [
         "Gravity",
+        {"resetRoom": {"nodes": [1]}},
         {"or": [
           {"and": [
             "canDash",
@@ -451,6 +456,7 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Choot", "count": 4}],
+      "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },
@@ -1052,6 +1058,7 @@
       "name": "Choot Farm (One Choot)",
       "requires": [
         "Gravity",
+        {"resetRoom": {"nodes": [2]}},
         {"cycleFrames": 270},
         {"or": [
           "canDash",
@@ -1090,6 +1097,7 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Choot", "count": 1}],
+      "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
       "blueSuitChecked": true
     },

--- a/region/maridia/inner-yellow/Plasma Spark Room.json
+++ b/region/maridia/inner-yellow/Plasma Spark Room.json
@@ -1101,6 +1101,7 @@
       "name": "Skultera Farm",
       "requires": [
         "canSuitlessMaridia",
+        {"resetRoom": {"nodes": [2]}},
         {"or": [
           {"and": [
             {"or": [
@@ -1121,6 +1122,7 @@
         ]}
       ],
       "farmCycleDrops": [{"enemy": "Skultera", "count": 2}],
+      "resetsObstacles": ["R-Mode"],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "devNote": [

--- a/region/norfair/east/Norfair Reserve Tank Room.json
+++ b/region/norfair/east/Norfair Reserve Tank Room.json
@@ -107,6 +107,7 @@
       "requires": [
         "h_heatProof",
         "canCarefulJump",
+        {"resetRoom": {"nodes": [1]}},
         {"or": [
           {"and": [
             "canDash",
@@ -139,6 +140,7 @@
       "name": "Triple Sova Farm",
       "requires": [
         "h_heatProof",
+        {"resetRoom": {"nodes": [1]}},
         {"or": [
           "h_lavaProof",
           "canInsaneJump",


### PR DESCRIPTION
somerando reported the East Ocean one in the [Discord](https://discord.com/channels/1053421401354285129/1053436236628496454/1531230989685358682). I checked and found a few more.