### PR TITLE
Add AGENTS.md to help Copilot not be confused

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+- When creating a new strat or tech, do not add an "id" field. It will be populated by an automated workflow later. Only node IDs and notable IDs are managed manually.


### PR DESCRIPTION
We've seen that Copilot thinks it is a mistake when a strat "id" is omitted on a new strat, whereas this is actually correct. So put this information here so it (and other agents) will understand. E.g., see most recently PR #2927 .