### PR TITLE
Ice Beam Gate Room: Sova Ice Clip

### DIFF
--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -1383,7 +1383,7 @@
     },
     {
       "link": [4, 2],
-      "name": "Sova Ice Clip",
+      "name": "Sova Ice Clip with X-Ray",
       "entranceCondition": {
         "comeInNormally": {}
       },
@@ -1416,6 +1416,52 @@
         "in that the shot would collide with the shutter, but this can be avoided:",
         "If Spazer is equipped, the shot block can be destroyed by crouching and firing a hero shot.",
         "If Wave is equipped, it can be cleared by walking forward and firing an angle-down shot before the shutter finishes closing."        
+      ]
+    },
+    {
+      "link": [4, 2],
+      "name": "Sova Precise Ice Clip",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "h_usePowerBomb",
+        {"ammo": {"type": "Super", "count": 1}},
+        "canInsaneJump",
+        {"or": [
+          {"and": [
+            "h_preciseIceClip",
+            "canBeVeryPatient"            
+          ]},
+          {"and": [
+            "h_highPixelIceClip",
+            "canBeExtremelyPatient"
+          ]}
+        ]}
+      ],
+      "clearsObstacles": ["A", "B", "C"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Clear the shot blocks to pass through the lower morph tunnel.",
+        "Wait for the Sova to move far enough to the right,",
+        "then lay a Power Bomb to break the blocks.",
+        "After the Sova returns and passes through the closed shutter,",
+        "damage it, then fire a precisely-timed Super shot while the Sova is moving vertically on a block near a shutter.",
+        "Freeze it mid-air and crouch jump to clip into the tunnel above.",
+        "This strat is useful if carrying a blue suit."
+      ],
+      "detailNote": [
+        "The freezing shot can be normalized by standing and firing the Super up at the ceiling,",
+        "buffering a horizontal beam shot to come out as soon as cooldown ends.",
+        "It is required to jump with a precisely timed aim-down between 3 and 5 frames after jumping:",
+        "too early and Samus will bonk the floor of the morph tunnel instead of clipping through it,",
+        "too late and Samus will bonk the ceiling above and fall back out.",
+        "The buffered freeze works with any beam combination.",
+        "A high-pixel clip is technically possible by firing the Super through the lower morph tunnel",
+        "while the Sova is moving vertically on the block next to the shutter,",
+        "then jumping and frame-perfectly freezing it;",
+        "in this case, aim down must be pressed between 1 and 3 frames after jumping."
       ]
     },
     {

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -1405,7 +1405,7 @@
         "Freeze it mid-air and use X-Ray to stand up and clip into the tunnel above."
       ],
       "detailNote": [
-        "The freezing shot can be normalized by standing and firing the Super diagonally at the ceiling,",
+        "The freezing shot can be normalized by standing and firing the Super diagonally left at the ceiling,",
         "buffering the beam shot to come out as soon as cooldown ends.",
         "After using X-Ray to stand up, it is required to jump with a precisely timed aim-down exactly 3 or 4 frames after jumping:",
         "too early and Samus will bonk the floor of the morph tunnel instead of clipping through it,",

--- a/region/norfair/west/Ice Beam Gate Room.json
+++ b/region/norfair/west/Ice Beam Gate Room.json
@@ -1382,6 +1382,43 @@
       "blueSuitChecked": true
     },
     {
+      "link": [4, 2],
+      "name": "Sova Ice Clip",
+      "entranceCondition": {
+        "comeInNormally": {}
+      },
+      "requires": [
+        "h_usePowerBomb",
+        {"ammo": {"type": "Super", "count": 1}},
+        "h_XRayMorphIceClip",
+        "canInsaneJump"
+      ],
+      "clearsObstacles": ["A", "B", "C"],
+      "flashSuitChecked": true,
+      "blueSuitChecked": true,
+      "note": [
+        "Clear the shot blocks to pass through the lower morph tunnel.",
+        "Wait for the Sova to move far enough to the right,",
+        "then lay a Power Bomb to break the blocks.",
+        "After the Sova returns and passes through the closed shutter,",
+        "damage it, then fire a Super to knock it off the ceiling.",
+        "Freeze it mid-air and use X-Ray to stand up and clip into the tunnel above."
+      ],
+      "detailNote": [
+        "The freezing shot can be normalized by standing and firing the Super diagonally at the ceiling,",
+        "buffering the beam shot to come out as soon as cooldown ends.",
+        "After using X-Ray to stand up, it is required to jump with a precisely timed aim-down exactly 3 or 4 frames after jumping:",
+        "too early and Samus will bonk the floor of the morph tunnel instead of clipping through it,",
+        "too late and Samus will bonk the ceiling above and fall back out.",
+        "This strat is useful if carrying a blue suit.",
+        "The buffered freeze works with any beam combination.",
+        "Having Spazer or Wave equipped creates an issue for clearing the second shot block,",
+        "in that the shot would collide with the shutter, but this can be avoided:",
+        "If Spazer is equipped, the shot block can be destroyed by crouching and firing a hero shot.",
+        "If Wave is equipped, it can be cleared by walking forward and firing an angle-down shot before the shutter finishes closing."        
+      ]
+    },
+    {
       "id": 84,
       "link": [4, 2],
       "name": "Arm Pump Crouch Gate Clip",


### PR DESCRIPTION
The rationale for the canInsaneJump:

- The aim-down is a 2-frame window, which is fairly precise, considering how unusual this setup is and the fact that it is fairly slow to retry.
- It's only useful with a blue suit (or dashless), and not the sort of thing we'd want coming into logic on the same difficulty level as blue suit itself.