### PR TITLE
Refine X-Ray hall damage boosts

### DIFF
--- a/region/brinstar/red/Red Brinstar Fireflea Room.json
+++ b/region/brinstar/red/Red Brinstar Fireflea Room.json
@@ -709,48 +709,36 @@
       "link": [2, 1],
       "name": "Damage Boost Speed Jump",
       "requires": [
+        "canTrickyDodgeEnemies",
         "canHorizontalDamageBoost",
         "canTrickyJump",
         "canUseIFrames",
         "h_speedJump",
-        {"or": [
-          "canInsaneJump",
-          {"and": [
-            "canTrickyDodgeEnemies",
-            {"enemyDamage": {"enemy": "Fireflea", "type": "contact", "hits": 1}}
-          ]},
-          {"enemyDamage": {"enemy": "Fireflea", "type": "contact", "hits": 2}}
-        ]},
-        {"or": [
-          {"and": [
-            "canInsaneJump",
-            {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 2}}
-          ]},
-          {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 3}}
-        ]},
+        {"enemyDamage": {"enemy": "Fireflea", "type": "contact", "hits": 1}},
+        {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 3}},
         {"or": [
           "canWallJump",
-          "canTrickyDodgeEnemies"
+          "canInsaneJump"
         ]}
       ],
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Use a Fireflea (or two) to quickly boost to the left,",
+        "Use a Fireflea to quickly boost to the left,",
         "to be able to catch the Waver and boost off it on its first cycle, to cross the first gap.",
-        "Take one or two more hits from the Wavers for i-frames;",
-        "take the last hit close to the ground while holding forward.",
-        "Then gain speed using Speed Booster to jump across the second gap.",
+        "Take two more hits from the Wavers for i-frames,",
+        "taking the last hit close to the ground while holding forward,",
+        "to get boosted downward and land on the spikes instantly.",
+        "Then gain speed using Speed Booster to jump across the second gap;",
+        "the jump can be done as early as 3 or 4 tiles from the runway edge,",
+        "or as late as the last frame before falling off:",
+        "if the last Waver hit is done correctly, Samus' i-frames will last all the way to the end of the runway.",
         "If the jump is slightly short, a wall jump can be used to get up."
       ],
       "detailNote": [
-        "Using the second Waver cycle leads to a bad pattern at the end,",
-        "where the path of the speedy jump will be blocked by a Waver,",
-        "which can still be avoided but only with great difficulty."
-      ],
-      "devNote": [
-        "FIXME: Patiently waiting for a different Waver cycle could be another way to avoid Fireflea damage.",
-        "FIXME: gaining a shinecharge on the spikes (and hero shot sparking out the left door) is possible though extremely precise."
+        "Using the second Waver cycle to cross the leads to a bad pattern at the end,",
+        "where the path of the speedy jump will be blocked by a Waver;",
+        "so it is important to use the Waver on its first cycle."
       ]
     },
     {
@@ -1630,8 +1618,34 @@
       "flashSuitChecked": true,
       "blueSuitChecked": true,
       "note": [
-        "Damage boost off of a Waver in order to get onto the upper spikes.",
-        "It is possible to quickly get into position to use the Waver or to wait for it to return."
+        "Damage boost off of a Waver to cross the gap onto the upper spikes."
+      ]
+    },
+    {
+      "link": [3, 1],
+      "name": "Patient Waver I-Frames Speed Jump",
+      "requires": [
+        "canTrickyDodgeEnemies",
+        "canHorizontalDamageBoost",
+        "canTrickyJump",
+        "canUseIFrames",
+        "h_speedJump",
+        {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 1}},
+        "canInsaneJump",
+        "canBePatient"
+      ],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Wait on the safe block for all three Wavers to come back to the right.",
+        "The Yapping Maw will not attack while Samus stands on the rightmost 3 pixels of the block.",
+        "When the Wavers return from the right, use the second one to gain i-frames,",
+        "hitting it close to the ground while holding forward,",
+        "to get boosted downward and land instantly on the spikes.",
+        "Then gain speed using Speed Booster to jump across the second gap."
+      ],
+      "devNote": [
+        "FIXME: gaining a shinecharge on the spikes (and hero shot sparking out the left door) is possible though extremely precise."
       ]
     },
     {
@@ -1876,11 +1890,12 @@
           {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 5}},
           {"and": [
             "canTrickyDodgeEnemies",
-            {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 3}}
+            {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 2}}
           ]},
           {"and": [
             "canInsaneJump",
-            {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 2}}
+            "canHorizontalDamageBoost",
+            {"enemyDamage": {"enemy": "Waver", "type": "contact", "hits": 1}}
           ]}
         ]}
       ],


### PR DESCRIPTION
The "Damage Boost Speed Jump" strat had too many variants baked into it which made the note (and logic) a bit confusing. So I split off a separate strat "Patient Waver I-Frames Speed Jump" as a higher-difficulty version that minimizes damage.

- "Damage Boost Speed Jump" gets a "canTrickyDodgeEnemies" requirement, bumping it up to Expert.
- "Patient Waver I-Frames Speed Jump" avoids the initial Fireflea hit by waiting for the second Waver cycle and skips a Waver hit by doing a more precise jump. It requires waiting for the Wavers to go all the way back and forth across the room in order to get a good cycle.
- The "Waver I-Frames" from the safe block to the safe ledge (3 -> 4) reduces the amount of expected Waver hits by one in the higher-difficulty requirements.

If we bump the notable "Full Room Damage Boosts (Right to Left)" to Expert+, a lot of variants still remain in logic tankless in Expert or lower; you would just need some movement item: Ice, Bombs, Speed Booster, Hi Jump or Spring Ball. In this case, the reduction in "Waver I-Frames" hits matters for keeping the IBJ and HiJump versions in Expert logic tankless, because with 4 assumed Waver hits you would not be able to afford taking a spike hit; so Expert will now expect 3 total Waver hits to make it to the safe ledge from the right side of the room, while Extreme would expect 2 and Very Hard would expect 6.